### PR TITLE
fix: always show twitch color on link hover

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -44,7 +44,7 @@
     >
       <h3 class="flex items-center">
         <a
-          class="hover:text-twitch transition hover:scale-110 inline-block"
+          class="hover:text-twitch transition-transform hover:scale-110 inline-block"
           href="https://twitch.tv/ibai"
           target="_blank"
           rel="nofollow noopener"
@@ -80,9 +80,7 @@
       animation-timing-function: ease-in;
     }
 
-    .twitch-link {
-      display: inline-block;
-
+    :not(a:hover) > .twitch-link {
       animation-timeline: view(block);
       animation-name: show;
       animation-timing-function: ease-in;


### PR DESCRIPTION
Actualmente, cuando el scroll es pequeño y se hace `hover` sobre el link con texto "SÍGUELO EN DIRECTO TWITCH.TV/IBAI", el trozo "TWITCH.TV/IBAI" permanece con el color aplicado por el scroll timeline 

Antes:
<video src="https://github.com/midudev/la-velada-web-oficial/assets/70046023/4eb62999-a208-4481-8f05-3330d22b454f"></video>

Después:
<video src="https://github.com/midudev/la-velada-web-oficial/assets/70046023/9509bcbc-9053-478d-be02-16b87701f88f"></video>

