### PR TITLE
fix(responsive): make content be always centered #277

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -46,7 +46,7 @@ const { title, description } = Astro.props
 	</head>
 
 	<body
-		class="selection:bg-accent dark [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
+		class="overflow-x-hidden selection:bg-accent dark [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
 	>
 		<!-- <SmokeBackground /> -->
 		<NoiseBackground />


### PR DESCRIPTION
## Descripción

Realize solo un cambio en el overflow del body (overflow-x-hidden), haciendo que este no pueda scrollear horizontalmente en ningun tamaño de pantalla

## Problema solucionado

Soluciona #277

Mas detalle:

El problema se origina en celulares y tablets.

Iphone 14 Pro Max:
![image](https://github.com/midudev/la-velada-web-oficial/assets/63322751/bd36fadd-1fee-442b-ab6f-5ccee422b4e6)

Ipad mini:
![image](https://github.com/midudev/la-velada-web-oficial/assets/63322751/d143962a-46d6-413f-b625-987dc70fe9ab)

Como se puede notar el contenido no esta centrado.

## Cambios propuestos

- En el body (Layout.astro) poner la clase overflow-x-hidden

## Capturas de pantalla (si corresponde)

Las siguientes imagenes son del despues:

Iphone 14 Pro Max:
![image](https://github.com/midudev/la-velada-web-oficial/assets/63322751/819a78d1-a335-4ad3-8b77-0b34907ce3a5)

Ipad mini:
![image](https://github.com/midudev/la-velada-web-oficial/assets/63322751/2f47d619-d97a-4d85-8eba-38c5ae4ffd4c)

## Comprobación de cambios

- [ x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x ] He actualizado la documentación, si corresponde.

## Impacto potencial

Arreglar la visualización en pantallas móviles y prevenir que en cambios futuros el scroll horizontal se active, ya que el diseno general de la pagina se desea mantener centrado dentro del contenedor.

## Contexto adicional

El cambio sugerido en la PR #275 no arregla el problema para tablets/ipads. 
