### PR TITLE
Fix/cursor pointer

### DIFF
--- a/src/components/ButtonUp.astro
+++ b/src/components/ButtonUp.astro
@@ -1,8 +1,8 @@
-<div class="fixed bottom-2 right-2 opacity-0 hidden transition-opacity">
+<div class="fixed bottom-2 right-2 opacity-0 transition-opacity">
 	<button
 		id="scroll-to-top"
 		aria-label="Volver al inicio de la página"
-		class="group flex size-12 cursor-pointer items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur hover:scale-105 motion-safe:transition"
+		class="group flex size-12 cursor-default items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur hover:scale-105 motion-safe:transition"
 	>
 		<svg
 			stroke-width="2"
@@ -27,7 +27,7 @@
 		const display = scrollTop > 20 ? "block" : "none"
 		if ($button) {
 			$button.parentElement?.classList.toggle("opacity-0", display === "none")
-			$button.parentElement?.classList.toggle("hidden", display === "none")
+			$button.classList.toggle("cursor-default", display === "none")
 		}
 	}
 

--- a/src/components/ButtonUp.astro
+++ b/src/components/ButtonUp.astro
@@ -1,4 +1,4 @@
-<div class="fixed bottom-2 right-2 opacity-0 transition-opacity">
+<div class="fixed bottom-2 right-2 opacity-0 hidden transition-opacity">
 	<button
 		id="scroll-to-top"
 		aria-label="Volver al inicio de la página"
@@ -25,7 +25,10 @@
 	function toggleScrollToTop() {
 		const scrollTop = document.body.scrollTop || document.documentElement.scrollTop
 		const display = scrollTop > 20 ? "block" : "none"
-		if ($button) $button.parentElement?.classList.toggle("opacity-0", display === "none")
+		if ($button) {
+			$button.parentElement?.classList.toggle("opacity-0", display === "none")
+			$button.parentElement?.classList.toggle("hidden", display === "none")
+		}
 	}
 
 	function throttledScrollHandler() {


### PR DESCRIPTION
## Descripción

Pequeña contribución para solucionar lo que considero un pequeño bug visual en el botón de ir arriba.

## Problema solucionado

No se si considerarlo un pequeño bug visual, cuando estabas arriba de la página el botón de ir arriba desaparecía, pero cuando pasabas por encima el tipo de cursor seguía siendo pointer.

## Cambios propuestos

En esta PR, primero le había añadido la clase hidden al botón cuando estaba arriba, pero al ver que tenía una transición de opacidad lo he cambiado por simplemente cambiándole el tipo de cursor a default.

## Capturas de pantalla (si corresponde)

Antes (el cursor de abajo a la derecha, ya he dicho que era algo pequeño)
![CursorPointer](https://github.com/midudev/la-velada-web-oficial/assets/19782502/4a4fc20e-e4f6-45a5-87a6-27aaf0b4e399)

Después
![CursorDefault](https://github.com/midudev/la-velada-web-oficial/assets/19782502/a9f4b826-42e9-4f6e-a69c-e97bde382032)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Solo visual

## Contexto adicional


## Enlaces útiles

- Documentación del proyecto: 
- Código de referencia: 
