### PR TITLE
fix: remove redundant anchor from tabindex and accessibility tree

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -14,8 +14,9 @@ import Typography from "@/components/Typography.astro"
 		href="https://twitch.tv/ibai"
 		target="_blank"
 		rel="nofollow noopener"
-		class="mx-auto -mt-11 mb-8 motion-safe:transition duration-200 hover:scale-110"
-		aria-label="síguelo en directo twitch.tv/ibai, se abrirá en una nueva pestaña"
+		class="mx-auto -mt-11 mb-8 duration-200 hover:scale-110 motion-safe:transition"
+		aria-hidden="true"
+		tabindex="-1"
 	>
 		<div class="w-14 md:w-20">
 			<TwitchLogo />


### PR DESCRIPTION
## Descripción

Eliminé un anchor redundante (Logo de Twitch) en la sección "En Directo" del tabindex y accessibility tree para mejorar la experiencia de usuario. Ya hay otro anchor abajo que cumple la misma función.

## Capturas de pantalla (si corresponde)

Antes

[antes.webm](https://github.com/midudev/la-velada-web-oficial/assets/133175356/1e0fa2d2-abd3-45af-bf68-65c862313bcc)

Después

[despues.webm](https://github.com/midudev/la-velada-web-oficial/assets/133175356/81518583-9307-49e1-8646-7ea46c507f4c)




## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
