### PR TITLE
fix: Padding for 320px mobile S version

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -32,7 +32,7 @@
     class="grid uppercase text-center gap-x-10 [grid-template-columns:1fr] md:grid-cols-[repeat(auto-fit,_minmax(150px,_1fr))] lg:[grid-template-columns:1fr_1.5fr_1fr]"
   >
     <article
-      class="order-2 md:flex-grow md:order-none flex place-items-center text-xl py-10 md:py-12 lg:py-20 px-10 border-y-2 border-primary"
+      class="order-2 md:flex-grow md:order-none flex place-items-center text-xl py-10 md:py-12 lg:py-20 px-5 sm:px-10 border-y-2 border-primary"
     >
       <h3 class="text-balance">
         Presentación, Pesaje, Entrevista y Cara a Cara
@@ -40,7 +40,7 @@
     </article>
 
     <article
-      class="order-1 md:flex-1 md:order-none flex place-items-center text-4xl py-10 md:py-12 lg:py-20 px-10 border-t-2 md:border-y-2 border-primary"
+      class="order-1 md:flex-1 md:order-none flex place-items-center text-4xl py-10 md:py-12 lg:py-20 px-5 sm:px-10 border-t-2 md:border-y-2 border-primary"
     >
       <h3>
         <a


### PR DESCRIPTION
He solucionado un problema en la versión móvil (320px) donde un elemento desproporcionado ("padin") causaba un error en la interfaz de usuario, pegándola al lado izquierdo. Esta corrección permitirá que las personas con teléfonos móviles antiguos puedan ver correctamente la página de la velada 4.  ☺️


### **Antes:** ❌

![Captura de pantalla 2024-02-22 005612](https://github.com/midudev/la-velada-web-oficial/assets/38046636/43ff376e-2149-4b08-801e-498972b99a32)

### **Ahora:**  ☺️

![Captura de pantalla 2024-02-22 022533](https://github.com/midudev/la-velada-web-oficial/assets/38046636/d236860d-72fd-4208-aa2a-ddecdd74b58d)

### **Antes:** ❌
![Captura de pantalla 2024-02-22 005637](https://github.com/midudev/la-velada-web-oficial/assets/38046636/fe07d43f-2cb9-426c-a182-68b8328c8f98)

### **Ahora:** ☺️

![Captura de pantalla 2024-02-22 022715](https://github.com/midudev/la-velada-web-oficial/assets/38046636/5c2cf750-e77d-4a74-8258-966cc2154714)

