### PR TITLE
Prevent scroll animation if system animations are disabled

### DIFF
--- a/src/components/TwitchLogo.astro
+++ b/src/components/TwitchLogo.astro
@@ -21,49 +21,45 @@
 </svg>
 
 <style>
-	@supports (animation-timeline: view()) {
-		.fill {
-			animation-timeline: view();
-			animation-name: showFill;
-			animation-timing-function: linear;
-		}
-	}
-
-	@supports (animation-timeline: scroll()) {
-		.stroke {
-			animation-timeline: scroll();
-			animation-name: showStroke;
-			animation-timing-function: linear;
-		}
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		svg {
-			animation-name: none;
-		}
-	}
-
-	@keyframes showStroke {
-		0%,
-		30% {
-			fill: var(--background-twitch);
+	@media (prefers-reduced-motion: no-preference) {
+		@supports (animation-timeline: view()) {
+			.fill {
+				animation-timeline: view();
+				animation-name: showFill;
+				animation-timing-function: linear;
+			}
 		}
 
-		40%,
-		100% {
-			fill: var(--color-twitch);
-		}
-	}
-
-	@keyframes showFill {
-		0%,
-		40% {
-			fill: var(--color-secondary);
+		@supports (animation-timeline: scroll()) {
+			.stroke {
+				animation-timeline: scroll();
+				animation-name: showStroke;
+				animation-timing-function: linear;
+			}
 		}
 
-		50%,
-		100% {
-			fill: var(--color-twitch-ice);
+		@keyframes showStroke {
+			0%,
+			30% {
+				fill: var(--background-twitch);
+			}
+
+			40%,
+			100% {
+				fill: var(--color-twitch);
+			}
+		}
+
+		@keyframes showFill {
+			0%,
+			40% {
+				fill: var(--color-secondary);
+			}
+
+			50%,
+			100% {
+				fill: var(--color-twitch-ice);
+			}
 		}
 	}
 </style>


### PR DESCRIPTION
## Descripción

Se evita que el scroll animation ocurra cuando las animaciones del sistema están explícitamente deshabilitadas.
La animación en cuestión, es el cambio del color de relleno del SVG del logo de Twitch al hacer scroll.

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

## Enlaces útiles

Antigua PR relacionada: https://github.com/midudev/la-velada-web-oficial/pull/173