### PR TITLE
Fix event time

### DIFF
--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -17,7 +17,7 @@
       "La presentación de La Velada del Año 4 está por comenzar.<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]",
     startDate: "2024-03-04",
     endDate: "2024-03-04",
-    startTime: "19:00",
+    startTime: "20:00",
     endTime: "22:00",
     options: ["Google", "Apple", "Microsoft365", "MicrosoftTeams"],
     timeZone: "Europe/Madrid",

--- a/src/consts/event-date.ts
+++ b/src/consts/event-date.ts
@@ -1,1 +1,1 @@
-export const EVENT_TIMESTAMP = 1709575200000 as const
+export const EVENT_TIMESTAMP = 1709578800000 as const

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -24,6 +24,7 @@ import CalendarButton from "../components/CalendarButton.astro"
     >
       Teatro Victoria (Barcelona)
     </a>
+    <span class="opacity-70 text-sm">Apertura de puertas 1h antes</span>
   </h2>
 
   <div class="flex flex-col md:flex-row items-center mt-6 gap-6">


### PR DESCRIPTION
El evento es a las 20:00h como se puede ver a las entradas, es la apertura de puertas la que es a las 19h.
<img width="1259" alt="Hora apertura" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/57f855e6-dee0-47b6-a80b-10656f6d88fe">
<img width="1190" alt="Hora evento" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/c60ab1c1-e62b-4a09-9585-aab648d3388a">

Por eso he cambiado las horas que se muestran tanto en la info inicial, como en la cuenta atrás, en el calendario y he añadido la información de las puertas abiertas 1h antes para quienes ya tuviesen las entradas en presencial.

<img width="691" alt="Como queda con hora y info apertura" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/212f3598-941b-4b69-921d-49883d78b514">
