### PR TITLE
[REFACTOR] moved literal theme strings to a const file to keep everything consistent + some clean up

### DIFF
--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -1,3 +1,7 @@
+---
+import { DARK_THEME, LIGHT_THEME } from "@/consts/themes"
+---
+
 <button
 	id="add-to-calendar"
 	class:list={`
@@ -6,12 +10,12 @@
 		uppercase transition hover:scale-110
 		hover:bg-primary hover:text-secondary
 	`}
-  	aria-label="agregar al calendario se abrirá ventana flotante"
+	aria-label="agregar al calendario se abrirá ventana flotante"
 >
 	Agregar al calendario
 </button>
 
-<script is:inline>
+<script is:inline define:vars={{ darkTheme: DARK_THEME, lightTheme: LIGHT_THEME }}>
 	const config = {
 		name: "🥊 La Velada del Año 4 - Evento de Presentación",
 		description:
@@ -54,7 +58,7 @@
 			button.innerHTML = text
 		}
 
-		const theme = document.documentElement.classList.contains("dark") ? "dark" : "light"
+		const theme = document.documentElement.classList.contains(darkTheme) ? darkTheme : lightTheme
 		config.lightMode = theme
 
 		window.atcb_action(config, button)

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,53 +1,48 @@
 ---
 import SunIcon from "@/icons/sun.astro"
 import MoonIcon from "@/icons/moon.astro"
+import { DARK_THEME, LIGHT_THEME } from "@/consts/themes"
 ---
 
 <button
-  id="themeToggle"
-  class="inline-flex text-primary transition any-hover:scale-125 any-hover:opacity-70"
+	id="themeToggle"
+	class="inline-flex text-primary transition any-hover:scale-125 any-hover:opacity-70"
 >
-  <SunIcon
-    class="opacity-100 transition-transform dark:-rotate-90 dark:opacity-0"
-  />
-  <MoonIcon
-    class="absolute rotate-90 opacity-0 transition-transform dark:rotate-0 dark:opacity-100"
-  />
-  <span class="sr-only"></span>
+	<SunIcon class="opacity-100 transition-transform dark:-rotate-90 dark:opacity-0" />
+	<MoonIcon
+		class="absolute rotate-90 opacity-0 transition-transform dark:rotate-0 dark:opacity-100"
+	/>
+	<span class="sr-only"></span>
 </button>
 
-<script is:inline>
-  const getThemePreference = () => {
-    if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
-      return localStorage.getItem("theme")
-    }
-    return window.matchMedia("(prefers-color-scheme: dark)").matches
-      ? "dark"
-      : "light"
-  }
-  const isDark = getThemePreference() === "dark"
-  document.documentElement.classList[isDark ? "add" : "remove"]("dark")
+<script is:inline define:vars={{ darkTheme: DARK_THEME, lightTheme: LIGHT_THEME }}>
+	const updateThemeMessage = (isDark) => {
+		const translation = isDark ? "oscuro" : "claro"
+		const actualThemeMsg = `Alternar tema, el tema actual es ${translation}`
+		const span = document.querySelector("span.sr-only")
+		span.innerHTML = actualThemeMsg
+	}
 
-  const handleToggleClick = () => {
-    const element = document.documentElement
-    element.classList.toggle("dark")
+	const getThemePreference = () => {
+		if (typeof localStorage !== "undefined" && localStorage.getItem("theme")) {
+			return localStorage.getItem("theme")
+		}
+		return window.matchMedia("(prefers-color-scheme: dark)").matches ? darkTheme : lightTheme
+	}
 
-    const isDark = element.classList.contains("dark")
-    localStorage.setItem("theme", isDark ? "dark" : "light")
+	const isDark = getThemePreference() === darkTheme
+	document.documentElement.classList[isDark ? "add" : "remove"](darkTheme)
 
-	updateThemeMessage(isDark ? "dark" : "light");
-  }
+	const handleToggleClick = () => {
+		const element = document.documentElement
+		element.classList.toggle(darkTheme)
 
-  document
-    .getElementById("themeToggle")
-    .addEventListener("click", handleToggleClick)
+		const isDark = element.classList.contains(darkTheme)
+		localStorage.setItem("theme", isDark ? darkTheme : lightTheme)
 
-  const updateThemeMessage = (theme) => {
-	const translation = theme === "dark" ? "oscuro" : "claro";
-	const actualThemeMsg = `Alternar tema, el tema actual es ${translation}`;
-	let span = document.querySelector("span.sr-only");
-	span.innerHTML = actualThemeMsg;
-  };
-  
-  updateThemeMessage(getThemePreference());
+		updateThemeMessage(isDark)
+	}
+
+	document.getElementById("themeToggle").addEventListener("click", handleToggleClick)
+	updateThemeMessage(getThemePreference())
 </script>

--- a/src/consts/themes.ts
+++ b/src/consts/themes.ts
@@ -1,0 +1,2 @@
+export const DARK_THEME = "dark"
+export const LIGHT_THEME = "light"


### PR DESCRIPTION
## Descripción

Se han sacado los string literales de los temas oscuros y claros a un fichero de constantes para tener una mayor mantenibilidad en el futuro.

A su vez se ha limpiado un poco el código

## Problema solucionado

El problema de tener los string literales sobre los temas "dark" y "light" hace que sea muy dificil mantenerlo, y a su vez se pueden cometer fallos a la hora de meterlo en un futuro.

## Cambios propuestos

Se han pasado a un fichero de constantes para ser reutilizables a lo largo del proyecto.

## Comprobación de cambios

- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

