### PR TITLE
fix: traducir aria-labels a español

### DIFF
--- a/src/components/ButtonUp.astro
+++ b/src/components/ButtonUp.astro
@@ -5,7 +5,7 @@
 		class="group flex size-12 cursor-default items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur hover:scale-105 motion-safe:transition"
 	>
 		<svg
-			aria-label="Scroll to top"
+			aria-label="Subir al inicio de la página"
 			stroke-width="2"
 			stroke="currentColor"
 			viewBox="0 0 24 24"

--- a/src/components/NoiseBackground.astro
+++ b/src/components/NoiseBackground.astro
@@ -1,7 +1,5 @@
-<canvas
-	id="noise"
-	aria-label="Background noise effect for display"
-	class="fixed top-0 -z-10 animate-fade-in"></canvas>
+<canvas id="noise" aria-label="Efecto de fondo de ruido" class="fixed top-0 -z-10 animate-fade-in"
+></canvas>
 
 <script>
 	let wWidth: number, wHeight: number

--- a/src/components/SmokeBackground.astro
+++ b/src/components/SmokeBackground.astro
@@ -1,5 +1,5 @@
 <div id="smoke-bkg" class="fixed top-0 -z-10 h-full w-full">
-	<canvas id="smoke-canvas" aria-label="Smoke Background effect" class="opacity-70 dark:opacity-40"
+	<canvas id="smoke-canvas" aria-label="Efecto de humo de fondo" class="opacity-70 dark:opacity-40"
 	></canvas>
 </div>
 


### PR DESCRIPTION
## Descripción

Traduje las etiquetas aria-label a español, ya que estaban en inglés.

## Problema solucionado

Ahora las etiquetas de accesibilidad están en español como corresponde, ya que es una página orientada a un púlblico español.

## Cambios propuestos

Cambiar las aria-label en inglés a español.

## Capturas de pantalla (si corresponde)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar accesibilidad

## Contexto adicional


## Enlaces útiles

- Documentación del proyecto:
- Código de referencia: 
