### PR TITLE
[feat]: Agregar la GEO de la Velada a los meta tags

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -42,6 +42,11 @@ const descriptionPage =
     <meta name="og:type" content="website" />
     <meta name="og:locale" content="es_ES" />
 
+	<meta name="geo.region" content="ES-CT" />
+	<meta name="geo.placename" content="Barcelona" />
+	<meta name="geo.position" content="41.37478;2.168872" />
+	<meta name="ICBM" content="41.37478, 2.168872" />
+
     <meta name="robots" content="index, follow" />
     <meta name="googlebot" content="index, follow" />
   </head>


### PR DESCRIPTION
## Descripción

Se agrego la GEO de la Velada en los meta tags para que los motores de busqueda sepan la ubicacion del evento y también mejorara el SEO para las personas que esten en esa ubicación 

## Problema solucionado

Mejora y optimizacion de SEO

## Cambios propuestos

Agregar los meta tags de geo localizacion correspondientes al evento de la velada

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/56895143/9987be4b-523c-4beb-85bd-48c5402a3d92)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Puede ayudar a mejorar la busqueda del SEO sobre todo a las personas que estan en la ubicacion cercana al evento, y además los motores de busqueda cuentan con la informacion de la localizacion 

## Contexto adicional

Sin contexto

## Enlaces útiles

- Documentación del proyecto: Aqui
- Código de referencia: Aqui noma
