### PR TITLE
Fix: fixed PrincipalDate button texts

### DIFF
--- a/src/components/Action.astro
+++ b/src/components/Action.astro
@@ -31,11 +31,6 @@ const { as: Tag, class: className, ...props } = Astro.props
 		border-color: #666;
 	}
 
-	.button-style > span {
-		display: inline-block;
-		transform: skew(21deg);
-	}
-
 	.button-style::before {
 		content: "";
 		position: absolute;

--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -8,7 +8,7 @@ import Action from "./Action.astro"
 	id="add-to-calendar"
 	aria-label="agregar al calendario se abrirá ventana flotante"
 >
-	<span> Agregar al calendario</span>
+	<span class="inline-block skew-x-[21deg]"> Agregar al calendario</span>
 </Action>
 
 <script is:inline>

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -45,7 +45,7 @@ import Typography from "@/components/Typography.astro"
 				rel="noopener noreferrer"
 				aria-label="entradas agotadas, se abrirá en una nueva pestaña"
 			>
-				<span> Comprar entradas </span>
+				<span class="inline-block skew-x-[21deg]"> Comprar entradas </span>
 			</Action>
 			<Typography as="span" variant="medium" color="primary" class:list={"text-center"}>
 				Próximamente


### PR DESCRIPTION
## Descripción

Los textos de los botones justo debajo de la fecha del evento aparecen curvados.

## Problema solucionado

Se ha modificado código de estilos para hacer que los textos de los botones justo debajo de la fecha aparezcan enderezados en vez de estar con la misma curvatura que el botón, al igual que estaban en la landing anterior.

## Cambios propuestos

Se ha eliminado la parte de css que estaba intentando hacer este cambio de estilo, ya que el style al no ser is:global dentro del componente Action, la declaración `.button-style > span` no se cargaba y los textos no se enderezaban.

Se han añadido las dos clases que estaban en el style del componente Action en ambos span de los botones.

## Capturas de pantalla (si corresponde)

### Antes (textos curvados con los botones)
![image](https://github.com/midudev/la-velada-web-oficial/assets/55552731/eff8b1fb-70c5-403b-a0e1-655b3af3c7cd)

### Después (textos enderezados)
![image](https://github.com/midudev/la-velada-web-oficial/assets/55552731/78d8561e-23e1-4efe-8fc0-73b82b50cfad)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Cuando se creen nuevos botones con el componente Action que dará el estilo curvado, habrá que añadir las clases de `inline-block skew-x-[21deg]` para que los textos se puedan leer bien rectos. No es un impacto como tal, sino la solución para el resto de veces.

## Contexto adicional

No he querido cambiar el style del componente Action directamente a is:global por si hay conflictos de clases más adelante, pero es otra forma de hacer que funcione. Lo probé y da el mismo resultado.
