### PR TITLE
 - Remove countdown text when event starts

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -81,9 +81,9 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 
 			if (diff < 1000) {
 				clearInterval(intervalId)
-				document.querySelector(".countdown-text").remove()
+				document.querySelector(".countdown-text")?.remove()
 
-				$countdown.innerHTML = "¡La velada ha comenzado! 🎉"
+				$countdown.innerHTML = "¡El evento de presentación ha empezado! 🎉"
 				$countdown.className = "text-primary uppercase font-semibold animate-fade-in text-3xl"
 
 				import("canvas-confetti").then(({ default: confetti }) => {

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -6,7 +6,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 
 <section class="my-0 flex flex-col place-items-center gap-y-10 lg:my-32" aria-label="cuenta atrás">
 	<LaVeladaLogo class="text-primary" />
-	<p class="text-balance text-center text-lg font-medium uppercase text-primary opacity-80">
+	<p class="text-balance text-center text-lg font-medium uppercase text-primary opacity-80 countdown-text">
 		Para el Evento de Presentación faltan
 	</p>
 
@@ -81,6 +81,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 
 			if (diff < 1000) {
 				clearInterval(intervalId)
+				document.querySelector(".countdown-text").remove()
 
 				$countdown.innerHTML = "¡La velada ha comenzado! 🎉"
 				$countdown.className = "text-primary uppercase font-semibold animate-fade-in text-3xl"


### PR DESCRIPTION
## Descripción

Quitar el texto "Para el Evento de Presentación faltan" cuando termine el contador y cambiar el texto "¡La velada ha comenzado! 🎉" por "¡El evento de presentación ha empezado! 🎉"


## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/56597534/bfb0bced-38f2-41d3-a387-974bb12769ff)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
