### PR TITLE
Fix ButtonUp position while executing konami code

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,4 +1,5 @@
 ---
+import ButtonUp from "@/components/ButtonUp.astro"
 import SmokeBackground from "@/components/SmokeBackground.astro"
 import "@fontsource-variable/jost"
 
@@ -61,6 +62,7 @@ const { title, description } = Astro.props
 		<div class="mx-auto max-w-6xl px-2 pt-16 md:pt-20 lg:px-10" id="main-content">
 			<slot />
 		</div>
+		<ButtonUp />
 	</body>
 </html>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,6 @@ import Footer from "@/sections/Footer.astro"
 import Hero from "@/sections/Hero.astro"
 import Info from "@/sections/Info.astro"
 import PrincipalDate from "@/sections/PrincipalDate.astro"
-import ButtonUp from "@/components/ButtonUp.astro"
 ---
 
 <Layout
@@ -22,6 +21,5 @@ import ButtonUp from "@/components/ButtonUp.astro"
 		<Countdown />
 	</main>
 	<Footer />
-	<ButtonUp />
 	<KonamiCode />
 </Layout>


### PR DESCRIPTION
## Descripción

Cuando se ejecutaba la animación del código konami no se limpiaba el estilo transform al terminar, lo que impedía el posicionamiento fijo del componente "ButtonUp" en la página.

## Cambios propuestos

- Se movió el componente "ButtonUp" hacia el Layout para quedar fuera del contenedor que gira al ejecutarse la animación del código konami

## Capturas de pantalla (si corresponde)

En ambos casos las capturas se tomaron al terminar la animación

Antes (aunque se hiciera scroll hacia arriba, el componente se quedaba dentro del footer)

![image](https://github.com/midudev/la-velada-web-oficial/assets/59067891/1ec4cd6b-37bc-4f2b-8afc-12c62599204c)

Después

![image](https://github.com/midudev/la-velada-web-oficial/assets/59067891/d0a82db5-b7da-4bdd-a65c-7ee9f208759c)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
