### PR TITLE
Fix: Blur of the logo cut on error404 page

### DIFF
--- a/src/sections/Error.astro
+++ b/src/sections/Error.astro
@@ -10,7 +10,7 @@ const { error, message, contextMessage } = Astro.props
 	class="m-auto flex w-full flex-wrap place-items-center items-center justify-center text-primary"
 >
 	<HeroLogo
-		class="m-5 h-auto w-[300px] text-primary animate-duration-0 md:w-[500px]"
+		class="m-5 h-auto w-[300px] text-primary overflow-visible animate-duration-0 md:w-[500px]"
 		disableAnimation
 	/>
 	<div class="m-5 mt-16 text-center">


### PR DESCRIPTION
## Descripción

He añadido `overflow-visible` para solucionar un corte del blur en el HeroLogo de la pagina de Error404

## Problema solucionado

Corte del blur en el componente `HeroLogo` de la pagina de Error404

## Cambios propuestos

Se añade `overflow-visible` en el componente `<HeroLogo>` del archivo `Error.astro` porque si no se corta el blur del logo principal en la pagina del error404

## Capturas de pantalla (si corresponde)

#### ANTES
![Error1](https://github.com/midudev/la-velada-web-oficial/assets/153825296/a26f6aab-283b-46d5-9120-cf8b31676aeb)

#### DESPUES
![Error2](https://github.com/midudev/la-velada-web-oficial/assets/153825296/6ab71abe-abbd-426d-98a4-470ba5ceba66)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

No debería tener ningún impacto potencial

## Contexto adicional


## Enlaces útiles

- Documentación del proyecto:
- Código de referencia: