### PR TITLE
Solucionado "container overflow" en pantallas pequeñas

### DIFF
--- a/src/sections/PresentationVideo.astro
+++ b/src/sections/PresentationVideo.astro
@@ -20,7 +20,7 @@ import Typography from "@/components/Typography.astro"
 	<div class="relative mt-8">
 		<img
 			aria-hidden="true"
-			class="absolute inset-0 -z-10 m-auto scale-125"
+			class="absolute inset-0 -z-10 m-auto md:scale-125"
 			src="/img/drawn-x-logo.webp"
 			alt="Logo X de La Velada dibujado a mano"
 		/>


### PR DESCRIPTION
## Descripción

Solucioné un error producido por el componente PresentationVideo.astro que producía que la imagen fuera más grande que el contenedor y que la página se viera mal en dispositivos móviles.

## Problema solucionado

https://github.com/midudev/la-velada-web-oficial/issues/277

## Cambios propuestos

- Cambiar clase scale-125 a md:scale-125 en PresentationVideo.astro

## Capturas de pantalla (si corresponde)

Antes

![antes](https://github.com/midudev/la-velada-web-oficial/assets/133175356/033ed74c-211e-4630-b2eb-8c4dde242440)

Después

![después](https://github.com/midudev/la-velada-web-oficial/assets/133175356/38c4d103-9dd4-4c49-a6ce-aefb51621790)


## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Arreglar la visualización en pantallas móviles

## Contexto adicional

Issue https://github.com/midudev/la-velada-web-oficial/issues/277

## Enlaces útiles

- Documentación del proyecto:
- Código de referencia: 
