### PR TITLE
Prevent duplicated CSS & and transition for buttons

### DIFF
--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -2,65 +2,9 @@
 import { DARK_THEME, LIGHT_THEME } from "@/consts/themes"
 ---
 
-<button
-	id="add-to-calendar"
-	class:list={`
-		inline-block border-2 border-primary px-4 py-1
-		text-lg font-medium
-		uppercase transition hover:scale-110
-		hover:bg-primary hover:text-secondary
-	`}
-	aria-label="agregar al calendario se abrirá ventana flotante"
->
+<button id="add-to-calendar" aria-label="agregar al calendario se abrirá ventana flotante">
 	<span> Agregar al calendario</span>
 </button>
-
-<style>
-	#add-to-calendar {
-		background: transparent;
-		border: none;
-		padding: 10px 20px;
-		display: inline-block;
-		font-size: 20px;
-		font-weight: 600;
-		width: 20rem;
-		text-transform: uppercase;
-		cursor: pointer;
-		transform: skew(-21deg);
-		color: var(--color-primary);
-		border: 2px solid var(--color-primary);
-	}
-
-	#add-to-calendar > span {
-		display: inline-block;
-		transform: skew(21deg);
-	}
-
-	#add-to-calendar::before {
-		content: "";
-		position: absolute;
-		top: 0;
-		bottom: 0;
-		right: 100%;
-		left: 0;
-		background: var(--color-primary);
-		opacity: 0;
-		z-index: -1;
-		transition: all 0.5s;
-	}
-
-	#add-to-calendar:hover {
-		color: var(--color-secondary);
-		scale: 1.1;
-		transform: skew(-21deg);
-	}
-
-	#add-to-calendar:hover::before {
-		left: 0;
-		right: 0;
-		opacity: 1;
-	}
-</style>
 
 <script is:inline define:vars={{ darkTheme: DARK_THEME, lightTheme: LIGHT_THEME }}>
 	const config = {

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -41,8 +41,9 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 	</div>
 </section>
 
-<style>
-	.scroll-horizontal > a {
+<style is:global>
+	.scroll-horizontal > a,
+	.scroll-horizontal > #add-to-calendar {
 		background: transparent;
 		border: none;
 		padding: 10px 20px;
@@ -55,14 +56,17 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		transform: skew(-21deg);
 		color: var(--color-primary);
 		border: 2px solid var(--color-primary);
+		transition: scale 150ms ease-in-out;
 	}
 
-	.scroll-horizontal > a > span {
+	.scroll-horizontal > a > span,
+	.scroll-horizontal > #add-to-calendar > span {
 		display: inline-block;
 		transform: skew(21deg);
 	}
 
-	.scroll-horizontal > a::before {
+	.scroll-horizontal > a::before,
+	.scroll-horizontal > #add-to-calendar::before {
 		content: "";
 		position: absolute;
 		top: 0;
@@ -75,13 +79,15 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		transition: all 0.5s;
 	}
 
-	.scroll-horizontal > a:hover {
+	.scroll-horizontal > a:hover,
+	.scroll-horizontal > #add-to-calendar:hover {
 		color: var(--color-secondary);
 		scale: 1.1;
 		transform: skew(-21deg);
 	}
 
-	.scroll-horizontal > a:hover::before {
+	.scroll-horizontal > a:hover::before,
+	.scroll-horizontal > #add-to-calendar:hover::before {
 		left: 0;
 		right: 0;
 		opacity: 1;
@@ -164,12 +170,12 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 
 	document.addEventListener("DOMContentLoaded", main)
 
-	 // Verifica si el evento ya ha pasado
-	 const eventHasPassed = EVENT_TIMESTAMP < Date.now()
-    if (eventHasPassed) {
-        const addToCalendarBtn = document.getElementById("add-to-calendar")
-        if (addToCalendarBtn) {
-            addToCalendarBtn.remove()
-        }
-    }
+	// Verifica si el evento ya ha pasado
+	const eventHasPassed = EVENT_TIMESTAMP < Date.now()
+	if (eventHasPassed) {
+		const addToCalendarBtn = document.getElementById("add-to-calendar")
+		if (addToCalendarBtn) {
+			addToCalendarBtn.remove()
+		}
+	}
 </script>


### PR DESCRIPTION
## Descripción

Se ha eliminado CSS duplicado y clases innecesarias de Tailwind en `src\components\CalendarButton.astro`. Por consecuente, se han actualizado los selectores en el CSS de `src\sections\PrincipalDate.astro`.

Además, se ha incluido una transición de 150ms en el _scale_ de los botones (_**Entradas Agotadas**_ y _**Agregar al calendario**_) al momento de hacer _hover_.

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
