### PR TITLE
Add: set cursor to default to improve accessibility

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -89,6 +89,7 @@ const { title, description } = Astro.props
 		scroll-behavior: smooth;
 		overflow-x: hidden;
 		overscroll-behavior: none;
+		cursor: default;
 	}
 
 	/* Hiding class, making content visible only to screen readers but not visually */


### PR DESCRIPTION
## Descripción

Indicado en la main Layout que el cursor sea por defecto.

## Problema solucionado

En la versión original, al pasar el ratón por encima ( hover) de elementos de textos y que no son inputs, el cursor cambiar a la versión texto. Pudiendo confundir así al usuario ya uqe no es un input y no se puede manipular el texto.



## Cambios propuestos

Con una simple linea en el html podemos solucionar esto, y mantenemos en que enlaces y en verdaderos inputs el cursor se vea como debe.

## Capturas de pantalla (si corresponde)

Antes , con el cursor de texto:
![hover text cursor](https://github.com/midudev/la-velada-web-oficial/assets/26023012/7e4af8d9-92d2-4d51-9ace-89c01675fa68)


Con los cambios:
<img width="686" alt="hover text default" src="https://github.com/midudev/la-velada-web-oficial/assets/26023012/519d379c-9811-4d35-9e4f-8ffe4b538328">

Hover en un link:
<img width="704" alt="hover link" src="https://github.com/midudev/la-velada-web-oficial/assets/26023012/f0c7c0df-68e0-4783-8407-25a588958444">



## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Solo visual :)

## Contexto adicional



## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
