### PR TITLE
[FIX] letter e info section

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -32,7 +32,7 @@ import Typography from "@/components/Typography.astro"
 	>
 		<span
 			class="-rotate-6 skew-x-6 text-center font-atomic text-xl text-white underline-offset-8 transition sm:text-3xl md:text-5xl"
-			>En directo
+			>en directo
 		</span>
 		<Typography
 			as="h2"


### PR DESCRIPTION
hay que revisar las tipos ya que no se pueden poner mayus (supongo que algo de la optimización

## Descripción

Básicamente cambiar la letra E a e ya que con Atomic queda rara (supongo que se ha optimizado la fuente para quitar mayus)

## Problema solucionado

Básicamente cambiar la letra E a e ya que con Atomic queda rara (supongo que se ha optimizado la fuente para quitar mayus)

## Cambios propuestos

Básicamente cambiar la letra E a e ya que con Atomic queda rara (supongo que se ha optimizado la fuente para quitar mayus)

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/81626570/86e2a11d-5c69-4a1f-babe-17e513da2b8b)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/81626570/7bcd31f8-1714-4df3-8422-563655b5a2cb)


## Comprobación de cambios

- [x ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x ] He actualizado la documentación, si corresponde.

## Impacto potencial

No hay

## Contexto adicional

No necesario

## Enlaces útiles

No necesario
