### PR TITLE
♿️ fix: footer icons hover fixed for mobile

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -5,7 +5,7 @@ import MoonIcon from "@/icons/moon.astro"
 
 <button
   id="themeToggle"
-  class="inline-flex text-primary transition md:hover:scale-125 md:hover:opacity-70"
+  class="inline-flex text-primary transition any-hover:scale-125 any-hover:opacity-70"
 >
   <SunIcon
     class="opacity-100 transition-transform dark:-rotate-90 dark:opacity-0"

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -8,7 +8,7 @@ import XIcon from "@/icons/x.astro"
   class="mt-20 w-full border-primary border-t-2 flex flex-col md:flex-row place-items-center md:justify-between pt-6 pb-20"
 >
   <span class="text-primary text-center">
-    &copy; 2024 La Velada del Año <span
+    &#169; 2024 La Velada del Año <span
       aria-hidden="true"
       class="hidden md:inline">|</span
     ><br aria-hidden="true" class="block md:hidden" /> Todos los derechos reservados.
@@ -25,7 +25,7 @@ import XIcon from "@/icons/x.astro"
           rel="noopener"
           aria-label="Instagram de la velada"
           href="https://www.instagram.com/infolavelada"
-          class="md:hover:scale-125 md:hover:opacity-70 transition inline-block"
+          class="any-hover:scale-125 any-hover:opacity-70 transition inline-block"
         >
           <InstagramIcon class="text-primary" />
         </a>
@@ -36,7 +36,7 @@ import XIcon from "@/icons/x.astro"
           rel="noopener"
           aria-label="X de la velada"
           href="https://x.com/infoLaVelada"
-          class="md:hover:scale-125 md:hover:opacity-70 transition inline-block"
+          class="any-hover:scale-125 any-hover:opacity-70 transition inline-block"
         >
           <XIcon class="text-primary" />
         </a>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -13,5 +13,7 @@ export default {
 		},
 	},
 	darkMode: 'class',
-	plugins: [animations],
+	plugins: [animations, function ({ addVariant }) {
+		addVariant("any-hover", "@media (any-hover: hover) { &:hover }")
+	}],
 }


### PR DESCRIPTION
## Descripción

Se ha removido el hover en los iconos del footer para dispositivos touch usando any-hover. 

## Problema solucionado

Cuando se tiene un dispositivo que no tiene mouse si no touch, el hover no funciona muy bien ya que queda en estado hover hasta que presionas otro elemento o otra parte de la pantalla.

Como primera impresión de la pagina decidí cambiar el modo oscuro y ví que el icono quedaba mas grande que los demás mientras scrolleaba y esto da un poco de TOC.

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

None

## Contexto adicional

None

## Enlaces útiles

https://caniuse.com/css-media-interaction

Mini video del icono en estado hover.

https://github.com/midudev/la-velada-web-oficial/assets/17632891/4a9cb6ac-7d36-4479-b298-58e1fdb9e479

Solución:

https://github.com/midudev/la-velada-web-oficial/assets/17632891/f771ac81-4b92-4cba-9bb3-02f90343cc4a





