### PR TITLE
fix: Update sponsors class names to avoid the ad blocker

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -58,7 +58,7 @@ const SPONSORS = [
 		{
 			SPONSORS.map(({ id, name, url }) => (
 				<a
-					class="sponsor-link group relative flex h-24 items-center justify-center overflow-hidden md:h-32"
+					class="company-link group relative flex h-24 items-center justify-center overflow-hidden md:h-32"
 					title={`Visita la página del patrocinador ${name}`}
 					href={url}
 					target="_blank"
@@ -68,7 +68,7 @@ const SPONSORS = [
 						loading="lazy"
 						src={`/img/${id}.svg`}
 						alt={`Logo del patrocinador ${name}`}
-						class="sponsor-logo w-30 h-auto transition group-hover:scale-110"
+						class="company-logo w-30 h-auto transition group-hover:scale-110"
 					/>
 				</a>
 			))
@@ -76,12 +76,12 @@ const SPONSORS = [
 	</div>
 </section>
 <style>
-	.sponsor-link {
+	.company-link {
 		background: linear-gradient(to bottom, rgba(255, 255, 255, 0.1) 0%, transparent 100%);
 		transition: all 0.5s ease;
 	}
 
-	.sponsor-link::before {
+	.company-link::before {
 		content: "";
 		position: absolute;
 		inset: 0;
@@ -92,17 +92,17 @@ const SPONSORS = [
 		transition: opacity 0.5s ease-in;
 	}
 
-	.sponsor-link:hover::before {
+	.company-link:hover::before {
 		opacity: 0.8;
 		height: 90%;
 		box-shadow: 0 -4px 3px rgba(50, 50, 50, 0.75);
 	}
 
-	.sponsor-logo {
+	.company-logo {
 		transition: transform 0.3s ease-in-out;
 	}
 
-	.sponsor-link:hover .sponsor-logo {
+	.company-link:hover .company-logo {
 		transform: scale(1.1);
 	}
 </style>


### PR DESCRIPTION
## Descripción

Modifique algunos nombres de clases para evitar el AD blocker

## Problema solucionado

Se resuelve el problema mencionado en la issue [El AD blocker remueve los logos de los sponsors #237
](https://github.com/midudev/la-velada-web-oficial/issues/237)

## Cambios propuestos

- Se renombro las clases que contenian la palabra sponsor por company para evitar el AD blocker.

## Capturas de pantalla (si corresponde)

Antes:
[screen-capture.webm](https://github.com/midudev/la-velada-web-oficial/assets/35277540/9164e84b-5d40-4e75-83ae-cb0494068d9d)

Despues:
[ad-blocker-solve.webm](https://github.com/midudev/la-velada-web-oficial/assets/35277540/1a8e0500-462a-4a78-a065-6552b4caaa58)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
