### PR TITLE
Custom text selection

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -58,7 +58,10 @@ const { title, description } = Astro.props
 		class="[&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
 	>
 		<SmokeBackground />
-		<div class="mx-auto max-w-6xl px-2 pt-16 md:pt-20 lg:px-10" id="main-content">
+		<div
+			class="mx-auto max-w-6xl px-2 pt-16 selection:bg-primary selection:text-secondary md:pt-20 lg:px-10"
+			id="main-content"
+		>
 			<slot />
 		</div>
 	</body>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -5,7 +5,7 @@ import HeroLogo from "@/components/HeroLogo.astro"
 <section class="flex flex-col place-items-center gap-4 lg:gap-9">
 	<h1 class="sr-only">Presentación de la Velada del Año IV</h1>
 	<span
-		class="animate-fade-in-up bg-primary px-3 py-0.5 text-base font-medium uppercase text-secondary animate-duration-1000 motion-reduce:animate-duration-[0s] md:px-6 md:py-1 lg:text-xl"
+		class="animate-fade-in-up select-none bg-primary px-3 py-0.5 text-base font-medium uppercase text-secondary animate-duration-1000 motion-reduce:animate-duration-[0s] md:px-6 md:py-1 lg:text-xl"
 		aria-hidden="true"
 	>
 		Presentación de la


### PR DESCRIPTION
## Descripción

Cambié el color azul por defecto al seleccionar el texto de la página para que siga la línea de colores de la web.

## Cambios propuestos

- Se agrega en el `Layout.astro` las clases `selection:bg-primary selection:text-secondary` para que herede toda la página
- Se agrega en el `sections/Hero.astro` la clase `select-none` para que no se vea raro al seleccionar el texto que ya tiene un background.

## Capturas de pantalla (si corresponde)

Look original:
![orig](https://github.com/midudev/la-velada-web-oficial/assets/92647365/6de06225-cd2c-4264-9707-efad25d3e96f)
![orig2](https://github.com/midudev/la-velada-web-oficial/assets/92647365/a28d9aa9-4066-4c07-8a13-95ef37f3f050)


Después de los cambios:
![byn](https://github.com/midudev/la-velada-web-oficial/assets/92647365/0299fc66-be97-4e19-b609-5aec7b0cea24)
![byn2](https://github.com/midudev/la-velada-web-oficial/assets/92647365/5ed50446-6544-4974-ba20-ec0660f53666)


## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

El pseudo-elemento `::selection` [no es full compatible con Safari en iOS](https://caniuse.com/?search=%3A%3Aselection)
