### PR TITLE
fix response on layout for ipad mini

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -45,7 +45,7 @@ const descriptionPage =
     <meta name="googlebot" content="index, follow" />
   </head>
   <body>
-    <div class="relative container mx-auto w-full -z-10">
+    <div class="relative container mx-auto w-full -z-10 overflow-x-clip">
       <img
         aria-hidden="true"
         src="/lights.svg"


### PR DESCRIPTION
Ya arreglaron el problema anterior #84 pero aun hay un problema que me percate para este layout de "ipad mini" es el unico layout que me percate que tenia ese problema pero lo solucione solo agregando la clase al contenedor de la imagen "overflow-x-clip".

![image](https://github.com/midudev/la-velada-web-oficial/assets/84356694/1b6592d5-af07-4568-b292-a1033b690e0c)
![image](https://github.com/midudev/la-velada-web-oficial/assets/84356694/dafc485e-8118-49f3-b9c2-59ca28024512)

Ahora:
![image](https://github.com/midudev/la-velada-web-oficial/assets/84356694/256e84fb-cc22-4e9e-abb8-e84421e21127)

