### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+## Descripción
+
+[Describa brevemente los cambios realizados en esta solicitud de extracción.]
+
+## Problema solucionado
+
+[Describa el problema o la tarea que aborda esta solicitud de extracción, si corresponde. Incluya el número de problema o enlace al problema si existe.]
+
+## Cambios propuestos
+
+[Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito.]
+
+## Capturas de pantalla (si corresponde)
+
+[Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible.]
+
+## Comprobación de cambios
+
+- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
+- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
+- [ ] He actualizado la documentación, si corresponde.
+
+## Impacto potencial
+
+[Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento.]
+
+## Contexto adicional
+
+[Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción.]
+
+## Enlaces útiles
+
+- Documentación del proyecto: [Enlace a la documentación del proyecto, si está disponible.]
+- Código de referencia: [Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable.]


### PR DESCRIPTION
## Descripción

Este PR añade plantillas para las PR de GitHub. Esto permitirá tener una plantilla con la información ideal que habría que completar en cada PR con el fin de recordar a cada contribuidor que no debe crear PR sin mensajes o sin capturas en caso de ser un cambio visual. ✨

El mensaje no es obligatorio por lo que cada contributor puede ajustarlo a la hora de crear su PR. Esto es parte de las [recomendaciones de Github](https://docs.github.com/en/communities) a la hora de trabajar con un proyecto open-source.

## Cambios propuestos

- Archivo pull_request_template.md para generar template de Github.

## Capturas de pantalla (si corresponde)

No se hacen cambios que afecten el diseño.

## Enlaces útiles

- [Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)
- [About issue and pull request templates](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates)
