### PR TITLE
Add map marker

### DIFF
--- a/src/icons/map-marker.astro
+++ b/src/icons/map-marker.astro
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="18" height="18" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" class={Astro.props.class}>
+	<path fill="currentColor" fill-rule="evenodd" d="M11.291 21.706 12 21l-.709.706zM12 21l.708.706a1 1 0 0 1-1.417 0l-.006-.007-.017-.017-.062-.063a47.708 47.708 0 0 1-1.04-1.106 49.562 49.562 0 0 1-2.456-2.908c-.892-1.15-1.804-2.45-2.497-3.734C4.535 12.612 4 11.248 4 10c0-4.539 3.592-8 8-8 4.408 0 8 3.461 8 8 0 1.248-.535 2.612-1.213 3.87-.693 1.286-1.604 2.585-2.497 3.735a49.583 49.583 0 0 1-3.496 4.014l-.062.063-.017.017-.006.006L12 21zm0-8a3 3 0 1 0 0-6 3 3 0 0 0 0 6z" clip-rule="evenodd"/></svg>

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -1,5 +1,6 @@
 ---
 import CalendarButton from "../components/CalendarButton.astro"
+import MapMarkerIcon from "@/icons/map-marker.astro"
 ---
 
 <section
@@ -18,11 +19,12 @@ import CalendarButton from "../components/CalendarButton.astro"
     <span>Evento de Presentación</span>
     <a
       href="https://maps.app.goo.gl/RFzHUVDhRqdQaTAo8"
-      class="hover:scale-110 hover:opacity-60 transition inline-block"
+      class="hover:scale-110 hover:opacity-60 transition inline-block align-middle"
       target="_blank"
-      rel="noopener"
+      rel="noopener" 
+      style="display: -webkit-box;"
     >
-      Teatro Victoria (Barcelona)
+        <MapMarkerIcon class="max-md:mt-1 md:mt-0.5 mr-1 md:size-6"></MapMarkerIcon> Teatro Victoria (Barcelona)
     </a>
   </h2>
 


### PR DESCRIPTION
## Descripción

Añadí un icono de map-marker junto al texto del Teatro. Esto es porque la primera vez que usé la página no me di cuenta de que era clickeable ese texto ya que visualmente no tiene nada distintivo. Mantuve el estilo y colores del resto del diseño y creo que queda bastante bien para que se de a entender de que ese texto es un botón.

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/43712486/46babd23-0a29-41b6-92d9-97b4d0c429ba)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
