### PR TITLE
refactor(Typography): add types and removed unnecessary code

### DIFF
--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -3,37 +3,33 @@ import type { HTMLTag, Polymorphic } from "astro/types"
 
 type Props<Tag extends HTMLTag> = Polymorphic<{
 	as: Tag
-	variant: string
-	color: string
-	href?: string
+	variant: keyof typeof variantClasses
+	color: keyof typeof colorClasses
 }>
 
-const { as: Tag, class: className, variant, color, href, ...props } = Astro.props
+const { as: Tag, class: className, variant, color, ...props } = Astro.props
 
-const variantClasses: { [key: string]: string } = {
+const variantClasses = {
 	h2: "text-lg font-medium uppercase lg:text-2xl",
 	h3: "text-2xl font-semibold uppercase",
 	body: "text-xl",
 	medium: "text-md",
 }
-const colorClasses: { [key: string]: string } = {
+
+const colorClasses = {
 	white: "text-white",
 	black: "text-black",
 	primary: "text-accent",
 	neutral: "text-neutral-300",
 }
 
-const classes = [variantClasses[variant], colorClasses[color], className]
+const classes = [
+	variantClasses[variant as keyof typeof variantClasses],
+	colorClasses[color as keyof typeof colorClasses],
+	className,
+]
 ---
 
-{
-	href ? (
-		<a href={href} class:list={classes} {...props}>
-			<slot />
-		</a>
-	) : (
-		<Tag class:list={classes} {...props}>
-			<slot />
-		</Tag>
-	)
-}
+<Tag class:list={classes} {...props}>
+	<slot />
+</Tag>


### PR DESCRIPTION
## Descripción

The component now need less code to do the same and props are typed.

variant and color overwrite types is needed because a bug of Astro that type Astro.props as any instead as T [Issue 10347](https://github.com/withastro/astro/issues/10347)

## Problema solucionado

Props no tienen tipos

## Cambios propuestos

Se han corregido los tipos y eliminado codigo innecesario

## Capturas de pantalla (si corresponde)

```astro
---
import type { HTMLTag, Polymorphic } from "astro/types"

type Props<Tag extends HTMLTag> = Polymorphic<{
	as: Tag
	variant: keyof typeof variantClasses
	color: keyof typeof colorClasses
}>

const { as: Tag, class: className, variant, color, ...props } = Astro.props

const variantClasses = {
	h2: "text-lg font-medium uppercase lg:text-2xl",
	h3: "text-2xl font-semibold uppercase",
	body: "text-xl",
	medium: "text-md",
}

const colorClasses = {
	white: "text-white",
	black: "text-black",
	primary: "text-accent",
	neutral: "text-neutral-300",
}

const classes = [
	variantClasses[variant as keyof typeof variantClasses],
	colorClasses[color as keyof typeof colorClasses],
	className,
]
---

<Tag class:list={classes} {...props}>
	<slot />
</Tag>
```

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
