### PR TITLE
(a11y) Arreglar vídeo para que se pueda reproducir presionando enter

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -8,8 +8,17 @@ interface Props {
 const { videoId, title, backgroundImage } = Astro.props
 ---
 
-<lite-youtube videoid={videoId} style={`background-image: url('${backgroundImage}')`} tabindex="0" role="button">
-	<a href={`https://youtube.com/watch?v=${videoId}`} class="lty-playbtn" title="Play Video">
+<lite-youtube
+	videoid={videoId}
+	style={`background-image: url('${backgroundImage}')`}
+	tabindex="0"
+	role="button"
+>
+	<a
+		href={`https://youtube.com/watch?v=${videoId}`}
+		class="lty-playbtn"
+		title="Reproducir presentación de La Velada del Año"
+	>
 		<span class="lyt-visually-hidden">{title}</span>
 	</a>
 </lite-youtube>
@@ -41,7 +50,9 @@ const { videoId, title, backgroundImage } = Astro.props
 			let playBtnEl = this.querySelector(".lty-playbtn")
 			// A label for the button takes priority over a [playlabel] attribute on the custom-element
 			this.playLabel =
-				(playBtnEl && playBtnEl.textContent.trim()) || this.getAttribute("playlabel") || "Play"
+				(playBtnEl && playBtnEl.textContent.trim()) ||
+				this.getAttribute("playlabel") ||
+				"Reproducir presentación de La Velada del Año"
 
 			this.dataset.title = this.getAttribute("title") || ""
 
@@ -80,6 +91,9 @@ const { videoId, title, backgroundImage } = Astro.props
 			// TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time
 			//   We'd want to only do this for in-viewport or near-viewport ones: https://github.com/ampproject/amphtml/pull/5003
 			this.addEventListener("click", this.activate)
+
+			// For accessibility, handle keypresses as well
+			this.addEventListener("keydown", this.handleKeyPress)
 
 			// Chrome & Edge desktop have no problem with the basic YouTube Embed with ?autoplay=1
 			// However Safari desktop and most/all mobile browsers do not successfully track the user gesture of clicking through the creation/loading of the iframe,
@@ -206,6 +220,12 @@ const { videoId, title, backgroundImage } = Astro.props
 
 			// Set focus for a11y
 			iframeEl.focus()
+		}
+
+		handleKeyPress(event) {
+			if (event.key === "Enter") {
+				this.activate()
+			}
 		}
 
 		createBasicIframe() {


### PR DESCRIPTION

## Descripción

He agregado un event listener para poder reproducir el vídeo utilizando la tecla enter tras seleccionarlo en caso de no poder usar el mouse, ya que no se podía realizar anteriormente.

Además traducí un par de labels a11y a español.

## Problema solucionado

- Agregar event listener a vídeo para reproducir el vídeo en caso de seleccionarlo y presionar enter (se pueden agregar más teclas a la función en caso de desearlo)
- Traducir labels a11y a español
## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la accesibilidad para todos los usuarios.
