### PR TITLE
Added description prop to Layout

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,26 +3,25 @@ import "@fontsource-variable/jost"
 
 interface Props {
   title: string
+  description: string
 }
 
-const { title } = Astro.props
-const descriptionPage =
-  "Evento de boxeo entre streamers y creadores de contenido, organizado por Ibai Llanos"
+const { title, description } = Astro.props
 ---
 
 <!doctype html>
 <html lang="es">
   <head>
     <title>{title}</title>
-  
+
     <meta charset="UTF-8" />
-    <meta name="description" content={descriptionPage} />
+    <meta name="description" content={description} />
 
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="canonical" href="https://lavelada.es" />
     <meta name="viewport" content="width=device-width" />
-    
-    <meta
+
+	<meta
       name="keywords"
       content="velada, streamers, creadores, Ibai, boxeo, midudev"
     />
@@ -31,12 +30,12 @@ const descriptionPage =
     <meta name="twitter:site" content="@infoLaVelada" />
     <meta name="twitter:creator" content="@ibai" />
     <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={descriptionPage} />
+    <meta name="twitter:description" content={description} />
     <meta name="twitter:image" content="/og.jpg" />
 
     <meta name="og:image" content="/og.jpg" />
     <meta name="og:title" content={title} />
-    <meta name="og:description" content={descriptionPage} />
+    <meta name="og:description" content={description} />
     <meta name="og:url" content="https://lavelada.es" />
     <meta name="og:site_name" content="La Velada 4" />
     <meta name="og:type" content="website" />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,7 +10,7 @@ import Info from "@/sections/Info.astro"
 import PrincipalDate from "@/sections/PrincipalDate.astro"
 ---
 
-<Layout title="La Velada 4 - Evento de Boxeo de Ibai Llanos">
+<Layout title="La Velada 4 - Evento de Boxeo de Ibai Llanos" description="Evento de boxeo entre streamers y creadores de contenido, organizado por Ibai Llanos">
   <Hero />
   <main>
     <PrincipalDate />


### PR DESCRIPTION
## Descripción
 Se ha añadido un nuevo prop description al componente Layout

## Problema solucionado
 Anteriormente, la descripción estaba en una constante en el Layout, lo cual hacía que el componente no fuera reutilizable.

## Cambios propuestos
 1.- Incluir un prop llamado "description" en el Layout para que sea reutilizable en el caso de que se agreguen más páginas en el futuro  y poner la descripción anterior directamente desde index.astro.

## Comprobación de cambios

- ✅ He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- ✅ He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente. (no aplica)
- ❌ He actualizado la documentación, si corresponde. (no aplica)

## Impacto potencial
 Agregar el prop "description" mejora la flexibilidad y la reutilización del componente.

