### PR TITLE
aria-hidden="true" for accessibility

### DIFF
--- a/src/components/SmokeBackground.astro
+++ b/src/components/SmokeBackground.astro
@@ -1,6 +1,7 @@
 <div
 	id="smoke-bkg"
 	class="fixed top-0 -z-10 h-full w-full opacity-0 transition-opacity duration-500"
+	aria-hidden="true"
 >
 </div>
 


### PR DESCRIPTION
## Descripción

Añadido aria-hidden="true" al elemento background de efecto de humo.

## Problema solucionado

![image](https://github.com/midudev/la-velada-web-oficial/assets/50919956/3433235d-84ca-4b8c-b042-471e15b9d17c)

## Cambios propuestos

Agregué el aria-hidden="true" al div para que los screen readers no lean este div que es meramente decorativo

## Capturas de pantalla (si corresponde)

no afecta

## Comprobación de cambios

- ✅ He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- ✅ He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- ✅ He actualizado la documentación, si corresponde.

## Impacto potencial

No impacta negativamente

## Contexto adicional

Utilizado el doc de mdn

## Enlaces útiles

- Documentación del proyecto: [[mdn](url)](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-hidden)
- Código de referencia: 

<button>
  <span class="fa fa-tweet" aria-hidden="true"></span>
  <span class="label"> Tweet </span>
</button>
