### PR TITLE
Updated countdown for more natural transitions between numbers

### DIFF
--- a/src/components/Date.astro
+++ b/src/components/Date.astro
@@ -2,9 +2,19 @@
 interface Props {
 	dateType: string
 	attribute: Record<string, string>
+	max: number
 }
 
 const { dateType, attribute } = Astro.props
+const maximumSplit = Astro.props.max.toString().split("")
+
+// + 1 porque hay que tener en cuenta el 0
+const maxFirst = Number.parseInt(maximumSplit[0]) + 1
+const maxSecond = Number.parseInt(maximumSplit[1]) + 1
+
+// + 1 porque hay que tener en cuenta el 0 para las transiciones
+const firstDigitHeight = (1 / (maxFirst + 1)) * 100
+const secondDigitHeight = (1 / (maxFirst + 1)) * 100
 ---
 
 <div class="flex w-16 flex-col place-items-center gap-y-2">
@@ -14,35 +24,16 @@ const { dateType, attribute } = Astro.props
 				class="translate-y-0 transition-transform duration-[800ms] motion-reduce:duration-0"
 				data-wrapper
 			>
-				<div class="h-10" data-num-0>
+				{
+					Array.from({ length: maxFirst }, () => 0).map((_, index) => (
+						// + 1 porque hay que tener en cuenta el 0 para las transiciones
+						<div data-num={index} style={`height: ${firstDigitHeight}%`}>
+							<span class="text-4xl tabular-nums">{index}</span>
+						</div>
+					))
+				}
+				<div style={`height: ${firstDigitHeight}%`} data-num-x0>
 					<span class="text-4xl tabular-nums">0</span>
-				</div>
-				<div class="h-10" data-num-1>
-					<span class="text-4xl tabular-nums">1</span>
-				</div>
-				<div class="h-10" data-num-2>
-					<span class="text-4xl tabular-nums">2</span>
-				</div>
-				<div class="h-10" data-num-3>
-					<span class="text-4xl tabular-nums">3</span>
-				</div>
-				<div class="h-10" data-num-4>
-					<span class="text-4xl tabular-nums">4</span>
-				</div>
-				<div class="h-10" data-num-5>
-					<span class="text-4xl tabular-nums">5</span>
-				</div>
-				<div class="h-10" data-num-6>
-					<span class="text-4xl tabular-nums">6</span>
-				</div>
-				<div class="h-10" data-num-7>
-					<span class="text-4xl tabular-nums">7</span>
-				</div>
-				<div class="h-10" data-num-8>
-					<span class="text-4xl tabular-nums">8</span>
-				</div>
-				<div class="h-10" data-num-9>
-					<span class="text-4xl tabular-nums">9</span>
 				</div>
 			</div>
 		</div>
@@ -51,35 +42,16 @@ const { dateType, attribute } = Astro.props
 				class="translate-y-0 transition-transform duration-[800ms] motion-reduce:duration-0"
 				data-wrapper
 			>
-				<div class="h-10" data-num-0>
+				{
+					Array.from({ length: maxSecond }, () => 0).map((_, index) => (
+						// + 1 porque hay que tener en cuenta el 0 para las transiciones
+						<div data-num={index} style={`height: ${secondDigitHeight}%`}>
+							<span class="text-4xl tabular-nums">{index}</span>
+						</div>
+					))
+				}
+				<div style={`height: ${secondDigitHeight}%`} data-num-x0>
 					<span class="text-4xl tabular-nums">0</span>
-				</div>
-				<div class="h-10" data-num-1>
-					<span class="text-4xl tabular-nums">1</span>
-				</div>
-				<div class="h-10" data-num-2>
-					<span class="text-4xl tabular-nums">2</span>
-				</div>
-				<div class="h-10" data-num-3>
-					<span class="text-4xl tabular-nums">3</span>
-				</div>
-				<div class="h-10" data-num-4>
-					<span class="text-4xl tabular-nums">4</span>
-				</div>
-				<div class="h-10" data-num-5>
-					<span class="text-4xl tabular-nums">5</span>
-				</div>
-				<div class="h-10" data-num-6>
-					<span class="text-4xl tabular-nums">6</span>
-				</div>
-				<div class="h-10" data-num-7>
-					<span class="text-4xl tabular-nums">7</span>
-				</div>
-				<div class="h-10" data-num-8>
-					<span class="text-4xl tabular-nums">8</span>
-				</div>
-				<div class="h-10" data-num-9>
-					<span class="text-4xl tabular-nums">9</span>
 				</div>
 			</div>
 		</div>

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -17,19 +17,19 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 		data-date={EVENT_TIMESTAMP}
 		role="timer"
 	>
