### PR TITLE
fix twitch icon color on dark mode

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -20,7 +20,7 @@
         fill="currentColor"
         d="M16.6001.600098.600098 16.6001v57.6H19.8001v16l16-16h12.8l28.8-28.8V.600098h-60.8Z"
       ></path><path
-        fill="#fff"
+        fill="var(--background-color)"
         d="m58.2003 55 12.8-12.8V7h-51.2v48h12.8v12.8l12.8-12.8h12.8Z"
       ></path><path
         fill="currentColor"


### PR DESCRIPTION
Antes:
<img width="422" alt="Captura de pantalla 2024-02-22 a les 10 38 51" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/93574aad-c577-4fa7-b01f-65484cf2547b">

Ahora:
<img width="421" alt="Captura de pantalla 2024-02-22 a les 10 38 16" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/185c2fa9-178d-4e75-a881-8bd9a2ecf11b">
