### PR TITLE
Prevent animations when system animations are disabled

### DIFF
--- a/src/components/ButtonUp.astro
+++ b/src/components/ButtonUp.astro
@@ -2,14 +2,14 @@
 	<button
 		id="scroll-to-top"
 		aria-label="Volver al inicio de la página"
-		class="group flex size-12 cursor-pointer items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur transition hover:scale-105"
+		class="group flex size-12 cursor-pointer items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur hover:scale-105 motion-safe:transition"
 	>
 		<svg
 			stroke-width="2"
 			stroke="currentColor"
 			viewBox="0 0 24 24"
 			fill="none"
-			class="h-6 w-6 -rotate-45 transition group-hover:-rotate-90"
+			class="h-6 w-6 -rotate-45 group-hover:-rotate-90 motion-safe:transition"
 			width="20px"
 		>
 			<path d="M14 5l7 7m0 0l-7 7m7-7H3" stroke-linejoin="round" stroke-linecap="round"></path>

--- a/src/components/Date.astro
+++ b/src/components/Date.astro
@@ -10,7 +10,10 @@ const { dateType, attribute } = Astro.props
 <div class="flex w-16 flex-col place-items-center gap-y-2">
 	<div class="relative overflow-hidden" {...attribute}>
 		<div class="float-left block h-10 w-auto overflow-hidden" data-first-group>
-			<div class="translate-y-0 transition-transform duration-[800ms]" data-wrapper>
+			<div
+				class="translate-y-0 transition-transform duration-[800ms] motion-reduce:duration-0"
+				data-wrapper
+			>
 				<div class="h-10" data-num-0>
 					<span class="text-4xl tabular-nums">0</span>
 				</div>
@@ -44,7 +47,10 @@ const { dateType, attribute } = Astro.props
 			</div>
 		</div>
 		<div class="float-left block h-10 w-auto overflow-hidden" data-second-group>
-			<div class="translate-y-0 transition-transform duration-[800ms]" data-wrapper>
+			<div
+				class="translate-y-0 transition-transform duration-[800ms] motion-reduce:duration-0"
+				data-wrapper
+			>
 				<div class="h-10" data-num-0>
 					<span class="text-4xl tabular-nums">0</span>
 				</div>

--- a/src/components/HeroLogo.astro
+++ b/src/components/HeroLogo.astro
@@ -17,22 +17,24 @@
 	></path>
 </svg>
 <style>
-	#logo {
-		fill-opacity: 0;
-		stroke-dasharray: 1300;
-		stroke-dashoffset: 1300;
-		animation: dash 2s ease-in forwards;
-	}
-
-	@keyframes dash {
-		70% {
+	@media (prefers-reduced-motion: no-preference) {
+		#logo {
 			fill-opacity: 0;
+			stroke-dasharray: 1300;
+			stroke-dashoffset: 1300;
+			animation: dash 2s ease-in forwards;
 		}
 
-		100% {
-			fill-opacity: 100%;
-			stroke-dashoffset: 0;
-			stroke-width: 1;
+		@keyframes dash {
+			70% {
+				fill-opacity: 0;
+			}
+
+			100% {
+				fill-opacity: 100%;
+				stroke-dashoffset: 0;
+				stroke-width: 1;
+			}
 		}
 	}
 </style>

--- a/src/components/SmokeBackground.astro
+++ b/src/components/SmokeBackground.astro
@@ -86,13 +86,17 @@
 		}
 	}
 
-	window.addEventListener("resize", () => {
-		canvas.width = window.innerWidth
-		canvas.height = window.innerHeight + 100
-	})
+	const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
 
