### PR TITLE
Mejoras de UI al error 404 Not Found

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -8,8 +8,12 @@ import Footer from "@/sections/Footer.astro"
 	description="Web Oficial de La Velada del Año IV, evento de boxeo entre streamers y creadores de contenido, organizado por Ibai Llanos"
 	title="La Velada del Año 4 - Página no encontrada"
 >
-	<main>
-		<Error error="404" message="Página no encontrada" />
-	</main>
+   <main>
+	   <Error
+		   error="404"
+		   message="Página no encontrada"
+		   contextMessage="¡Hola! Lo sentimos, pero no pudimos encontrar lo que buscabas. Verifica que la dirección URL sea correcta."
+	   />
+   </main>
 	<Footer />
 </Layout>

--- a/src/sections/Error.astro
+++ b/src/sections/Error.astro
@@ -6,7 +6,6 @@ import Typography from "@/components/Typography.astro"
 const { error, message, contextMessage } = Astro.props
 ---
 
-
 <section
 	class="m-auto flex w-full flex-wrap place-items-center items-center justify-center text-primary"
 >
@@ -21,7 +20,7 @@ const { error, message, contextMessage } = Astro.props
 			color="neutral"
 			class:list={"mb-10 font-bold text-white"}
 		>
-			Error {error}
+			error {error}
 		</Typography>
 		<Typography as="h2" variant="h2" color="neutral" class:list={"text-white"}>
 			<p>{message}</p>

--- a/src/sections/Error.astro
+++ b/src/sections/Error.astro
@@ -1,20 +1,35 @@
 ---
 import Action from "@/components/Action.astro"
 import HeroLogo from "@/components/HeroLogo.astro"
+import Typography from "@/components/Typography.astro"
 
-const { error, message } = Astro.props
+const { error, message, contextMessage } = Astro.props
 ---
 
-<section class="mt-8 flex flex-col place-items-center text-primary md:mt-16">
+
+<section
+	class="m-auto flex w-full flex-wrap place-items-center items-center justify-center text-primary"
+>
 	<HeroLogo
-		class="h-auto w-[300px] text-primary animate-duration-0 md:w-[500px]"
+		class="m-5 h-auto w-[300px] text-primary animate-duration-0 md:w-[500px]"
 		disableAnimation
 	/>
-	<div class="mt-16 text-center">
-		<h1 class="text-5xl font-semibold uppercase text-white md:text-6xl">Error {error}</h1>
-		<h1 class="mt-5 text-2xl font-semibold uppercase md:text-4xl">{message}</h1>
+	<div class="m-5 mt-16 text-center">
+		<Typography
+			as="h1"
+			variant="atomic-title"
+			color="neutral"
+			class:list={"mb-10 font-bold text-white"}
+		>
+			Error {error}
+		</Typography>
+		<Typography as="h2" variant="h2" color="neutral" class:list={"text-white"}>
+			<p>{message}</p>
+		</Typography>
+		<p class="mt-5 max-w-80 text-xl">{contextMessage}</p>
+
+		<Action class="mt-7 text-center" href="/" aria-label="volver a la página principal" as="a"
+			>Ir al inicio</Action
+		>
 	</div>
-	<Action class="mt-5 text-center" href="/" aria-label="volver a la página principal" as="a"
-		>Volver</Action
-	>
 </section>


### PR DESCRIPTION
## Descripción

Mejoras en la UI de la página NotFound para que se vea más llamativo y sea mas entendible por el usuario agregando una breve descripción del error

## Problema solucionado

El mensaje de notfound se mostraba abajo y sin mucho contexto. En la nueva versión se le muestra un mensaje al usuario en el top de la página junto al botón de volver

## Cambios propuestos

**Uso del Typography en lugar de los h1 que habían anteriormente
Creación de un nuevo parámetro llamado contextMessage, donde le damos información al usuario del error
Flex horizontal para vistas en PC, y con wrap para vistas móviles**

**Interfaz original:**

![veladaerroantiguo](https://github.com/midudev/la-velada-web-oficial/assets/96151177/3bf8adc0-d128-43ea-b5c5-eb8e6140597e)
 
**Interfaz con mejoras:**

![notfoundfiz](https://github.com/midudev/la-velada-web-oficial/assets/96151177/84d508b8-b0f9-4e25-975e-89bf7a8125fc)


## Comprobación de cambios

- [Sí ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [Sí ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [Sí ] He actualizado la documentación, si corresponde.

## Impacto potencial

La página de error 404 not found ya no tiene scroll por lo que es más fácil de entender en una primera impresión y se ve estéticamente mejor
