### PR TITLE
Añadir Link hacia la ubicación del Teatro Victoria 

### DIFF
--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -10,7 +10,9 @@
 
   <h2 class="uppercase text-2xl font-medium flex flex-col max-w-sm mt-6">
     <span>Evento de Presentación</span>
-    <span>Teatro Victoria (Barcelona)</span>
+    <a href="https://maps.app.goo.gl/RFzHUVDhRqdQaTAo8" class="hover:scale-110 hover:opacity-60 transition inline-block" target="_blank" rel="noopener">
+      Teatro Victoria (Barcelona)
+    </a>
   </h2>
 
   <a

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -10,7 +10,10 @@
 
   <h2 class="uppercase text-2xl font-medium flex flex-col max-w-sm mt-6">
     <span>Evento de Presentación</span>
-    <a href="https://maps.app.goo.gl/RFzHUVDhRqdQaTAo8" class="hover:scale-110 hover:opacity-60 transition inline-block" target="_blank" rel="noopener">
+    <a href="https://maps.app.goo.gl/RFzHUVDhRqdQaTAo8" 
+      class="hover:scale-110 hover:opacity-60 transition inline-block" 
+      target="_blank" 
+      rel="noopener">
       Teatro Victoria (Barcelona)
     </a>
   </h2>


### PR DESCRIPTION
Se añade la link hacia la ubicación de Teatro Victoria en  google maps.

Imagen con efecto hover.


![image](https://github.com/midudev/la-velada-web-oficial/assets/75146145/79899120-da29-4b9a-b02e-65b3d523a802)