-	smokeImage.onload = () => {
-		init()
-		animate()
+	if (!reducedMotion.matches) {
+		window.addEventListener("resize", () => {
+			canvas.width = window.innerWidth
+			canvas.height = window.innerHeight + 100
+		})
+
+		smokeImage.onload = () => {
+			init()
+			animate()
+		}
 	}
 </script>

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -6,11 +6,11 @@ import { DARK_THEME, LIGHT_THEME } from "@/consts/themes"
 
 <button
 	id="themeToggle"
-	class="inline-flex text-primary transition any-hover:scale-125 any-hover:opacity-70"
+	class="inline-flex text-primary any-hover:scale-125 any-hover:opacity-70 motion-safe:transition"
 >
-	<SunIcon class="opacity-100 transition-transform dark:-rotate-90 dark:opacity-0" />
+	<SunIcon class="opacity-100 motion-safe:transition-transform dark:-rotate-90 dark:opacity-0" />
 	<MoonIcon
-		class="absolute rotate-90 opacity-0 transition-transform dark:rotate-0 dark:opacity-100"
+		class="absolute rotate-90 opacity-0 motion-safe:transition-transform dark:rotate-0 dark:opacity-100"
 	/>
 	<span class="sr-only"></span>
 </button>

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -26,7 +26,7 @@ import XIcon from "@/icons/x.astro"
 					rel="noopener"
 					aria-label="Instagram de la velada, se abrirá en una nueva pestaña"
 					href="https://www.instagram.com/infolavelada"
-					class="inline-block transition any-hover:scale-125 any-hover:opacity-70"
+					class="inline-block any-hover:scale-125 any-hover:opacity-70 motion-safe:transition"
 				>
 					<InstagramIcon class="text-primary" />
 				</a>
@@ -37,7 +37,7 @@ import XIcon from "@/icons/x.astro"
 					rel="noopener"
 					aria-label="X de la velada, se abrirá en una nueva pestaña"
 					href="https://x.com/infoLaVelada"
-					class="inline-block transition any-hover:scale-125 any-hover:opacity-70"
+					class="inline-block any-hover:scale-125 any-hover:opacity-70 motion-safe:transition"
 				>
 					<XIcon class="text-primary" />
 				</a>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -5,7 +5,7 @@ import HeroLogo from "@/components/HeroLogo.astro"
 <section class="flex flex-col place-items-center gap-4 lg:gap-9">
 	<h1 class="sr-only">Presentación de la Velada del Año IV</h1>
 	<span
-		class="animate-fade-in-up bg-primary px-3 py-0.5 text-base font-medium uppercase text-secondary animate-duration-1000 md:px-6 md:py-1 lg:text-xl"
+		class="animate-fade-in-up bg-primary px-3 py-0.5 text-base font-medium uppercase text-secondary animate-duration-1000 motion-reduce:animate-duration-[0s] md:px-6 md:py-1 lg:text-xl"
 		aria-hidden="true"
 	>
 		Presentación de la

--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -10,7 +10,7 @@ import TwitchLogo from "@/components/TwitchLogo.astro"
 		href="https://twitch.tv/ibai"
 		target="_blank"
 		rel="nofollow noopener"
-		class="mx-auto transition hover:scale-125"
+		class="mx-auto hover:scale-125 motion-safe:transition"
 		aria-label="síguelo en directo twitch.tv/ibai, se abrirá en una nueva pestaña"
 	>
 		<TwitchLogo />
@@ -33,7 +33,7 @@ import TwitchLogo from "@/components/TwitchLogo.astro"
 				aria-label="síguelo en directo twitch.tv/ibai, se abrirá en una nueva pestaña"
 			>
 				<a
-					class="inline-block transition-transform hover:scale-110 hover:text-twitch"
+					class="inline-block hover:scale-110 hover:text-twitch motion-safe:transition-transform"
 					href="https://twitch.tv/ibai"
 					target="_blank"
 					rel="nofollow noopener"

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -4,7 +4,7 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 ---
 
 <section
-	class="mx-auto mt-16 flex animate-fade-in flex-col place-items-center text-center text-primary animate-delay-[2s] md:mt-32"
+	class="mx-auto mt-16 flex animate-fade-in flex-col place-items-center text-center text-primary animate-delay-[2s] motion-reduce:animate-delay-[0s] motion-reduce:animate-duration-[0s] md:mt-32"
 >
 	<div class="text-3xl font-semibold uppercase md:text-5xl">
 		<time class="date"></time>
@@ -17,7 +17,6 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		<span>Evento de Presentación</span>
 		<a
 			href="https://maps.app.goo.gl/RFzHUVDhRqdQaTAo8"
-			class="inline-block align-middle transition hover:scale-110 hover:opacity-60"
 			target="_blank"
 			rel="noopener"
 			style="display: -webkit-box;"
@@ -56,7 +55,6 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		transform: skew(-21deg);
 		color: var(--color-primary);
 		border: 2px solid var(--color-primary);
-		transition: scale 150ms ease-in-out;
 	}
 
 	.scroll-horizontal > a > span,
@@ -76,7 +74,6 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		background: var(--color-primary);
 		opacity: 0;
 		z-index: -1;
-		transition: all 0.5s;
 	}
 
 	.scroll-horizontal > a:hover,
@@ -91,6 +88,18 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		left: 0;
 		right: 0;
 		opacity: 1;
+	}
+
+	@media (prefers-reduced-motion: no-preference) {
+		.scroll-horizontal > a,
+		.scroll-horizontal > #add-to-calendar {
+			transition: scale 150ms ease-in-out;
+		}
+
+		.scroll-horizontal > a::before,
+		.scroll-horizontal > #add-to-calendar::before {
+			transition: all 0.5s;
+		}
 	}
 </style>
 


### PR DESCRIPTION
## Descripción

Algunos usuarios suelen tener las animaciones deshabilitadas, por lo que estaría genial respetar eso y evitar las animaciones cuando el usuario ha deshabilitado las animaciones del sistema.

## Cambios propuestos

Se han incluido las clases de tailwind `motion-safe:` y `motion-reduce:`, además del CSS media query `@media (prefers-reduced-motion) {}` para incluir animaciones selectivamente.

## Antes

https://github.com/midudev/la-velada-web-oficial/assets/56328053/94f5e783-ad9b-4d08-ace8-61dfaff38278

## Después

https://github.com/midudev/la-velada-web-oficial/assets/56328053/ba37a789-c3e6-49c8-aba6-fc2455766fc3

> Nota: Ambos videos se grabaron con las animaciones desactivadas (Windows 11)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion
https://tailwindcss.com/docs/animation#prefers-reduced-motion
