### PR TITLE
Estilos en la sección info para tablet y small desktop

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -29,10 +29,10 @@
   </a>
 
   <div
-    class="grid uppercase text-center gap-x-10 [grid-template-columns:1fr] md:grid-cols-[repeat(auto-fit,_minmax(150px,_1fr))] lg:[grid-template-columns:1fr_1.5fr_1fr]"
+    class="grid uppercase text-center gap-x-10 [grid-template-columns:1fr] md:grid-cols-[repeat(4,_1fr)] lg:[grid-template-columns:1fr_1.5fr_1fr]"
   >
     <article
-      class="order-2 md:flex-grow md:order-none flex justify-center items-center text-xl text-center py-10 md:py-12 lg:py-20 md:px-0 px-10 border-y-2 border-primary"
+      class="order-2 md:col-[span_2/auto] lg:col-auto lg:flex-grow md:order-2 lg:order-none flex justify-center items-center text-xl text-center py-10 md:py-20 md:px-0 px-10 border-y-2 border-primary"
     >
       <h3 class="text-balance md:max-w-[250px]">
         Presentación, Pesaje, Entrevista y Cara a Cara
@@ -40,7 +40,7 @@
     </article>
 
     <article
-      class="order-1 md:flex-1 md:order-none flex justify-center items-center text-3xl lg:text-4xl py-10 md:py-12 lg:py-20 px-10 md:px-0 lg:px-0 border-t-2 md:border-y-2 border-primary"
+      class="order-1 md:col-[1/span_4] lg:col-auto lg:flex-1 md:order-1 lg:order-none flex justify-center items-center text-3xl lg:text-4xl py-10 md:py-20 px-10 md:px-0 lg:px-0 md:mb-10 lg:mb-0 border-t-2 md:border-y-2 border-primary"
     >
       <h3 class="md:max-w-[250px]">
         <a
@@ -58,7 +58,7 @@
     </article>
 
     <article
-      class="order-3 md:order-none text-xl py-10 sm:py-12 md:py-12 lg:py-20 px-10 md:px-0 border-b-2 md:border-y-2 border-primary flex justify-center items-center"
+      class="order-3 md:order-3 lg:order-none md:col-[span_2/auto] lg:col-auto text-xl py-10 sm:py-12 md:py-20 px-10 md:px-0 border-b-2 md:border-y-2 border-primary flex justify-center items-center"
     >
       <h3 class="text-balance md:max-w-[250px]">
         Con la presencia de los boxeadores y las boxeadoras


### PR DESCRIPTION
## Descripción

Implementé una pequeña mejora para mostrar el contenido de la sección Info en resoluciones entre 768px (_tablet_) y 1024px (_small desktop_), una visual **no suministrada** en Figma.

## Problema solucionado

Visualización de la sección Info para _tablet_ y _small desktop_

## Cambios propuestos

1. Cambio en _grid-template-columns_ de la sección para el breakpoint md.
2. Cambio en _grid-column_ y ajuste de _py_ para cada uno de los artículos en el breakpoint md y lg (con el fin de mantener la visual esperada de acuerdo a Figma en desktop).
3. Ajuste en _order_ para cada uno de los artículos en el breakpoint md y lg (con el fin de mantener la visual esperada de acuerdo a Figma en desktop).

## Capturas de pantalla

Antes:
![before-info](https://github.com/midudev/la-velada-web-oficial/assets/87620636/c2361d8c-7451-471e-889b-902fe616ba11)

Ahora:
![now-info](https://github.com/midudev/la-velada-web-oficial/assets/87620636/bf6b16e4-6919-4f45-8837-a7a30c109706)

## Comprobación de cambios

- [✔️] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [✔️] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [✔️] He actualizado la documentación, si corresponde.

## Impacto potencial

No hay cambios potenciales, solo visuales.

## Contexto adicional

Sin contexto adicional.

## Enlaces útiles

- Código de referencia: https://github.com/midudev/la-velada-web-oficial/blob/main/src/sections/Info.astro
