### PR TITLE
Fix konami errors

### DIFF
--- a/src/components/KonamiCode.astro
+++ b/src/components/KonamiCode.astro
@@ -1,5 +1,5 @@
 <script defer>
-	const container = document.querySelector("body")
+	const container = document.querySelector("#main-content")
 
 	const konamiCode = [
 		"ArrowUp",
@@ -28,11 +28,11 @@
 		if (konamiCodePosition !== konamiCode.length) return
 
 		container.style.transform = "rotateY(360deg)"
-		container.style.transition = "transform 3s ease"
+		container.style.transition = "transform 2s ease"
 
 		container.addEventListener("transitionend", () => {
-			container.style.transition = "none"
-			container.style.transform = "rotateY(0deg)"
+			container.style.transition = ""
+			container.style.transform = ""
 		})
 
 		konamiCodePosition = 0

--- a/src/components/KonamiCode.astro
+++ b/src/components/KonamiCode.astro
@@ -1,40 +1,40 @@
 <script defer>
-  const container = document.querySelector("body")
+	const container = document.querySelector("body")
 
-  const konamiCode = [
-    "ArrowUp",
-    "ArrowUp",
-    "ArrowDown",
-    "ArrowDown",
-    "ArrowLeft",
-    "ArrowRight",
-    "ArrowLeft",
-    "ArrowRight",
-    "b",
-    "a",
-  ]
-  let konamiCodePosition = 0
+	const konamiCode = [
+		"ArrowUp",
+		"ArrowUp",
+		"ArrowDown",
+		"ArrowDown",
+		"ArrowLeft",
+		"ArrowRight",
+		"ArrowLeft",
+		"ArrowRight",
+		"b",
+		"a",
+	]
+	let konamiCodePosition = 0
 
-  document.addEventListener("keydown", ({ key }) => {
-    const requiredKey = konamiCode[konamiCodePosition]
+	document.addEventListener("keydown", ({ key }) => {
+		const requiredKey = konamiCode[konamiCodePosition]
 
-    if (key != requiredKey) {
-      konamiCodePosition = 0
-      return
-    }
+		if (key !== requiredKey) {
+			konamiCodePosition = 0
+			return
+		}
 
-    konamiCodePosition++
+		konamiCodePosition++
 
-    if (konamiCodePosition != konamiCode.length) return
+		if (konamiCodePosition !== konamiCode.length) return
 
-    container.style.transform = "rotateY(360deg)"
-    container.style.transition = "transform 3s ease"
+		container.style.transform = "rotateY(360deg)"
+		container.style.transition = "transform 3s ease"
 
-    container.addEventListener("transitionend", () => {
-      container.style.transition = "none"
-      container.style.transform = "rotateY(0deg)"
-    })
+		container.addEventListener("transitionend", () => {
+			container.style.transition = "none"
+			container.style.transform = "rotateY(0deg)"
+		})
 
-    konamiCodePosition = 0
-  })
+		konamiCodePosition = 0
+	})
 </script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -58,7 +58,7 @@ const { title, description } = Astro.props
 		class="[&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
 	>
 		<SmokeBackground />
-		<div class="mx-auto max-w-6xl px-2 pt-16 md:pt-20 lg:px-10">
+		<div class="mx-auto max-w-6xl px-2 pt-16 md:pt-20 lg:px-10" id="main-content">
 			<slot />
 		</div>
 	</body>


### PR DESCRIPTION
## Descripción
Solucioné un problema con el código Konami, el fondo con humo se iba a la parte de arriba de la página durante la rotación.

## Cambios propuestos

- Se agregó un ID en la sección con contenido de la página para así hacerla accesible desde el componente del Konami
- Se cambió para usar comparaciónes estrictas en los IFs
- En vez de girar el body, se gira la sección con contenido para mantener el fondo fijo

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
