### PR TITLE
now the light looks good on mobile

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -49,7 +49,7 @@ const descriptionPage =
       <img
         aria-hidden="true"
         src="/lights.svg"
-        class="absolute left-0 top-0 opacity-0 transform-gpu w-screen brightness-0 dark:brightness-200"
+        class="absolute scale-150 left-12 lg:scale-100 lg:left-0 top-0 opacity-0 transform-gpu w-screen brightness-0 dark:brightness-200"
         onload="this.classList.add('animate-fade-in', 'animate-duration-500')"
       />
     </div>


### PR DESCRIPTION
light svg covers full width on mobile

before:
![Screen Shot 2024-02-22 at 12 37 08](https://github.com/midudev/la-velada-web-oficial/assets/106329576/ff367d65-d3eb-4668-bef9-6cc0a7e745b0)

after:
![Screen Shot 2024-02-22 at 12 36 58](https://github.com/midudev/la-velada-web-oficial/assets/106329576/7a1d6ce4-5c23-4ea9-aea5-6b82e9e3cfaa)


