### PR TITLE
responsive: add padding on sponsors logos

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -71,7 +71,7 @@ const SPONSORS = [
 						loading="lazy"
 						src={`/img/${id}.svg`}
 						alt={`Logo del patrocinador ${name}`}
-						class="company-logo w-30 h-auto transition group-hover:scale-110"
+						class="company-logo w-30 h-auto transition group-hover:scale-110 px-4"
 					/>
 				</a>
 			))


### PR DESCRIPTION
## Descripción
Añadir padding a los logos de los esponsors para que se vea bien en pantallas más pequeñas
## Capturas de pantalla (si corresponde)

Antes:
<img width="382" alt="Sponsors padding antes" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/86c3c5d7-5119-4bea-8a20-0c231a75a0e9">

Despues:
<img width="381" alt="Sponsors padding despues" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/bec3bc6a-9247-4162-9b8e-0f2e53b2298c">


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
