### PR TITLE
fixing twitch/ibai text mobile responsive

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -5,7 +5,7 @@ import HeroLogo from "@/components/HeroLogo.astro"
 <section class="flex flex-col place-items-center gap-4 lg:gap-9">
 	<h1 class="sr-only bg-black/30">Presentación de la Velada del Año IV</h1>
 	<a
-		class="-rotate-6 font-atomic text-4xl text-white underline-offset-8 transition hover:scale-110 hover:underline"
+		class="-rotate-6 font-atomic text-2xl md:text-4xl text-white underline-offset-8 transition hover:scale-110 hover:underline"
 		href="https://www.twitch.tv/ibai"
 		target="_blank"
 		rel="noopener"


### PR DESCRIPTION
## Descripción

Modifiqué el tamaño del texto del link al canal de Ibai encima del logo para que siga el diseño original.

## Capturas de pantalla (si corresponde)

Antes:
![Captura de pantalla 2024-03-06 205015](https://github.com/midudev/la-velada-web-oficial/assets/134991353/755d8a99-ce83-46e7-96d6-2dc41323f783)

Después: 
![Captura de pantalla 2024-03-06 205104](https://github.com/midudev/la-velada-web-oficial/assets/134991353/18f4f7dd-7d5d-4cc5-bf2c-7c3181dfc531)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
