### PR TITLE
Add styles to fix a text time break 

### DIFF
--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -8,12 +8,12 @@ import Action from "@/components/Action.astro"
 	class="mx-auto mt-16 flex animate-fade-in flex-col place-items-center text-center text-primary animate-delay-300 motion-reduce:animate-delay-[0s] motion-reduce:animate-duration-[0s] md:mt-32"
 >
 	<header class="text-3xl font-semibold uppercase md:text-5xl">
-		<time class="date"></time>
+		<time class="date inline-block"></time>
 		<span class="date-time-separator hidden">
 			<span aria-hidden="true" class="mx-1 hidden md:inline">·</span>
 			<br aria-hidden="true" class="block md:hidden" />
 		</span>
-		<time class="time"></time>
+		<time class="time hidden"></time>
 	</header>
 
 	<h2 class="mt-6 flex max-w-sm flex-col text-lg font-medium uppercase lg:text-2xl">
@@ -123,6 +123,7 @@ import Action from "@/components/Action.astro"
 		if ($timeSpan != null && showTime) {
 			$timeSpan.innerHTML = timeString
 			$timeSpan.setAttribute("datetime", validDatetime)
+			$timeSpan?.classList.remove("hidden")
 			$dateSeparator?.classList.remove("hidden")
 		}
 	}


### PR DESCRIPTION
## Descripción
Agregue algunas clases de tailwind en la etiqueta time del component `<PrincipalDate />`

## Problema solucionado

Un pequeño salto en el texto de 13 de Julio

## Cambios propuestos
Agregue la class inline-block en la etiqueta time:
```html
<header class="text-3xl font-semibold uppercase md:text-5xl">
  <time class="date inline-block"></time>
</header>
```
Y también agregue un `classList.remove` en el JavaScript:
```js
if ($timeSpan != null && showTime) {
  $dateSeparator?.classList.remove("hidden")
}
```

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

