### PR TITLE
add text-center for phone view

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -142,7 +142,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 				document.querySelector(".countdown-text")?.remove()
 
 				$countdown.innerHTML = "¡El evento de presentación ha empezado! 🎉"
-				$countdown.className = "text-primary uppercase font-semibold animate-fade-in text-3xl"
+				$countdown.className = "text-primary uppercase font-semibold animate-fade-in text-3xl text-center"
 
 				import("canvas-confetti").then(({ default: confetti }) => {
 					confetti()


### PR DESCRIPTION
## Descripción

Alinea el texto que anuncia que la presentación ha empezado para mejor visualización en movil

## Problema solucionado

En movil el texto "¡EL EVENTO DE PRESENTACIÓN HA EMPEZADO! 🎉" aparecía posicionado hacia la izquierda en
lugar de aparecer centrado

## Cambios propuestos

se añade la clase "text-center" de Tailwind en la creacion del elemento

## Capturas de pantalla (si corresponde)

Antes:
![2024-03-05 09_39_09-La Velada del Año 4 - Evento de Boxeo de Ibai Llanos y 1 página más -  InPrivate](https://github.com/midudev/la-velada-web-oficial/assets/56647411/d9a92dcc-98d8-48f8-ac38-c633210f5f68)

Ahora:
![2024-03-05 09_38_52-La Velada del Año 4 - Evento de Boxeo de Ibai Llanos y 10 páginas más - Personal](https://github.com/midudev/la-velada-web-oficial/assets/56647411/30c4125d-0a60-4440-b37a-b63adcedbf4a)

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Nada mas alla de la apariencia

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
