### PR TITLE
fix: Uso del TZ también para el día

### DIFF
--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -46,7 +46,8 @@
 
   const dateFormatOptions = {
     day: "numeric",
-    month: "long"
+    month: "long",
+    timeZone: USER_TZ
   }
 
   // Se usa la configuración regional "en-GB" para mostrar la abreviatura de la zona horaria (CET, PST, EST...) y no su valor en GMT


### PR DESCRIPTION
En mi PR anterior solo usaba el TZ del usuario para la hora, pero no para el día. Esta PR lo corrige.