### PR TITLE
feat(LiteYouTube): :wheelchair: add role and tabindex attributes to lite-youtube for improved accessibility

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -8,7 +8,7 @@ interface Props {
 const { videoId, title, backgroundImage } = Astro.props
 ---
 
-<lite-youtube videoid={videoId} style={`background-image: url('${backgroundImage}')`}>
+<lite-youtube videoid={videoId} style={`background-image: url('${backgroundImage}')`} tabindex="0" role="button">
 	<a href={`https://youtube.com/watch?v=${videoId}`} class="lty-playbtn" title="Play Video">
 		<span class="lyt-visually-hidden">{title}</span>
 	</a>


### PR DESCRIPTION
## Descripción

Se agregó el atributo role al elemento <lite-youtube> con el propósito de mejorar la accesibilidad para usuarios que utilizan tecnologías de asistencia, como lectores de pantalla. Esto ayuda a clarificar la función y el propósito del elemento, lo que contribuye a una mejor experiencia de usuario en general.

## Problema solucionado

Al agregar los atributos role y tabindex al elemento <lite-youtube>, se resuelve un problema de accesibilidad al hacer que el reproductor de video de YouTube integrado sea más usable para personas con discapacidades visuales o que dependen de la navegación por teclado.

## Capturas de pantalla (si corresponde)

![imagen](https://github.com/midudev/la-velada-web-oficial/assets/109250897/76e914c5-00c8-486f-8cbe-dffe206be96d)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

https://developer.mozilla.org/es/docs/Web/Accessibility/Understanding_WCAG/Keyboard?utm_source=devtools&utm_medium=a11y-panel-checks-keyboard#Clickable_elements_must_be_focusable_and_should_have_interactive_semantics
