### PR TITLE
Cambio a country codes en paises de LATAM

### DIFF
--- a/src/consts/event-date.ts
+++ b/src/consts/event-date.ts
@@ -54,12 +54,14 @@ export const timeZoneAbbreviations: { [key: string]: string } = {
 	"Africa/Cairo": "EET", // Eastern European Time (Egypt)
 	"Africa/Lagos": "WAT", // West Africa Time
 
-	// South America
+	// South America, for countries with one time zone we use the country code to improve readability
 	"America/Sao_Paulo": "BRT", // Brasilia Time
-	"America/Buenos_Aires": "ART", // Argentine Time
-	"America/Lima": "PET", // Peru Time
-	"America/Bogota": "COL", // Colombia Time
-	"America/Caracas": "VET", // Venezuelan Standard Time
+	"America/Buenos_Aires": "ARG", // Argentine Time
+	"America/Lima": "PE", // Peruvian Time
+	"America/Bogota": "COL", // Colombian Time
+	"America/Caracas": "VE", // Venezuelan Standard Time
+	"America/Montevideo": "UY", // Uruguayan Time
+	"America/Santiago": "CL", // Chilean Time
 
 	// Additional Global Time Zones
 	"Pacific/Auckland": "NZDT", // New Zealand Daylight Time
@@ -67,8 +69,6 @@ export const timeZoneAbbreviations: { [key: string]: string } = {
 	"Pacific/Fiji": "FJT", // Fiji Time
 	"Pacific/Tongatapu": "TOT", // Tonga Time
 	"Etc/UTC": "UTC", // Coordinated Universal Time
-	"America/Montevideo": "UYT", // Uruguay Time
-	"America/Santiago": "CLT", // Chile Time
 	"America/St_Johns": "NST", // Newfoundland Time
 	"Asia/Kathmandu": "NPT", // Nepal Time
 	"Asia/Yerevan": "AMT", // Armenia Time


### PR DESCRIPTION
## Descripción

Se cambian las abreviaciones de los paises de LATAM con solo una timezone por el country code. Con esto de mejora la identificacion.

Fuente: [Sanidad Española](https://www.sanidad.gob.es/ciudadanos/saludAmbLaboral/docs/codigoIsoPai.pdf)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Estos cambios no implican un impacto potencial en le rendimiento de la web. Estos cambios solo aplican sobre la usabilidad de la misma.
