### PR TITLE
[feat] Internacionalizacion con i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ pnpm-debug.log*
 pnpm-lock.yaml
 package-lock.json
 yarn.lock
+bun.lockb
 
 # .vs folder
 .vs/

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,10 +1,18 @@
 import tailwind from "@astrojs/tailwind"
 import vercel from "@astrojs/vercel/serverless"
 import { defineConfig } from "astro/config"
+import preact from "@astrojs/preact"
 
 // https://astro.build/config
 export default defineConfig({
-	integrations: [tailwind()],
+	integrations: [tailwind(), preact()],
+	i18n: {
+		defaultLocale: "es",
+		locales: ["es", "en"],
+		routing: {
+			prefixDefaultLocale: false,
+		},
+	},
 	adapter: vercel({
 		webAnalytics: { enabled: true },
 	}),

--- a/src/components/App.astro
+++ b/src/components/App.astro
@@ -1,0 +1,26 @@
+---
+import Layout from "../layouts/Layout.astro"
+
+import KonamiCode from "../components/KonamiCode.astro"
+
+import Countdown from "../sections/Countdown.astro"
+import Footer from "../sections/Footer.astro"
+import Hero from "../sections/Hero.astro"
+import Info from "../sections/Info.astro"
+import PrincipalDate from "../sections/PrincipalDate.astro"
+
+import { getI18n } from "../i18n"
+const { currentLocale = 'es' } = Astro
+const i18n = getI18n({currentLocale})
+---
+
+<Layout title={i18n.SEO_TITLE}>
+  <Hero />
+  <main>
+    <PrincipalDate />
+    <Info />
+    <Countdown />
+  </main>
+  <Footer />
+  <KonamiCode />
+</Layout>

--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -1,3 +1,9 @@
+---
+import { getI18n } from "../i18n"
+const { currentLocale = "es" } = Astro
+const i18n = getI18n({ currentLocale })
+---
+
 <button
 	id="add-to-calendar"
 	class:list={`
@@ -7,7 +13,7 @@
     hover:bg-primary hover:text-secondary
   `}
 >
-	Agregar al calendario
+	{i18n.ADD_TO_CALENDAR}
 </button>
 
 <script is:inline>

--- a/src/components/LangToggle.astro
+++ b/src/components/LangToggle.astro
@@ -1,0 +1,35 @@
+---
+import SpainFlag from "@/components/flags/Spain.astro"
+import UnitedStatesFlag from "@/components/flags/UnitedStates.astro"
+---
+
+<button
+	id="langToggle"
+	class="inline-flex text-primary transition hover:scale-125 hover:opacity-70"
+>
+	<a id="esFlag" href="/">
+		<SpainFlag class="h-6 transition-transform" />
+	</a>
+	<a id="enFlag" href="/en">
+		<UnitedStatesFlag class="h-6 transition-transform" />
+	</a>
+	<span class="sr-only">Language</span>
+</button>
+
+<script is:inline>
+	function getLangFromUrl() {
+		const path = window.location.pathname
+		return path.includes("/en") ? "en" : "es"
+	}
+
+	const lang = getLangFromUrl()
+	document.addEventListener("DOMContentLoaded", function () {
+		if (lang === "es") {
+			document.getElementById("esFlag").classList.add("hidden")
+			document.getElementById("enFlag").classList.remove("hidden")
+		} else {
+			document.getElementById("esFlag").classList.remove("hidden")
+			document.getElementById("enFlag").classList.add("hidden")
+		}
+	})
+</script>

--- a/src/components/flags/Spain.astro
+++ b/src/components/flags/Spain.astro
@@ -1,0 +1,10 @@
+<svg
+	class="h-auto w-4"
+	xmlns="http://www.w3.org/2000/svg"
+	width="750"
+	height="500"
+	viewBox="0 0 750 500"
+>
+	<rect width="750" height="500" fill="#c60b1e"></rect>
+	<rect width="750" height="250" fill="#ffc400" y="125"></rect>
+</svg>

--- a/src/components/flags/Spain.astro
+++ b/src/components/flags/Spain.astro
@@ -1,10 +1,4 @@
-<svg
-	class="h-auto w-4"
-	xmlns="http://www.w3.org/2000/svg"
-	width="750"
-	height="500"
-	viewBox="0 0 750 500"
->
-	<rect width="750" height="500" fill="#c60b1e"></rect>
-	<rect width="750" height="250" fill="#ffc400" y="125"></rect>
+<svg xmlns="http://www.w3.org/2000/svg" class={Astro.props.class} viewBox="0 0 750 500">
+	<path fill="#c60b1e" d="M0 0h750v500H0z"></path>
+	<path fill="#ffc400" d="M0 125h750v250H0z"></path>
 </svg>

--- a/src/components/flags/UnitedStates.astro
+++ b/src/components/flags/UnitedStates.astro
@@ -1,0 +1,21 @@
+<svg class="h-auto w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900"
+	><path fill="#b22234" d="M0 0h7410v3900H0z"></path><path
+		d="M0 450h7410m0 600H0m0 600h7410m0 600H0m0 600h7410m0 600H0"
+		stroke="#fff"
+		stroke-width="300"></path><path fill="#3c3b6e" d="M0 0h2964v2100H0z"></path><g fill="#fff"
+		><g id="d"
+			><g id="c"
+				><g id="e"
+					><g id="b"
+						><path id="a" d="M247 90l70.534 217.082-184.66-134.164h228.253L176.466 307.082z"
+						></path><use xlink:href="#a" y="420"></use><use xlink:href="#a" y="840"></use><use
+							xlink:href="#a"
+							y="1260"></use></g
+					><use xlink:href="#a" y="1680"></use></g
+				><use xlink:href="#b" x="247" y="210"></use></g
+			><use xlink:href="#c" x="494"></use></g
+		><use xlink:href="#d" x="988"></use><use xlink:href="#c" x="1976"></use><use
+			xlink:href="#e"
+			x="2470"></use></g
+	></svg
+>

--- a/src/components/flags/UnitedStates.astro
+++ b/src/components/flags/UnitedStates.astro
@@ -1,21 +1,25 @@
-<svg class="h-auto w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 7410 3900"
-	><path fill="#b22234" d="M0 0h7410v3900H0z"></path><path
-		d="M0 450h7410m0 600H0m0 600h7410m0 600H0m0 600h7410m0 600H0"
-		stroke="#fff"
-		stroke-width="300"></path><path fill="#3c3b6e" d="M0 0h2964v2100H0z"></path><g fill="#fff"
-		><g id="d"
-			><g id="c"
-				><g id="e"
-					><g id="b"
-						><path id="a" d="M247 90l70.534 217.082-184.66-134.164h228.253L176.466 307.082z"
-						></path><use xlink:href="#a" y="420"></use><use xlink:href="#a" y="840"></use><use
-							xlink:href="#a"
-							y="1260"></use></g
-					><use xlink:href="#a" y="1680"></use></g
-				><use xlink:href="#b" x="247" y="210"></use></g
-			><use xlink:href="#c" x="494"></use></g
-		><use xlink:href="#d" x="988"></use><use xlink:href="#c" x="1976"></use><use
-			xlink:href="#e"
-			x="2470"></use></g
-	></svg
->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 5850 3900" class={Astro.props.class}>
+  <path fill="#b22234" d="M0 0h7410v3900H0z"/>
+  <path stroke="#fff" stroke-width="300" d="M0 450h7410m0 600H0m0 600h7410m0 600H0m0 600h7410m0 600H0"/>
+  <path fill="#3c3b6e" d="M0 0h2964v2100H0z"/>
+  <g fill="#fff">
+    <g id="d">
+      <g id="c">
+        <g id="e">
+          <g id="b">
+            <path id="a" d="m247 90 70.53 217.08-184.66-134.16h228.26L176.47 307.08z"/>
+            <use xlink:href="#a" y="420"/>
+            <use xlink:href="#a" y="840"/>
+            <use xlink:href="#a" y="1260"/>
+          </g>
+          <use xlink:href="#a" y="1680"/>
+        </g>
+        <use xlink:href="#b" x="247" y="210"/>
+      </g>
+      <use xlink:href="#c" x="494"/>
+    </g>
+    <use xlink:href="#d" x="988"/>
+    <use xlink:href="#c" x="1976"/>
+    <use xlink:href="#e" x="2470"/>
+  </g>
+</svg>

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,21 @@
+{
+  "SEO_TITLE": "La Velada 4 - Ibai Llanos Boxing Event",
+  "ADD_TO_CALENDAR": "Add to Calendar",
+  "LAUNCH_EVENT_CALENDAR": "🥊 La Velada del Año 4 - Presentation Event",
+  "DESCRIPTION_CALENDAR": "Presentation Event for La Velada del Año 4 is about to start. Tune in to Twitch and don't miss it → [url]https://twitch.tv/ibai[/url]",
+  "DATE": "March 4th",
+  "LAUNCH_EVENT": "Presentation Event",
+  "PLACE": "Teatro Victoria (Barcelona)",
+  "SOLD_OUT": "Sold Out",
+  "PRESENTATION_COMPLETE": "Presentation of La Velada del Año IV",
+  "PRESENTATION": "Presentation of",
+  "TIME_TO_START": "For the Presentation Event there is",
+  "ACTIVITIES": "Introduction, Weigh-In, Interview, and Face-Off",
+  "STREAMING": "Follow it live",
+  "BOXERS":"With the presence of the male and female boxers",
+  "ALL_RIGHTS_RESERVED": "All rights reserved",
+  "DAYS": "Days",
+  "HOURS": "Hours",
+  "MINUTES": "Minutes",
+  "SECONDS": "Seconds"
+}

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,0 +1,21 @@
+{
+  "SEO_TITLE": "La Velada 4 - Evento de Boxeo de Ibai Llanos",
+  "ADD_TO_CALENDAR": "Agregar al calendario",
+  "LAUNCH_EVENT_CALENDAR": "🥊 La Velada del Año 4 - Evento de Presentación",
+  "DESCRIPTION_CALENDAR": "La presentación de La Velada del Año 4 está por comenzar.<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]",
+  "DATE": "4 de marzo",
+  "LAUNCH_EVENT": "Evento de Presentación",
+  "PLACE": "Teatro Victoria (Barcelona)",
+  "SOLD_OUT": "Entradas agotadas",
+  "PRESENTATION_COMPLETE": "Presentación de la Velada del Año IV",
+  "PRESENTATION": "Presentación de la",
+  "TIME_TO_START": "Para el Evento de Presentación faltan",
+  "ACTIVITIES": "PRESENTACIÓN, PESAJE, ENTREVISTA Y CARA A CARA",
+  "STREAMING": "Síguelo en directo",
+  "BOXERS": "Con la presencia de los boxeadores y las boxeadoras",
+  "ALL_RIGHTS_RESERVED": "Todos los derechos reservados",
+  "DAYS": "Días",
+  "HOURS": "Horas",
+  "MINUTES": "Minutos",
+  "SECONDS": "Segundos"
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,13 @@
+import spanish from "./es.json"
+import english from "./en.json"
+
+const LANGUAGES = {
+	SPANISH: "es",
+	ENGLISH: "en",
+}
+
+export const getI18n = ({ currentLocale = "es" }: { currentLocale: string | undefined }) => {
+	if (currentLocale === LANGUAGES.ENGLISH) return english
+	if (currentLocale === LANGUAGES.SPANISH) return spanish
+	return spanish
+}

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,0 +1,5 @@
+---
+import App from "../../components/App.astro"
+---
+
+<App />

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,22 +1,5 @@
 ---
-import Layout from "@/layouts/Layout.astro"
-
-import KonamiCode from "@/components/KonamiCode.astro"
-
-import Countdown from "@/sections/Countdown.astro"
-import Footer from "@/sections/Footer.astro"
-import Hero from "@/sections/Hero.astro"
-import Info from "@/sections/Info.astro"
-import PrincipalDate from "@/sections/PrincipalDate.astro"
+import App from "../components/App.astro"
 ---
 
-<Layout title="La Velada 4 - Evento de Boxeo de Ibai Llanos">
-  <Hero />
-  <main>
-    <PrincipalDate />
-    <Info />
-    <Countdown />
-  </main>
-  <Footer />
-  <KonamiCode />
-</Layout>
+<App />

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -2,6 +2,10 @@
 import LaVeladaLogo from "@/icons/la-velada.astro"
 import Date from "@/components/Date.astro"
 import { EVENT_TIMESTAMP } from "@/consts/event-date"
+
+import { getI18n } from "../i18n"
+const { currentLocale = 'es' } = Astro
+const i18n = getI18n({currentLocale})
 ---
 
 <section class="my-0 lg:my-32 flex flex-col gap-y-10 place-items-center">
@@ -10,26 +14,26 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
   <p
     class="uppercase text-lg font-medium text-primary opacity-80 text-center text-balance"
   >
-    Para el Evento de Presentación faltan
+    {i18n.TIME_TO_START}
   </p>
   
   <div
     class="flex flex-row gap-x-1 text-primary uppercase font-semibold"
     data-date={EVENT_TIMESTAMP}
   >
-    <Date time="00" dateType="Días" attribute={{ "data-days": "" }} />
+    <Date time="00" dateType={i18n.DAYS} attribute={{ "data-days": "" }} />
 
     <span aria-hidden="true" class="mt-1 text-xl">:</span>
 
-    <Date time="00" dateType="Horas" attribute={{ "data-hours": "" }} />
+    <Date time="00" dateType={i18n.HOURS} attribute={{ "data-hours": "" }} />
 
     <span aria-hidden="true" class="mt-1 text-xl">:</span>
 
-    <Date time="00" dateType="Minutos" attribute={{ "data-minutes": "" }} />
+    <Date time="00" dateType={i18n.MINUTES} attribute={{ "data-minutes": "" }} />
 
     <span aria-hidden="true" class="mt-1 text-xl">:</span>
 
-    <Date time="00" dateType="Segundos" attribute={{ "data-seconds": "" }} />
+    <Date time="00" dateType={i18n.SECONDS} attribute={{ "data-seconds": "" }} />
   </div>
 </section>
 

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -1,53 +1,56 @@
 ---
 import ThemeToggle from "@/components/ThemeToggle.astro"
+import LangToggle from "@/components/LangToggle.astro"
 import InstagramIcon from "@/icons/instagram.astro"
 import XIcon from "@/icons/x.astro"
 
 import { getI18n } from "../i18n"
-const { currentLocale = 'es' } = Astro
-const i18n = getI18n({currentLocale})
+const { currentLocale = "es" } = Astro
+const i18n = getI18n({ currentLocale })
 ---
 
 <footer
-  class="mt-20 w-full border-primary border-t-2 flex flex-col md:flex-row place-items-center md:justify-between pt-6 pb-20"
+	class="mt-20 flex w-full flex-col place-items-center border-t-2 border-primary pb-20 pt-6 md:flex-row md:justify-between"
 >
-  <span class="text-primary text-center">
-    &#169; 2024 La Velada del Año <span
-      aria-hidden="true"
-      class="hidden md:inline">|</span
-    ><br aria-hidden="true" class="block md:hidden" /> {i18n.ALL_RIGHTS_RESERVED}.
-  </span>
-  <span
-    aria-hidden="true"
-    class="md:hidden border-primary border-t-2 w-full mt-6 pt-6"></span>
+	<span class="text-center text-primary">
+		&#169; 2024 La Velada del Año <span aria-hidden="true" class="hidden md:inline">|</span><br
+			aria-hidden="true"
+			class="block md:hidden"
+		/>
+		{i18n.ALL_RIGHTS_RESERVED}.
+	</span>
+	<span aria-hidden="true" class="mt-6 w-full border-t-2 border-primary pt-6 md:hidden"></span>
 
-  <nav>
-    <ul class="flex flex-row gap-x-6 items-center">
-      <li>
-        <a
-          target="_blank"
-          rel="noopener"
-          aria-label="Instagram de la velada"
-          href="https://www.instagram.com/infolavelada"
-          class="hover:scale-125 hover:opacity-70 transition inline-block"
-        >
-          <InstagramIcon class="text-primary" />
-        </a>
-      </li>
-      <li>
-        <a
-          target="_blank"
-          rel="noopener"
-          aria-label="X de la velada"
-          href="https://x.com/infoLaVelada"
-          class="hover:scale-125 hover:opacity-70 transition inline-block"
-        >
-          <XIcon class="text-primary" />
-        </a>
-      </li>
-      <li>
-        <ThemeToggle />
-      </li>
-    </ul>
-  </nav>
+	<nav>
+		<ul class="flex flex-row items-center gap-x-6">
+			<li>
+				<a
+					target="_blank"
+					rel="noopener"
+					aria-label="Instagram de la velada"
+					href="https://www.instagram.com/infolavelada"
+					class="inline-block transition hover:scale-125 hover:opacity-70"
+				>
+					<InstagramIcon class="text-primary" />
+				</a>
+			</li>
+			<li>
+				<a
+					target="_blank"
+					rel="noopener"
+					aria-label="X de la velada"
+					href="https://x.com/infoLaVelada"
+					class="inline-block transition hover:scale-125 hover:opacity-70"
+				>
+					<XIcon class="text-primary" />
+				</a>
+			</li>
+			<li>
+				<ThemeToggle />
+			</li>
+			<li>
+				<LangToggle />
+			</li>
+		</ul>
+	</nav>
 </footer>

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -2,6 +2,10 @@
 import ThemeToggle from "@/components/ThemeToggle.astro"
 import InstagramIcon from "@/icons/instagram.astro"
 import XIcon from "@/icons/x.astro"
+
+import { getI18n } from "../i18n"
+const { currentLocale = 'es' } = Astro
+const i18n = getI18n({currentLocale})
 ---
 
 <footer
@@ -11,7 +15,7 @@ import XIcon from "@/icons/x.astro"
     &#169; 2024 La Velada del Año <span
       aria-hidden="true"
       class="hidden md:inline">|</span
-    ><br aria-hidden="true" class="block md:hidden" /> Todos los derechos reservados.
+    ><br aria-hidden="true" class="block md:hidden" /> {i18n.ALL_RIGHTS_RESERVED}.
   </span>
   <span
     aria-hidden="true"

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -1,16 +1,18 @@
 ---
 import HeroLogo from "@/components/HeroLogo.astro"
+
+import { getI18n } from "../i18n"
+const { currentLocale = "es" } = Astro
+const i18n = getI18n({ currentLocale })
 ---
 
 <section class="flex flex-col place-items-center gap-4 lg:gap-9">
-  <h1 class="sr-only">Presentación de la Velada del Año IV</h1>
-  <span
-    class="animate-fade-in animate-delay-300 text-base lg:text-xl uppercase text-secondary bg-primary px-3 py-0.5 md:px-6 md:py-1 font-medium"
-    aria-hidden="true"
-  >
-    Presentación de la
-  </span>
-  <HeroLogo
-    class="text-primary animate-fade-in-up w-[300px] h-auto md:w-[500px]"
-  />
+	<h1 class="sr-only">{i18n.PRESENTATION_COMPLETE}</h1>
+	<span
+		class="animate-fade-in bg-primary px-3 py-0.5 text-base font-medium uppercase text-secondary animate-delay-300 md:px-6 md:py-1 lg:text-xl"
+		aria-hidden="true"
+	>
+		{i18n.PRESENTATION}
+	</span>
+	<HeroLogo class="h-auto w-[300px] animate-fade-in-up text-primary md:w-[500px]" />
 </section>

--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -1,109 +1,109 @@
 ---
-
+import { getI18n } from "../i18n"
+const { currentLocale = "es" } = Astro
+const i18n = getI18n({ currentLocale })
 ---
 
-<section class="flex font-medium text-primary gap-y-10 my-32 flex-col">
-  <a
-    href="https://twitch.tv/ibai"
-    target="_blank"
-    rel="nofollow noopener"
-    class="hover:scale-125 hover:opacity-70 transition mx-auto"
-    aria-label="Síguelo en directo twitch.tv/ibai"
-  >
-    <svg
-      class="twitch text-primary detect-in-viewport"
-      width="78"
-      height="91"
-      fill="none"
-      viewBox="0 0 78 91"
-      ><path
-        fill="currentColor"
-        d="M16.6001.600098.600098 16.6001v57.6H19.8001v16l16-16h12.8l28.8-28.8V.600098h-60.8Z"
-      ></path><path
-        fill="var(--background-color)"
-        d="m58.2003 55 12.8-12.8V7h-51.2v48h12.8v12.8l12.8-12.8h12.8Z"
-      ></path><path
-        fill="currentColor"
-        d="M39 19.8h6.4V39H39V19.8Zm22.4 0V39H55V19.8h6.4Z"></path>
-    </svg>
-  </a>
+<section class="my-32 flex flex-col gap-y-10 font-medium text-primary">
+	<a
+		href="https://twitch.tv/ibai"
+		target="_blank"
+		rel="nofollow noopener"
+		class="mx-auto transition hover:scale-125 hover:opacity-70"
+		aria-label="Síguelo en directo twitch.tv/ibai"
+	>
+		<svg
+			class="twitch detect-in-viewport text-primary"
+			width="78"
+			height="91"
+			fill="none"
+			viewBox="0 0 78 91"
+			><path
+				fill="currentColor"
+				d="M16.6001.600098.600098 16.6001v57.6H19.8001v16l16-16h12.8l28.8-28.8V.600098h-60.8Z"
+			></path><path
+				fill="var(--background-color)"
+				d="m58.2003 55 12.8-12.8V7h-51.2v48h12.8v12.8l12.8-12.8h12.8Z"></path><path
+				fill="currentColor"
+				d="M39 19.8h6.4V39H39V19.8Zm22.4 0V39H55V19.8h6.4Z"></path>
+		</svg>
+	</a>
 
-  <div
-    class="grid uppercase text-center gap-x-10 [grid-template-columns:1fr] md:grid-cols-[repeat(auto-fit,_minmax(150px,_1fr))] lg:[grid-template-columns:1fr_1.5fr_1fr]"
-  >
-    <article
-      class="order-2 md:flex-grow md:order-none flex justify-center items-center text-xl text-center py-10 md:py-12 lg:py-20 md:px-0 px-10 border-y-2 border-primary"
-    >
-      <h3 class="text-balance md:max-w-[250px]">
-        Presentación, Pesaje, Entrevista y Cara a Cara
-      </h3>
-    </article>
+	<div
+		class="grid gap-x-10 text-center uppercase [grid-template-columns:1fr] md:grid-cols-[repeat(auto-fit,_minmax(150px,_1fr))] lg:[grid-template-columns:1fr_1.5fr_1fr]"
+	>
+		<article
+			class="order-2 flex items-center justify-center border-y-2 border-primary px-10 py-10 text-center text-xl md:order-none md:flex-grow md:px-0 md:py-12 lg:py-20"
+		>
+			<h3 class="text-balance md:max-w-[250px]">
+				{i18n.ACTIVITIES}
+			</h3>
+		</article>
 
-    <article
-      class="order-1 md:flex-1 md:order-none flex justify-center items-center text-3xl lg:text-4xl py-10 md:py-12 lg:py-20 px-10 md:px-0 lg:px-0 border-t-2 md:border-y-2 border-primary"
-    >
-      <h3 class="md:max-w-[250px]">
-        <a
-          class="hover:text-twitch transition-transform hover:scale-110 inline-block"
-          href="https://twitch.tv/ibai"
-          target="_blank"
-          rel="nofollow noopener"
-        >
-          Síguelo en directo <span
-            class="twitch-link detect-in-viewport transition-colors"
-            >twitch.tv/ibai</span
-          >
-        </a>
-      </h3>
-    </article>
+		<article
+			class="order-1 flex items-center justify-center border-t-2 border-primary px-10 py-10 text-3xl md:order-none md:flex-1 md:border-y-2 md:px-0 md:py-12 lg:px-0 lg:py-20 lg:text-4xl"
+		>
+			<h3 class="md:max-w-[250px]">
+				<a
+					class="inline-block transition-transform hover:scale-110 hover:text-twitch"
+					href="https://twitch.tv/ibai"
+					target="_blank"
+					rel="nofollow noopener"
+				>
+					{i18n.STREAMING} <span class="twitch-link detect-in-viewport transition-colors"
+						>twitch.tv/ibai</span
+					>
+				</a>
+			</h3>
+		</article>
 
-    <article
-      class="order-3 md:order-none text-xl py-10 sm:py-12 md:py-12 lg:py-20 px-10 md:px-0 border-b-2 md:border-y-2 border-primary flex justify-center items-center"
-    >
-      <h3 class="text-balance md:max-w-[250px]">
-        Con la presencia de los boxeadores y las boxeadoras
-      </h3>
-    </article>
-  </div>
+		<article
+			class="order-3 flex items-center justify-center border-b-2 border-primary px-10 py-10 text-xl sm:py-12 md:order-none md:border-y-2 md:px-0 md:py-12 lg:py-20"
+		>
+			<h3 class="text-balance md:max-w-[250px]">
+				{i18n.BOXERS}
+			</h3>
+		</article>
+	</div>
 </section>
 
 <style>
-  .twitch-link,
-  svg {
-    @apply text-twitch;
-  }
+	.twitch-link,
+	svg {
+		@apply text-twitch;
+	}
 
-  @supports (animation-timeline: view()) {
-    svg {
-      animation-timeline: view();
-      animation-name: show;
-      animation-timing-function: ease-in;
-    }
+	@supports (animation-timeline: view()) {
+		svg {
+			animation-timeline: view();
+			animation-name: show;
+			animation-timing-function: ease-in;
+		}
 
-    :not(a:hover) > .twitch-link {
-      animation-timeline: view(block);
-      animation-name: show;
-      animation-timing-function: ease-in;
-    }
-  }
+		:not(a:hover) > .twitch-link {
+			animation-timeline: view(block);
+			animation-name: show;
+			animation-timing-function: ease-in;
+		}
+	}
 
-  @media (prefers-reduced-motion: reduce) {
-    svg {
-      animation-name: none;
-    }
-  }
+	@media (prefers-reduced-motion: reduce) {
+		svg {
+			animation-name: none;
+		}
+	}
 
-  @keyframes show {
-    from {
-      @apply text-primary;
-    }
+	@keyframes show {
+		from {
+			@apply text-primary;
+		}
 
-    50% {
-      @apply text-twitch;
-    }
+		50% {
+			@apply text-twitch;
+		}
 
-    100% {
-      @apply text-twitch;
-    }
-  }
+		100% {
+			@apply text-twitch;
+		}
+	}
 </style>

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -1,13 +1,17 @@
 ---
 import CalendarButton from "../components/CalendarButton.astro"
 import MapMarkerIcon from "@/icons/map-marker.astro"
+
+import { getI18n } from "../i18n"
+const { currentLocale = 'es' } = Astro
+const i18n = getI18n({currentLocale})
 ---
 
 <section
   class="animate-fade-in animate-delay-500 mt-16 md:mt-32 mx-auto flex flex-col place-items-center text-center text-primary"
 >
   <div class="uppercase text-3xl md:text-5xl font-semibold">
-    <time class="date"> 4 de marzo</time>
+    <time class="date"> {i18n.DATE} </time>
     <span aria-hidden="true" class="hidden md:inline mx-1">·</span>
     <br aria-hidden="true" class="block md:hidden" />
     <time class="time"></time>
@@ -16,7 +20,7 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
   <h2
     class="uppercase text-lg lg:text-2xl font-medium flex flex-col max-w-sm mt-6"
   >
-    <span>Evento de Presentación</span>
+    <span>{i18n.LAUNCH_EVENT}</span>
     <a
       href="https://maps.app.goo.gl/RFzHUVDhRqdQaTAo8"
       class="hover:scale-110 hover:opacity-60 transition inline-block align-middle"
@@ -24,7 +28,7 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
       rel="noopener" 
       style="display: -webkit-box;"
     >
-        <MapMarkerIcon class="max-md:mt-1 md:mt-0.5 mr-1 md:size-6"></MapMarkerIcon> Teatro Victoria (Barcelona)
+        <MapMarkerIcon class="max-md:mt-1 md:mt-0.5 mr-1 md:size-6"></MapMarkerIcon> {i18n.PLACE}
     </a>
   </h2>
 
@@ -40,7 +44,7 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
       target="_blank"
       rel="noopener noreferrer"
     >
-      Entradas agotadas
+      {i18n.SOLD_OUT}
     </a>
 
     <CalendarButton />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
   "extends": "astro/tsconfigs/strict",
   "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
     "baseUrl": ".",
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Descripción

Traducción añadida

## Problema solucionado

Web escrita en inglés y español

## Cambios propuestos

Se han añadido SVG con las banderas de España y Estados Unidos para representar el idioma. Y se ha añadido al footer la posibilidad de cambiar el idioma empleando i18n

## Capturas de pantalla (si corresponde)

Cuando la página está en Español se puede ver este boton

![image](https://github.com/midudev/la-velada-web-oficial/assets/40019177/5b9b2f6c-2b50-467a-b1dd-e7420422db06)

Y cuando está en inglés

![image](https://github.com/midudev/la-velada-web-oficial/assets/40019177/09bc7b28-3954-42e9-9b5f-532f2d5caa04)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

- Documentación del proyecto: [i18n ASTRO](https://docs.astro.build/en/recipes/i18n/)
