### PR TITLE
feature: add SectionTitle Component

### DIFF
--- a/src/components/SectionTitle.astro
+++ b/src/components/SectionTitle.astro
@@ -1,0 +1,26 @@
+---
+import Typography from "./Typography.astro"
+
+interface Props {
+	title: string
+	description: string
+	variant?: keyof typeof variantSizes
+}
+
+const { title, description, variant = "standar" } = Astro.props
+
+const variantSizes = {
+	small: "mx-auto max-w-[250px] text-wrap",
+	standar: "",
+}
+
+const classSize = variantSizes[variant]
+---
+
+<Typography as="h3" variant="h3" color="white" class:list={"text-center"}>
+	{title}
+</Typography>
+
+<Typography as="p" variant="body" color="neutral" class:list={`mt-4 text-center ${classSize}`}>
+	{description}
+</Typography>


### PR DESCRIPTION
## Descripción
Se generalizo en un componente para los títulos de las secciones que se estaban duplicando el código del componente `<Typography />` .

## Problema solucionado
Anteriormente, teníamos un problema de duplicación de código en el componente `<Typography />` al manejar títulos de secciones. Esta duplicación no solo era propensa a errores, sino que también dificultaba el mantenimiento y la coherencia en la apariencia de los títulos. Al generalizar el componente, hemos solucionado este problema y mejorado la estructura del código.

## IMPORTANTE
No inserte el componente, queda pendiente:
- Insertar en `components/Sponsors.astro` :
```tsx
 --- 
import SectionTitle from "@/components/SectionTitle.astro"
 --- 
<SectionTitle
		title="Patrocinadores"
		description="La Velada puede llevarse a cabo gracias a la colaboración de..."
/>
```

- Insertar en  `components/PresentationVideo.astro` : 
```tsx
 --- 
import SectionTitle from "@/components/SectionTitle.astro"
 --- 
<SectionTitle
		title="Presentación"
		description="Vuelve a ver la presentación desde el Teatro Victoria"
		variant="small"
/>
```


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
