### PR TITLE
fix: animation-timeline Safari fallback

### DIFF
--- a/src/components/TwitchLogo.astro
+++ b/src/components/TwitchLogo.astro
@@ -8,15 +8,15 @@
 >
 	<path
 		class="stroke"
-		fill="var(--background-twitch)"
+		fill="var(--color-twitch)"
 		d="M16.6001.600098.600098 16.6001v57.6H19.8001v16l16-16h12.8l28.8-28.8V.600098h-60.8Z"></path>
 	<path
 		class="fill"
-		fill="var(--color-secondary)"
+		fill="var(--color-twitch-ice)"
 		d="m58.2003 55 12.8-12.8V7h-51.2v48h12.8v12.8l12.8-12.8h12.8Z"></path>
 	<path
 		class="stroke"
-		fill="var(--background-twitch)"
+		fill="var(--color-twitch)"
 		d="M39 19.8h6.4V39H39V19.8Zm22.4 0V39H55V19.8h6.4Z"></path>
 </svg>
 
@@ -42,6 +42,7 @@
 	}
 
 	@keyframes showStroke {
+		0%,
 		40% {
 			fill: var(--background-twitch);
 		}
@@ -53,6 +54,7 @@
 	}
 
 	@keyframes showFill {
+		0%,
 		40% {
 			fill: var(--color-secondary);
 		}


### PR DESCRIPTION
## Descripción

Safari no soporta el `animation-timeline`.

## Problema solucionado

Se ha creado un fallback para que en Safari se vea la versión de color del logotipo de Twitch, en lugar de la versión a 1 tinta.

## Capturas de pantalla

### Antes
![antes](https://github.com/midudev/la-velada-web-oficial/assets/18669273/06db1016-95c7-4e22-b063-4a666628bef3)

### Después
![despues](https://github.com/midudev/la-velada-web-oficial/assets/18669273/c298cb0e-c201-4e1f-a161-758942bf909d)



## Enlaces útiles

Can I Use del animation-timeline: [caniuse-animation-timeline](https://caniuse.com/?search=animation-timeline)
