### PR TITLE
Fix nested CSS error

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-jsx-a11y": "6.8.0",
     "husky": "9.0.11",
     "lightningcss": "1.24.0",
+    "postcss-nesting": "12.1.0",
     "prettier": "3.2.5",
     "prettier-plugin-astro": "0.13.0",
     "prettier-plugin-tailwindcss": "0.5.12",

--- a/postcss.config.mjs
+++ b/postcss.config.mjs
@@ -1,0 +1,8 @@
+export default {
+	plugins: {
+		"postcss-import": {},
+		"tailwindcss/nesting": "postcss-nesting",
+		"tailwindcss": {},
+		"autoprefixer": {},
+	},
+}


### PR DESCRIPTION
## Descripción

Hay un error en la consola sobre nested CSS en `src\sections\SelectYourBoxer.astro`. Esta PR lo soluciona siguiendo las [sugerencias de Tailwind](https://tailwindcss.com/docs/using-with-preprocessors#nesting)

![image](https://github.com/midudev/la-velada-web-oficial/assets/56328053/7aba8b45-cd9c-4bd3-8c08-0a34f7326ac9)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
