### PR TITLE
Fix tag link preload font atomic

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,6 +22,7 @@ const { title, description } = Astro.props
 		<meta name="description" content={description} />
 
 		<link rel="preload" href={jost} as="font" type="font/woff2" crossorigin />
+		<link rel="preload" href="/fonts/atomic.woff2" as="font" type="font/woff2" crossorigin />
 
 		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 		<link rel="canonical" href="https://lavelada.es" />


### PR DESCRIPTION
## Descripción

Agregue el tag link preload para la fuente atomic.woff2

## Problema solucionado

Ayudar un poco con la carga de la fuente atomic.woff2

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

