### PR TITLE
Add `ISSUE_TEMPLATE`

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,38 @@
+# Pre-requisitos
+
+<!-- Por favor responde las siguientes preguntas antes de crear un issue. **PUEDES ELIMINAR LA SECCIÓN DE REQUISITOS.** -->
+
+- [ ] Estoy corriendo la última versión.
+- [ ] He revisado si ya hay un issue creado con las mismas características.
+
+# Comportamiento esperado
+
+<!-- Describa el aquí el comportamiento esperado. -->
+
+# Comportamiento actual
+
+<!-- Describa el aquí el comportamiento actual. Incluye capturas de pantalla o videos si es posible. -->
+
+# Información del bug (si corresponde)
+
+<!-- Ayude a proporcionar información sobre la falla si se trata de un error. Si no es un error, elimine el resto de esta plantilla. -->
+
+## Pasos para reproducirlo
+
+<!-- Proporcione los pasos detallados para reproducir el problema. -->
+
+1. Paso 1
+2. Paso 2
+
+## Contexto
+
+<!-- Proporcione cualquier información relevante sobre su configuración. Esto es importante en caso de que el problema no sea reproducible excepto bajo ciertas condiciones. -->
+
+- Navegador: Firefox, Chrome, Safari, Microsoft Edge, Opera, etc.
+- Versión del navegador: ---
+- Sistema operativo: Windows, MacOS, Linux
+
+
+## Logs de error (si corresponde)
+
+<!-- Incluya aquí cualquier fragmento de registro o archivo relevante. -->


### PR DESCRIPTION
## Descripción

Template para crear issues

## Cambios propuestos

- Agregué un template para poder crear issues y que esten más detallados para poder reproducirlos

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/21049417/c2a688bf-5b2c-402e-b454-fbb686366033)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

- [Issue template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/manually-creating-a-single-issue-template-for-your-repository)
