### PR TITLE
Fix de parpadeo del background en Safari

### DIFF
--- a/src/components/NoiseBackground.astro
+++ b/src/components/NoiseBackground.astro
@@ -19,31 +19,31 @@
 			transform: translate3d(0, 0, 0);
 		}
 		10% {
-			transform: translate3d(-5%, -5%, 0);
+			transform: translate3d(-1%, -2%, 0);
 		}
 		20% {
-			transform: translate3d(-10%, 5%, 0);
+			transform: translate3d(-2%, 2%, 0);
 		}
 		30% {
-			transform: translate3d(5%, -10%, 0);
+			transform: translate3d(0%, 2%, 0);
 		}
 		40% {
-			transform: translate3d(-5%, 15%, 0);
+			transform: translate3d(-1%, 1%, 0);
 		}
 		50% {
-			transform: translate3d(-10%, 5%, 0);
+			transform: translate3d(-1%, 5%, 0);
 		}
 		60% {
-			transform: translate3d(15%, 0, 0);
+			transform: translate3d(1%, 0, 0);
 		}
 		70% {
-			transform: translate3d(15%, 15%, 0);
+			transform: translate3d(1%, 5%, 0);
 		}
 		80% {
-			transform: translate3d(10%, 5%, 0);
+			transform: translate3d(1%, 2%, 0);
 		}
 		90% {
-			transform: translate3d(5%, 10%, 0);
+			transform: translate3d(3%, 1%, 0);
 		}
 		100% {
 			transform: translate3d(0, 0, 0);


### PR DESCRIPTION
# Descripción

Modifiqué la animación de **noise** que se utiliza en el background que generaba parpadeos molestos en Safari.

## Problema solucionado

Resuelve el error reportado en la issue de [Problemas efecto ruido en Safari #216](https://github.com/midudev/la-velada-web-oficial/issues/216)
## Cambios propuestos

Cambié los porcentajes en la progresión de la animación de noise haciendolos mas pequeños, menos bruscos. Genera los resultados visuales esperados en todos los navegadores probados (Brave, Chrome, Firefox), incluido Safari

## Capturas de pantalla

### Antes:

https://github.com/midudev/la-velada-web-oficial/assets/103329387/7419cb4d-8c3c-45db-a480-7cfa695be697

### Despues:

https://github.com/midudev/la-velada-web-oficial/assets/103329387/b45e0086-0248-4966-86ac-2af373945cfe

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
