### PR TITLE
Fix issue #183

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -29,7 +29,7 @@ import TwitchLogo from "@/components/TwitchLogo.astro"
 			class="order-1 flex items-center justify-center border-t-2 border-primary px-10 py-10 text-3xl md:order-none md:flex-1 md:border-y-2 md:px-0 md:py-12 lg:px-0 lg:py-20 lg:text-4xl"
 		>
 			<h3
-				class="md:max-w-[250px]"
+				class="flex justify-center md:max-w-[250px]"
 				aria-label="síguelo en directo twitch.tv/ibai, se abrirá en una nueva pestaña"
 			>
 				<a


### PR DESCRIPTION
## Descripción
A partir de 1024px de ancho, el link al twitch de Ibai en el `Info.astro` se ve desplazado hacia la derecha porque el ancho del anchor era mayor al del contenedor, el h3.

## Problema solucionado

Fixes #183.

## Cambios propuestos

1. Se centra el anchor tag usando flex y justify-center en el contenedor del anchor.

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/92647365/de073953-efde-49cc-9946-d2e91eaaf66b)


Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/92647365/7c9c1ed3-5558-4389-b6af-aa19a0214f94)


## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

1. A los detallistas compulsivos no les va a titilar el ojo cuando vean que hay algo que no está centrado.

## Contexto adicional

## Enlaces útiles

Enlace a la issue que resuelvo: #183 
