### PR TITLE
fix: preload critical asset (background)

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -20,6 +20,7 @@ const descriptionPage =
     <link rel="canonical" href="https://lavelada.es" />
     <title>{title}</title>
     <meta name="viewport" content="width=device-width" />
+    <link rel="preload" as="image" href="/concrete.png" />
     <meta
       name="keywords"
       content="velada, streamers, creadores, Ibai, boxeo, midudev"


### PR DESCRIPTION
En conexiones lentas, el background podría tardar un poco en cargar. Con este commit se intenta solventar dicho problema cargando la imagen de antemano, antes que otros recursos

Antes: 
<video src='https://github-production-user-asset-6210df.s3.amazonaws.com/70046023/306803151-c10dab4f-fe4c-4e7d-ac03-8300a0410822.mp4?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=AKIAVCODYLSA53PQK4ZA%2F20240221%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240221T232436Z&X-Amz-Expires=300&X-Amz-Signature=064b9339076a18a4a98756fc85b63a6f8d1958e3f4549252ca8c2f7772ee9931&X-Amz-SignedHeaders=host&actor_id=70046023&key_id=0&repo_id=761334150'></video>

Después:
![background](https://github.com/midudev/la-velada-web-oficial/assets/70046023/6fb8422f-2024-4ba0-9754-15baf6132cee)