-		<Date dateType="Días" attribute={{ "data-days": "" }} />
+		<Date dateType="Días" attribute={{ "data-days": "" }} max={99} />
 
 		<span aria-hidden="true" class="mt-1 text-xl">:</span>
 
-		<Date dateType="Horas" attribute={{ "data-hours": "" }} />
+		<Date dateType="Horas" attribute={{ "data-hours": "" }} max={23} />
 
 		<span aria-hidden="true" class="mt-1 text-xl">:</span>
 
-		<Date dateType="Minutos" attribute={{ "data-minutes": "" }} />
+		<Date dateType="Minutos" attribute={{ "data-minutes": "" }} max={59} />
 
 		<span aria-hidden="true" class="mt-1 text-xl">:</span>
 
-		<Date dateType="Segundos" attribute={{ "data-seconds": "" }} />
+		<Date dateType="Segundos" attribute={{ "data-seconds": "" }} max={59} />
 	</div>
 </section>
 
@@ -76,10 +76,27 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 
 		function animateDigit(group: HTMLElement, value: string) {
 			const wrapper = group.querySelector("[data-wrapper]")
-			const num = group.querySelector(`[data-num-${value}]`)
+			const num = group.querySelector(`[data-num="${value}"]`)
+			const xnum = group.querySelector("[data-num-x0]")
 
-			if (wrapper instanceof HTMLElement && num instanceof HTMLElement) {
+			if (
+				wrapper instanceof HTMLElement &&
+				num instanceof HTMLElement &&
+				xnum instanceof HTMLElement
+			) {
 				wrapper.style.transform = `translateY(-${num.offsetTop}px)`
+
+				// Cuando cambie, volver arriba
+				if (value === "0") {
+					setTimeout(() => {
+						wrapper.classList.toggle("duration-[800ms]", false)
+						wrapper.classList.toggle("transition-transform", false)
+						wrapper.style.transform = `translateY(-${xnum.offsetTop}px)`
+					}, 800)
+				} else {
+					wrapper.classList.toggle("duration-[800ms]", true)
+					wrapper.classList.toggle("transition-transform", true)
+				}
 			}
 		}
 


### PR DESCRIPTION
## Descripción

Esta pull request se centra en arreglar el problema de las transiciones del contador. Este se movía hacia arriba demasiado rápido y había números no utilizados por el sistema sexagesimal que usa el tiempo y las 24 horas que tiene un día.

## Problema solucionado

Se ha solucionado el problema de las transiciones del contador que se hacían en velocidades distintas y a veces podría llevar al mareo. Esto sucedía cuando una cifra pasaba del 0 al 9 (o del 0 al 5, dependiendo de si eran segundos, minutos...). Más adelante están las capturas con la comparación de los cambios.

## Cambios propuestos

1. Añadir un 0 al final del todo que se  cambia por el 0 de arriba del todo sin transiciones cambiando las clases de tailwind. 
2. Añadir una propiedad max para no repetir números y que las transiciones sigan funcionando sin ir rápido.

## Capturas de pantalla (si corresponde)

**ANTES:**
![2024-03-0211-53-56-ezgif com-video-to-gif-converter](https://github.com/midudev/la-velada-web-oficial/assets/67011864/544e14f8-7f52-4c61-88fe-c0b684b3e03d)

**DESPUÉS:**
![2024-03-0211-52-57-ezgif com-video-to-gif-converter](https://github.com/midudev/la-velada-web-oficial/assets/67011864/582f42cd-26bf-42bb-81f9-3587aa8a7257)

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Se ha hecho el mínimo cambio posible, basado en el código fuente del creador del contador.

## Contexto adicional

## Enlaces útiles

- Documentación del proyecto:
- Código de referencia:
