### PR TITLE
feat: embed ibai stream

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,12 +8,14 @@ import Footer from "@/sections/Footer.astro"
 import Hero from "@/sections/Hero.astro"
 import Info from "@/sections/Info.astro"
 import PrincipalDate from "@/sections/PrincipalDate.astro"
+import Stream from "@/sections/Stream.astro"
 ---
 
 <Layout title="La Velada 4 - Evento de Boxeo de Ibai Llanos">
   <Hero />
   <main>
     <PrincipalDate />
+    <Stream />
     <Info />
     <Countdown />
   </main>

--- a/src/sections/Stream.astro
+++ b/src/sections/Stream.astro
@@ -2,17 +2,18 @@
 import { EVENT_TIMESTAMP } from "@/consts/event-date"
 
 const NOW = new Date().getTime()
+const domain = new URL(Astro.request.url).hostname
 ---
 
 {
   NOW >= EVENT_TIMESTAMP ? (
     <div class="mt-32 flex justify-center items-center">
       <iframe
-        src="https://player.twitch.tv/?channel=ibai&parent=localhost"
+        src={`https://player.twitch.tv/?channel=ibai&parent=${domain}`}
         width="1280"
         height="720"
         allowfullscreen
-      ></iframe>
+      />
     </div>
   ) : null
 }

--- a/src/sections/Stream.astro
+++ b/src/sections/Stream.astro
@@ -1,7 +1,18 @@
-<div class="mt-32 flex justify-center items-center">
-  <iframe
-    src="https://player.twitch.tv/?channel=ibai&parent=localhost"
-    width="1280"
-    height="720"
-    allowfullscreen></iframe>
-</div>
+---
+import { EVENT_TIMESTAMP } from "@/consts/event-date"
+
+const NOW = new Date().getTime()
+---
+
+{
+  NOW >= EVENT_TIMESTAMP ? (
+    <div class="mt-32 flex justify-center items-center">
+      <iframe
+        src="https://player.twitch.tv/?channel=ibai&parent=localhost"
+        width="1280"
+        height="720"
+        allowfullscreen
+      ></iframe>
+    </div>
+  ) : null
+}

--- a/src/sections/Stream.astro
+++ b/src/sections/Stream.astro
@@ -1,0 +1,7 @@
+<div class="mt-32 flex justify-center items-center">
+  <iframe
+    src="https://player.twitch.tv/?channel=ibai&parent=localhost"
+    width="1280"
+    height="720"
+    allowfullscreen></iframe>
+</div>


### PR DESCRIPTION
El stream de Ibai se muestra cuando una persona ingresa a la web y el evento ya ha iniciado.
<video src="https://github.com/midudev/la-velada-web-oficial/assets/70046023/4eecf205-402f-4022-90f0-8bc41206c9ee"></video>

**_Posible improvement:_** Reaccionar al cumplimiento de la fecha con JavaScript y mostrar el stream. De esta forma, las personas que ingresen a la web antes del inicio del Stream podrán ver el stream sin necesidad de recargar la web

Source: https://dev.twitch.tv/docs/embed/video-and-clips/#non-interactive-inline-frames-for-live-streams-and-vods