### PR TITLE
Agregar paquete @vercel/speed-insights

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@fontsource-variable/jost": "5.0.18",
     "@vercel/analytics": "1.2.2",
+    "@vercel/speed-insights": "^1.0.10",
     "astro": "4.4.14"
   },
   "devDependencies": {

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -1,4 +1,6 @@
 ---
+import SpeedInsights from "@vercel/speed-insights/astro"
+
 interface Props {
 	title: string
 	description: string
@@ -39,3 +41,5 @@ const { title, description, jost } = Astro.props
 
 <meta name="robots" content="index, follow" />
 <meta name="googlebot" content="index, follow" />
+
+<SpeedInsights />


### PR DESCRIPTION
## Descripción

Agregar paquete @vercel/speed-insights e importar componente SpeedInsigths in SEO.astro

## Problema solucionado

## Cambios propuestos

Agregar el monitoreo de SpeedInsigths proporcionado por vercel

## Capturas de pantalla (si corresponde)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

## Enlaces útiles
