### PR TITLE
[feat]: Optimizacion carga del calendario

### DIFF
--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -25,6 +25,8 @@
     iCalFileName: "Reminder-Event",
   }
 
+  let status
+
   function loadStyle(src) {
     return new Promise(function (resolve, reject) {
       let link = document.createElement("link")
@@ -39,12 +41,19 @@
   }
 
   const button = document.querySelector("#add-to-calendar")
-  button?.addEventListener("click", () => {
-    Promise.all([
-      import("/js/add-to-calendar.js"),
-      loadStyle("/css/add-to-calendar.css"),
-    ]).then(() => {
-      atcb_action(config, button)
-    })
+  button?.addEventListener("click", async () => {
+    if(status === "loading") return 
+	if(!status) {
+	  const text = button.innerHTML
+	  button.innerHTML = "Cargando..."
+	  status = "loading"
+      await Promise.all([
+		import("/js/add-to-calendar.js"),
+		loadStyle("/css/add-to-calendar.css"),
+	  ])
+	  status = "loaded"
+	  button.innerHTML = text
+	}
+	atcb_action(config, button)
   })
 </script>

--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -25,8 +25,6 @@
     iCalFileName: "Reminder-Event",
   }
 
-  let status
-
   function loadStyle(src) {
     return new Promise(function (resolve, reject) {
       let link = document.createElement("link")
@@ -41,19 +39,12 @@
   }
 
   const button = document.querySelector("#add-to-calendar")
-  button?.addEventListener("click", async () => {
-    if(status === "loading") return 
-	if(!status) {
-	  const text = button.innerHTML
-	  button.innerHTML = "Cargando..."
-	  status = "loading"
-      await Promise.all([
-		import("/js/add-to-calendar.js"),
-		loadStyle("/css/add-to-calendar.css"),
-	  ])
-	  status = "loaded"
-	  button.innerHTML = text
-	}
-	atcb_action(config, button)
+  button?.addEventListener("click", () => {
+    Promise.all([
+      import("/js/add-to-calendar.js"),
+      loadStyle("/css/add-to-calendar.css"),
+    ]).then(() => {
+      atcb_action(config, button)
+    })
   })
 </script>


### PR DESCRIPTION
## Descripción

En dispositivos con conexiones lentas (probar con 3G lento en las herramientas del desarrollador) el boton "Agregar al calendario" tarda un poco ya que por cada click se importa el JS y CSS para agregar al calendario.

## Problema solucionado

Ahora la primera vez que se hace click en el boton aparece "Cargando..." en el texto momentaneamente, se carga y muestra el calendario. Las siguientes veces ya no es necesario cargar y lo muestra de inmediato

## Cambios propuestos

Agregue una variable en el script de CalendarButon.astro con el estado, y cuando el boton hace click, si no esta cargado lo carga, si ya esta cargado muestra el calendario de una vez, y si el usuario hace varias veces click si todavia esta cargando no hace nada, para no hacer mas descargas innecesarias 

## Capturas de pantalla (si corresponde)


https://github.com/midudev/la-velada-web-oficial/assets/56895143/cb5a21e9-6db0-4b81-9479-c2188a20a011


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejor funcionamiento para los usuarios con una conectividad baja 

## Contexto adicional

Gracias por leer y tomar consideracion de este PR! 

## Enlaces útiles

- Documentación del proyecto: Aqui
- Código de referencia: Aqui noma
