### PR TITLE
Add Typescript suggestions for Typography props

### DIFF
--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -3,27 +3,29 @@ import type { HTMLTag, Polymorphic } from "astro/types"
 
 type Props<Tag extends HTMLTag> = Polymorphic<{
 	as: Tag
-	variant: string
-	color: string
+	variant: VariantClasses
+	color: ColorClasses
 	href?: string
 }>
-
 const { as: Tag, class: className, variant, color, href, ...props } = Astro.props
-
-const variantClasses: { [key: string]: string } = {
+const variantClassesKey = variant as VariantClasses
+const colorClassesKey = color as ColorClasses
+const variantClasses = {
 	h2: "text-lg font-medium uppercase lg:text-2xl",
 	h3: "text-2xl font-semibold uppercase",
 	body: "text-xl",
 	medium: "text-md",
-}
-const colorClasses: { [key: string]: string } = {
+} as const
+type VariantClasses = keyof typeof variantClasses
+
+const colorClasses = {
 	white: "text-white",
 	black: "text-black",
 	primary: "text-accent",
 	neutral: "text-neutral-300",
 }
-
-const classes = [variantClasses[variant], colorClasses[color], className]
+type ColorClasses = keyof typeof colorClasses
+const classes = [variantClasses[variantClassesKey], colorClasses[colorClassesKey], className]
 ---
 
 {

--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -7,7 +7,9 @@ type Props<Tag extends HTMLTag> = Polymorphic<{
 	color: ColorClasses
 	href?: string
 }>
+
 const { as: Tag, class: className, variant, color, href, ...props } = Astro.props
+
 const variantClasses = {
 	h2: "text-lg font-medium uppercase lg:text-2xl",
 	h3: "text-2xl font-semibold uppercase",
@@ -15,7 +17,6 @@ const variantClasses = {
 	medium: "text-md",
 } as const
 type VariantClasses = keyof typeof variantClasses
-
 const colorClasses = {
 	white: "text-white",
 	black: "text-black",
@@ -23,6 +24,7 @@ const colorClasses = {
 	neutral: "text-neutral-300",
 }
 type ColorClasses = keyof typeof colorClasses
+
 const classes = [variantClasses[variant as VariantClasses], colorClasses[color as ColorClasses], className]
 ---
 

--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -8,8 +8,6 @@ type Props<Tag extends HTMLTag> = Polymorphic<{
 	href?: string
 }>
 const { as: Tag, class: className, variant, color, href, ...props } = Astro.props
-const variantClassesKey = variant as VariantClasses
-const colorClassesKey = color as ColorClasses
 const variantClasses = {
 	h2: "text-lg font-medium uppercase lg:text-2xl",
 	h3: "text-2xl font-semibold uppercase",
@@ -25,7 +23,7 @@ const colorClasses = {
 	neutral: "text-neutral-300",
 }
 type ColorClasses = keyof typeof colorClasses
-const classes = [variantClasses[variantClassesKey], colorClasses[colorClassesKey], className]
+const classes = [variantClasses[variant as VariantClasses], colorClasses[color as ColorClasses], className]
 ---
 
 {


### PR DESCRIPTION
## Descripción

Durante el directo vi que, para el nuevo componente Typography, Miguel dijo que estaria bien que autocompletase los posibles valores de las props. Actualmente si no conoces los valores tienes que ir al componente a mirarlos

## Problema solucionado

Con esta implementacion los devs que quieran usar este componente podran seleccionar del autocompletado, lo que facilitara el desarrollo

## Cambios propuestos

Quitando el tipo de las const ya existentes y añadiend "as const".
Creando dos tipos nuevos para facilitar la reutilizacion en varias partes

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/44357391/4bf8b58a-898f-4741-8fe1-78beb6c7ce04)

## Comprobación de cambios

- [X ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X ] He actualizado la documentación, si corresponde.

## Impacto potencial

Ninguno, solo cambia typescript

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
