### PR TITLE
Se ajusta componente Action

### DIFF
--- a/src/components/Action.astro
+++ b/src/components/Action.astro
@@ -6,17 +6,15 @@ type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }>
 const { as: Tag, class: className, ...props } = Astro.props
 ---
 
-<Tag class:list={["button-style *:duration-500", className]} {...props}><slot /></Tag>
+<Tag class:list={["button-style *:duration-500", className]} {...props}>
+	<span><slot /></span>
+</Tag>
 
 <style>
 	.button-style {
-		background: transparent;
-		border: none;
 		padding: 10px 20px;
 		display: inline-block;
-		font-size: 20px;
 		font-weight: 600;
-		width: 20rem;
 		text-transform: uppercase;
 		cursor: pointer;
 		transform: skew(-21deg);
@@ -39,26 +37,20 @@ const { as: Tag, class: className, ...props } = Astro.props
 	.button-style::before {
 		content: "";
 		position: absolute;
-		top: 0;
-		bottom: 0;
-		right: 0;
-		left: 0;
+		inset: -2px;
 		background: var(--color-primary);
 		transform: scaleX(0);
 		transform-origin: right; /* To end from left to right */
-		z-index: -1;
 	}
 
 	.button-style:hover {
 		color: var(--color-secondary);
 		scale: 1.1;
-		transform: skew(-21deg);
 	}
 
 	.button-style:hover::before {
-		transform-origin: left; /* To start from left to right */
 		transform: scaleX(1);
-		opacity: 1;
+		transform-origin: left; /* To start from left to right */
 	}
 
 	@media (prefers-reduced-motion: no-preference) {

--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -8,7 +8,7 @@ import Action from "./Action.astro"
 	id="add-to-calendar"
 	aria-label="agregar al calendario se abrirá ventana flotante"
 >
-	<span> Agregar al calendario</span>
+	Agregar al calendario
 </Action>
 
 <script is:inline>

--- a/src/sections/Error.astro
+++ b/src/sections/Error.astro
@@ -27,8 +27,8 @@ const { error, message, contextMessage } = Astro.props
 		</Typography>
 		<p class="mt-5 max-w-80 text-xl">{contextMessage}</p>
 
-		<Action class="mt-7 text-center" href="/" aria-label="volver a la página principal" as="a"
-			>Ir al inicio</Action
-		>
+		<Action class="mt-7 text-center" href="/" aria-label="volver a la página principal" as="a">
+			Ir al inicio
+		</Action>
 	</div>
 </section>

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -45,7 +45,7 @@ import Typography from "@/components/Typography.astro"
 				rel="noopener noreferrer"
 				aria-label="entradas agotadas, se abrirá en una nueva pestaña"
 			>
-				<span> Comprar entradas </span>
+				Comprar entradas
 			</Action>
 			<Typography as="span" variant="medium" color="primary" class:list={"text-center"}>
 				Próximamente


### PR DESCRIPTION
## Descripción

Ajuste en la implementación del componente Action.astro.


## Cambios propuestos

Existe css que no está siendo utilizado y css que no es necesario utilizar.
Se mueven etiquetas `<span>` dentro del componente para que carguen correctamente los estilos (Deja recto el texto).

## Capturas de pantalla
#### Página de inicio
- Antes
![Antes inicio](https://github.com/midudev/la-velada-web-oficial/assets/93208313/edd93ef8-b9de-47d7-821f-941aee339b34)

- Después
![Despues inicio](https://github.com/midudev/la-velada-web-oficial/assets/93208313/c801b61a-aed5-46bf-85e7-28b0ae3b0b0a)

#### Página de error
- Antes
![Antes](https://github.com/midudev/la-velada-web-oficial/assets/93208313/5481d356-5426-4e93-b30b-bb2bc0969e4d)
- Después
![Despues](https://github.com/midudev/la-velada-web-oficial/assets/93208313/1e025e4c-a081-49b6-8958-47024315db9d)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.


## Contexto adicional

Al hacer `:hover` causaba ciertos saltos en el texto mientras se reproducía la animación, esto lo corrige. 👍 

