### PR TITLE
Prevent smoke animation if user has animations disabled

### DIFF
--- a/src/components/SmokeBackground.astro
+++ b/src/components/SmokeBackground.astro
@@ -3,121 +3,125 @@
 <script>
 	import * as THREE from "three"
 
-	const $bkg = document.getElementById("smoke-bkg")
+	const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
 
-	let w = window.innerWidth
-	let h = window.innerHeight
+	if (!reducedMotion.matches) {
+		const $bkg = document.getElementById("smoke-bkg")
 
-	const THEME = {
-		dark: {
-			background: 0x666666,
-			light: 0xffffff,
-			opacity: 1,
-		},
-		light: {
-			background: 0xeeeeee,
-			light: 0xffffff,
-			opacity: 0.2,
-		},
-	} as const
+		let w = window.innerWidth
+		let h = window.innerHeight
 
-	const themePreference = window.getThemePreference()
-	let currentTheme = THEME[themePreference]
+		const THEME = {
+			dark: {
+				background: 0x666666,
+				light: 0xffffff,
+				opacity: 1,
+			},
+			light: {
+				background: 0xeeeeee,
+				light: 0xffffff,
+				opacity: 0.2,
+			},
+		} as const
 
-	// inicializar Three.js
-	// 3 cosas básicas: escena, cámara, renderizador
-
-	// escena 🖼️
-	const scene = new THREE.Scene()
-
-	// camara 📹
-	// 75 -> ángulo de visión
-	const camera = new THREE.PerspectiveCamera(75, w / h, 1, 1000)
-	camera.position.z = 10
-	scene.add(camera)
-
-	// ▶️ renderizador
-	const renderer = new THREE.WebGLRenderer()
-	renderer.setSize(w, h)
-	// color de fondo
-	renderer.setClearColor(currentTheme.background, 1)
-
-	$bkg?.appendChild(renderer.domElement)
-
-	// añadir una luz directional
-	const light = new THREE.DirectionalLight(currentTheme.light, 0.5)
-	// posicion de la luz
-	light.position.set(-1, 3, 1)
-	scene.add(light)
-
-	const smokeParticles: THREE.Mesh[] = []
-
-	const loader = new THREE.TextureLoader()
-	loader.crossOrigin = "" // <- en localhost no pasa nada, pero si desplegamos a un servidor, puede ser necesario
-
-	loader.load("/smoke.webp", (texture) => {
-		// 1. geometria
-		// crear un plano geométrico de 300x300
-		const smokeGeo = new THREE.PlaneGeometry(300, 300)
-
-		// 2. material
-		const smokeMaterial = new THREE.MeshLambertMaterial({
-			map: texture,
-			transparent: true,
-			opacity: currentTheme.opacity,
-		})
-
-		const NUM_OF_PARTICLES = 300
-		for (let p = 0; p < NUM_OF_PARTICLES; p++) {
-			// crear la malla con la geometria y el material
-			const particle = new THREE.Mesh(smokeGeo, smokeMaterial)
-			// posicionar aleatoriamente
-			// en la x, y, z
-			particle.position.set(
-				Math.random() * 500 - 250, // X (de -250 a 250)
-				Math.random() * 500 - 250, // Y (de -250 a 250)
-				Math.random() * 1000 - 100 // Z (de -100 a 900)
-			)
-			// aleatoriamente la z
-			particle.rotation.z = Math.random() * 360
-			// añadimos la particula en la escena
-			scene.add(particle)
-			// añadimos la particula al array
-			smokeParticles.push(particle)
-		}
-	})
-
-	function resize() {
-		h = window.innerHeight
-		w = window.innerWidth
-		camera.aspect = w / h
-		camera.updateProjectionMatrix() // este metodo lo tenéis que ejecutar siempre que cambiais los parámetros de la cámara
-		renderer.setSize(w, h)
-	}
-
-	function animate() {
-		requestAnimationFrame(animate)
-
-		smokeParticles.forEach((particle) => {
-			particle.rotation.z += 0.001
-		})
-
-		renderer.render(scene, camera)
-	}
-
-	animate()
-
-	// se va a disparar continuamente mientras hace el resize
-	window.addEventListener("resize", resize)
-
-	window.addEventListener("theme-changed", () => {
 		const themePreference = window.getThemePreference()
-		currentTheme = THEME[themePreference]
-		light.color.setHex(currentTheme.light)
+		let currentTheme = THEME[themePreference]
+
+		// inicializar Three.js
+		// 3 cosas básicas: escena, cámara, renderizador
+
+		// escena 🖼️
+		const scene = new THREE.Scene()
+
+		// camara 📹
+		// 75 -> ángulo de visión
+		const camera = new THREE.PerspectiveCamera(75, w / h, 1, 1000)
+		camera.position.z = 10
+		scene.add(camera)
+
+		// ▶️ renderizador
+		const renderer = new THREE.WebGLRenderer()
+		renderer.setSize(w, h)
+		// color de fondo
 		renderer.setClearColor(currentTheme.background, 1)
 
-		smokeParticles.forEach((particle) => {
-			particle.material.opacity = currentTheme.opacity
+		$bkg?.appendChild(renderer.domElement)
+
+		// añadir una luz directional
+		const light = new THREE.DirectionalLight(currentTheme.light, 0.5)
+		// posicion de la luz
+		light.position.set(-1, 3, 1)
+		scene.add(light)
+
+		const smokeParticles: THREE.Mesh[] = []
+
+		const loader = new THREE.TextureLoader()
+		loader.crossOrigin = "" // <- en localhost no pasa nada, pero si desplegamos a un servidor, puede ser necesario
+
+		loader.load("/smoke.webp", (texture) => {
+			// 1. geometria
+			// crear un plano geométrico de 300x300
+			const smokeGeo = new THREE.PlaneGeometry(300, 300)
+
+			// 2. material
+			const smokeMaterial = new THREE.MeshLambertMaterial({
+				map: texture,
+				transparent: true,
+				opacity: currentTheme.opacity,
+			})
+
+			const NUM_OF_PARTICLES = 300
+			for (let p = 0; p < NUM_OF_PARTICLES; p++) {
+				// crear la malla con la geometria y el material
+				const particle = new THREE.Mesh(smokeGeo, smokeMaterial)
+				// posicionar aleatoriamente
+				// en la x, y, z
+				particle.position.set(
+					Math.random() * 500 - 250, // X (de -250 a 250)
+					Math.random() * 500 - 250, // Y (de -250 a 250)
+					Math.random() * 1000 - 100 // Z (de -100 a 900)
+				)
+				// aleatoriamente la z
+				particle.rotation.z = Math.random() * 360
+				// añadimos la particula en la escena
+				scene.add(particle)
+				// añadimos la particula al array
+				smokeParticles.push(particle)
+			}
 		})
-	})
+
+		function resize() {
+			h = window.innerHeight
+			w = window.innerWidth
+			camera.aspect = w / h
+			camera.updateProjectionMatrix() // este metodo lo tenéis que ejecutar siempre que cambiais los parámetros de la cámara
+			renderer.setSize(w, h)
+		}
+
+		function animate() {
+			requestAnimationFrame(animate)
+
+			smokeParticles.forEach((particle) => {
+				particle.rotation.z += 0.001
+			})
+
+			renderer.render(scene, camera)
+		}
+
+		animate()
+
+		// se va a disparar continuamente mientras hace el resize
+		window.addEventListener("resize", resize)
+
+		window.addEventListener("theme-changed", () => {
+			const themePreference = window.getThemePreference()
+			currentTheme = THEME[themePreference]
+			light.color.setHex(currentTheme.light)
+			renderer.setClearColor(currentTheme.background, 1)
+
+			smokeParticles.forEach((particle) => {
+				particle.material.opacity = currentTheme.opacity
+			})
+		})
+	}
 </script>


### PR DESCRIPTION
## Descripción

Algunos usuarios suelen tener las animaciones deshabilitadas, por lo que estaría genial respetar eso y prevenir usar Three.js en esos casos. Se ha agregado un `if` al inicio del código para evitar hacer el smoke animation si el usuario tiene las animaciones deshabilitadas.

## Cambios propuestos

Se lee la preferencia del usuario al inicio del script y se crean las animaciones solo si el usuario tiene no tiene el `prefers-reduced-motion` habilitado.

Aún puede mejorarse, por ejemplo, importar Three.js dinámicamente si el usuario tiene las animaciones activadas.
Otra mejora puede ser escuchar los cambios en el `prefers-reduced-motion` en tiempo real. Actualmente solo se actualiza al recargar la página.

Nota: En el _diff_ quizás sea difícil de ver los cambios que he agregado, esto es porque agregué un `if` al inicio del script, lo que añade un nivel de sangría extra a las líneas posteriores.

![image](https://github.com/midudev/la-velada-web-oficial/assets/56328053/b0e493d6-9238-4b13-b003-50e61f61f9cb)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion