### PR TITLE
Add temporal countdown context

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -5,6 +5,8 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date";
 ---
 
 <section class="my-32 flex flex-col gap-y-10 place-items-center">
+  <p class="uppercase text-lg font-medium">Para el Evento de Presentación faltan</p>
+  
   <LaVeladaLogo class="text-primary" />
 
   <div


### PR DESCRIPTION
Contexto para que se entienda que ahora la cuenta atras es para el evento de presentación, no por la Velada

<img width="645" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/9f6c1651-bf17-47dc-956b-9386f0540f7f">
