### PR TITLE
add timer on reszie window, affect canvas size after 600ms

### DIFF
--- a/src/components/SmokeBackground.astro
+++ b/src/components/SmokeBackground.astro
@@ -86,9 +86,17 @@
 		}
 	}
 
+	const secondsWaitToResize = 600;
+	let idTmWindowsResize = 0
+
 	window.addEventListener("resize", () => {
-		canvas.width = window.innerWidth
-		canvas.height = window.innerHeight + 100
+
+		window.clearTimeout(idTmWindowsResize)
+		idTmWindowsResize = window.setTimeout( () => {
+			canvas.width = window.innerWidth
+			canvas.height = window.innerHeight + 100
+		}, secondsWaitToResize)
+
 	})
 
 	smokeImage.onload = () => {


### PR DESCRIPTION
## Descripción

Se ha realizado un cambio en la función de evento "resize" del documento, lo que hace es esperar 600ms para hacer redimensión del canvas 

## Problema solucionado

Se intenta corregir que se haga el cambio de tamaño del canvas cada vez que se redimensiona la ventana

## Cambios propuestos

Se ha adicionado en el código un timer para dar 600ms de espera para cambiar las dimensiones del canvas.


## Comprobación de cambios

- [✅  ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [✅  ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ✅ ] He actualizado la documentación, si corresponde.


