### PR TITLE
fix: replace 'class' with 'class:list' in icon files

### DIFF
--- a/src/icons/boxing-gloves.astro
+++ b/src/icons/boxing-gloves.astro
@@ -1,5 +1,5 @@
 <svg
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	xmlns="http://www.w3.org/2000/svg"
 	width="105"
 	height="85"

--- a/src/icons/instagram.astro
+++ b/src/icons/instagram.astro
@@ -4,7 +4,7 @@
 	height="48"
 	fill="none"
 	viewBox="0 0 48 48"
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	role="img"
 	aria-label="Logotipo de Instagram"
 >

--- a/src/icons/la-velada.astro
+++ b/src/icons/la-velada.astro
@@ -1,5 +1,5 @@
 <svg
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	xmlns="http://www.w3.org/2000/svg"
 	width="206"
 	height="224"

--- a/src/icons/map-marker.astro
+++ b/src/icons/map-marker.astro
@@ -4,7 +4,7 @@
 	viewBox="0 0 24 24"
 	xmlns="http://www.w3.org/2000/svg"
 	fill="none"
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	role="img"
 	aria-label="Icono de localizacion"
 >

--- a/src/icons/moon.astro
+++ b/src/icons/moon.astro
@@ -4,7 +4,7 @@
 	height="48"
 	fill="currentColor"
 	viewBox="0 0 256 256"
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	role="img"
 	aria-label="Icono de tema oscuro"
 >

--- a/src/icons/sun.astro
+++ b/src/icons/sun.astro
@@ -4,7 +4,7 @@
 	height="48"
 	fill="currentColor"
 	viewBox="0 0 256 256"
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	role="img"
 	aria-label="Icono de tema claro"
 >

--- a/src/icons/weight-boxer.astro
+++ b/src/icons/weight-boxer.astro
@@ -1,5 +1,5 @@
 <svg
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	xmlns="http://www.w3.org/2000/svg"
 	width="86"
 	height="106"

--- a/src/icons/x.astro
+++ b/src/icons/x.astro
@@ -5,7 +5,7 @@
 	height="32px"
 	viewBox="0 0 35 32"
 	version="1.1"
-	class={Astro.props.class}
+	class:list={Astro.props.class}
 	role="img"
 	aria-label="Logotipo de X"
 >


### PR DESCRIPTION
## Description

Changes were made to the implementation of icons to correct the incorrect use of `class` in favor of `class:list`. This improves code consistency and follows best practices.

## Issue Resolved

This change addresses the identified issue in the icon files where `class` was being used incorrectly, generating warnings.

## Proposed Changes

- Fixed the use of `class` to `class:list` in icon files, following Astro's recommendations.
- The following files have been updated: `boxing-gloves.astro`, `instagram.astro`, `la-velada.astro`, `map-marker.astro`, `moon.astro`, `sun.astro`, `weight-boxer.astro`, and `x.astro`.

## Screenshots 
before

![2024-03-01_11-48](https://github.com/midudev/la-velada-web-oficial/assets/101147375/63e65b1e-01bb-49bf-8636-fe11ccc99c81)

after

![image](https://github.com/midudev/la-velada-web-oficial/assets/101147375/630f409c-d305-4018-8827-ce0321e456fb)

## Checks Performed

- [x] Reviewed changes locally to ensure there are no errors or issues.
- [x] Tested these changes on multiple devices and browsers to ensure the web application looks and functions correctly.
- [ ] Updated documentation to reflect the changes made.

## Potential Impact

These changes are expected to have no significant negative impacts.

## Additional Context

These changes are part of a series of improvements to follow best practices and maintain consistency in the codebase.

## Useful Links

- [Reference Code](https://github.com/luis-tenorio-code/la-velada-web-oficial/tree/cambios-class-a-list/src/icons)