### PR TITLE
Agrego color al hover del ButtonUp

### DIFF
--- a/src/components/ButtonUp.astro
+++ b/src/components/ButtonUp.astro
@@ -2,7 +2,7 @@
 	<button
 		id="scroll-to-top"
 		aria-label="Volver al inicio de la página"
-		class="group flex size-12 cursor-default items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur hover:scale-105 motion-safe:transition"
+		class="group flex size-12 cursor-default items-center justify-center rounded-lg border-2 border-primary bg-black/10 text-primary backdrop-blur hover:scale-105 hover:border-accent motion-safe:transition"
 	>
 		<svg
 			aria-label="Subir al inicio de la página"
@@ -10,7 +10,7 @@
 			stroke="currentColor"
 			viewBox="0 0 24 24"
 			fill="none"
-			class="h-6 w-6 -rotate-45 group-hover:-rotate-90 motion-safe:transition"
+			class="h-6 w-6 -rotate-45 group-hover:-rotate-90 group-hover:text-accent motion-safe:transition"
 			width="20px"
 		>
 			<path d="M14 5l7 7m0 0l-7 7m7-7H3" stroke-linejoin="round" stroke-linecap="round"></path>


### PR DESCRIPTION
## Descripción

Para seguir la convección del color "accent" en los iconos y algunos botones, agregué el color en el hover del ButtonUp

## Problema solucionado

El ButtonUp no llevaba el color "accent"en el hover.

## Cambios propuestos

1. Agregar color "accent" en el hover del ButtonUp

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/77457893/bca9d7aa-b30a-49c2-91cd-0c74d490feb6)

Despues:
![image](https://github.com/midudev/la-velada-web-oficial/assets/77457893/467f8d34-c87e-43a7-86ea-28f3e0853cde)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

Es mi primera PR en la vida siguiendo el Curso de GIT desde cero en tu canal <3

## Enlaces útiles

