### PR TITLE
Add: mb-8 en la sección info.astro

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -32,7 +32,7 @@ import Typography from "@/components/Typography.astro"
 		aria-label="Enlace al canal de Twitch de Ibai Llanos"
 	>
 		<span
-			class="-rotate-6 skew-x-6 text-center font-atomic text-xl text-white underline-offset-8 transition sm:text-3xl md:text-5xl"
+			class="mb-8 -rotate-6 skew-x-6 text-center font-atomic text-xl text-white underline-offset-8 transition sm:text-3xl md:text-5xl"
 			>en directo
 		</span>
 		<Typography


### PR DESCRIPTION
## Descripción

Agregue un pequeño margen de separación

## Problema solucionado

Problema de separacion entre dos textos.

## Cambios propuestos

Modifique la sección info.astro, la etiqueta <span> donde esta el texto que  dice En directo.

## Capturas de pantalla (si corresponde)
Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/98416036/e2228c05-77bb-413d-a2f6-830cb159e05b)

Despues:
![image](https://github.com/midudev/la-velada-web-oficial/assets/98416036/4bee52a4-3fdb-4eb7-88f4-abd3b8caedc1)

## Comprobación de cambios

- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Ninguno


