### PR TITLE
fix: stop countdown at event date

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -5,14 +5,14 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 ---
 
 <section class="my-0 lg:my-32 flex flex-col gap-y-10 place-items-center">
-  
+
   <LaVeladaLogo class="text-primary" />
   <p
     class="uppercase text-lg font-medium text-primary opacity-80 text-center text-balance"
   >
     Para el Evento de Presentación faltan
   </p>
-  
+
   <div
     class="flex flex-row gap-x-1 text-primary uppercase font-semibold"
     data-date={EVENT_TIMESTAMP}
@@ -57,9 +57,16 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
       return Math.floor(time).toString().padStart(2, "0")
     }
 
+	let countdownInterval: number | undefined
+
     function updateCountdown() {
       const now = Date.now()
       const diff = date - now
+
+	  if (diff <= 0) {
+		clearInterval(countdownInterval)
+		return
+	  }
 
       if ($days instanceof HTMLElement) {
         $days.innerText = formatTime(diff / DAY)
@@ -78,7 +85,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
       }
     }
 
-    setInterval(updateCountdown, SECOND)
+	countdownInterval = setInterval(updateCountdown, SECOND)
     updateCountdown()
   }
 


### PR DESCRIPTION
## Descripción

Se ha añadido una condición de parada para la cuenta regresiva "Countdown.astro".

## Problema solucionado

La cuenta regresiva no se pararía al llegar a cero, seguiría actualizándose mostrando números negativos.

## Cambios propuestos

Condición de parada para la cuenta regresiva eliminando el intervalo sobre la función "updateCountdown".

## Capturas de pantalla

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/45204904/a6233a5d-bd5c-4cf1-89ff-fa3f5e443926)

Ahora:
![image](https://github.com/midudev/la-velada-web-oficial/assets/45204904/8444cfd0-e976-40a3-b5f6-a84861888d23)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
