### PR TITLE
fix: add select-none to sponsors and infojobs logo

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -10,7 +10,7 @@ import { SPONSORS } from "@/consts/sponsors"
 	<Typography as="p" variant="body" color="neutral" class:list={"mt-4 text-center"}>
 		La Velada puede llevarse a cabo gracias a la colaboración de...
 	</Typography>
-	<div class="mt-12 grid grid-cols-2 gap-8 md:grid-cols-3">
+	<div class="mt-12 grid select-none grid-cols-2 gap-8 md:grid-cols-3">
 		{
 			SPONSORS.map(({ id, name, url }) => (
 				<a
@@ -45,7 +45,7 @@ import { SPONSORS } from "@/consts/sponsors"
 				loading="lazy"
 				src="/img/sponsors/infojobs.svg"
 				alt="Logo de InfoJobs"
-				class="inline-block h-auto w-32"
+				class="inline-block h-auto w-32 select-none"
 			/>
 		</a>
 	</div>


### PR DESCRIPTION
## Descripción

Siguiendo el estilo de la PR https://github.com/midudev/la-velada-web-oficial/pull/326, añadí select-none a los sponsors y al logo de InfoJobs, ya que son imágenes.

## Capturas de pantalla

Antes

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/c75eac70-eb21-4331-b95a-ddfb9858fda1)

Después

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/f2d37997-d08a-4633-9c00-5d5c5023b9f8)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.


## Contexto adicional

PR https://github.com/midudev/la-velada-web-oficial/pull/326
