### PR TITLE
Responsive for width < 360px

### DIFF
--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -3,6 +3,7 @@ import Action from "./Action.astro"
 ---
 
 <Action
+	class="!w-full !text-base xs:!text-xl"
 	as="button"
 	id="add-to-calendar"
 	aria-label="agregar al calendario se abrirá ventana flotante"

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -29,9 +29,10 @@ import Typography from "@/components/Typography.astro"
 		</a>
 	</Typography>
 
-	<footer class="scroll-horizontal items-top mt-6 flex flex-col gap-9 md:flex-row">
-		<div class="flex flex-col items-center justify-center gap-y-2">
+	<footer class="scroll-horizontal items-top mt-6 flex w-full flex-col gap-9 xs:w-auto md:flex-row">
+		<div class="mx-auto flex w-[90%] flex-col items-center justify-center gap-y-2 xs:w-80">
 			<Action
+				class="!w-full !text-base xs:!text-xl"
 				as="a"
 				aria-disabled="true"
 				href="#"
@@ -45,7 +46,7 @@ import Typography from "@/components/Typography.astro"
 				Próximamente
 			</Typography>
 		</div>
-		<div>
+		<div class="mx-auto w-[90%] xs:w-80">
 			<CalendarButton />
 		</div>
 	</footer>

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,5 @@
 import animations from "@midudev/tailwind-animations"
-
+import defaultTheme from "tailwindcss/defaultTheme"
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
@@ -14,6 +14,10 @@ export default {
 				accent: "var(--color-accent)",
 				twitch: "var(--color-twitch)",
 				ice: "var(--color-twitch-ice)",
+			},
+			screens: {
+				xs: "360px",
+				...defaultTheme.screens,
 			},
 		},
 	},


### PR DESCRIPTION
## Description

Tailwind media query *xs* for screen width size <= 360px. 

fix: action buttons now do not overflow the screen (font size fixed at 16px when width screen is < 360px)

 screen size of tested  device: 320x568
before: 

![Screenshot 2024-03-07 at 11-36-41 La Velada del Año 4 - Evento de Boxeo de Ibai Llanos](https://github.com/midudev/la-velada-web-oficial/assets/106329576/56ec8f82-9763-48cc-8ba5-df5f12c0821f)

after:
![Screenshot 2024-03-07 at 12-16-15 La Velada del Año 4 - Evento de Boxeo de Ibai Llanos](https://github.com/midudev/la-velada-web-oficial/assets/106329576/e435a3da-cccb-42f2-9752-d60e30932296)
