### PR TITLE
Update contributors URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Consulta nuestra [guía de contribución](https://github.com/midudev/la-velada-w
 
 **¡Gracias a todos los colaboradores que han hecho posible este proyecto!**
 
-[![Contribuidores](https://contrib.rocks/image?repo=midudev/la-velada-web-oficial&theme=flat)](https://github.com/midudev/la-velada-web-oficial/graphs/contributors)
+[![Contribuidores](https://contrib.rocks/image?repo=midudev/la-velada-web-oficial)](https://github.com/midudev/la-velada-web-oficial/graphs/contributors)
 
 ## 🛠️ Stack
 


### PR DESCRIPTION
## Descripción

La lista de los contribuidores por algún motivo no se muestra completa. Esta PR pretende solucionarlo.

## Problema solucionado

Ahora se ve la lista completa de contribuidores.

## Cambios propuestos

Se removió el `&theme=flat` del URL de los contribuidores.

## Capturas de pantalla (si corresponde)

| Antes  | Ahora |
| ------------- | ------------- |
| ![image](https://github.com/midudev/la-velada-web-oficial/assets/56328053/2a88453c-97a1-4fe4-822a-f855a91be8ae) |  ![image](https://github.com/midudev/la-velada-web-oficial/assets/56328053/c22d9dc0-2f13-4cfa-b6ee-d3244bcbe10c) |

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

https://contrib.rocks/
