### PR TITLE
fix: handleKeyPress now handles space

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -223,7 +223,7 @@ const {
 		}
 
 		handleKeyPress(event) {
-			if (event.key === "Enter") {
+			if (event.code === "Enter" || event.code === "Space") {
 				this.activate()
 			}
 		}


### PR DESCRIPTION
## Descripción

Agregué la tecla espacio a las teclas que activan el vídeo al enfocarlo, ya que igual se usa para este propósito.

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
