### PR TITLE
fix: avoid duplicate scrollbar

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const { title, description, preloadImgLCP } = Astro.props
 	</head>
 
 	<body
-		class="dark overflow-x-hidden selection:bg-accent [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
+		class="dark selection:bg-accent [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
 	>
 		<!-- <SmokeBackground /> -->
 		<NoiseBackground />
@@ -56,8 +56,10 @@ const { title, description, preloadImgLCP } = Astro.props
 			html {
 				font-family: "Jost Variable", system-ui, sans-serif;
 				background: var(--background-color);
-				overflow-x: hidden;
 				overscroll-behavior: none;
+				overflow-x: hidden;
+				overflow-y: scroll;
+				scrollbar-gutter: stable force;
 			}
 
 			main {


### PR DESCRIPTION
## Descripción

Se removió la clase "overflow-x-hidden" del body, esto hacia que al cargar la pagina (con conexión lenta ) aparecieran dos scrollbar

## Problema solucionado

Al cargar la pagina (con conexión lenta ) aparecieran dos scrollbar

## Cambios propuestos

Se removió la clase "overflow-x-hidden" del body y se agrego el siguiente código css en la etiqueta html:

``` css
	overflow-y: scroll;
	scrollbar-gutter: stable force;
```

La prodiedad "scrollbar-gutter" permite reservar el espacio del scrollbar, lo que evita cambios de diseño no deseados a medida que crece el contenido.

## Capturas de pantalla (si corresponde)

### Antes:

[scrollbar duplicados.webm](https://github.com/midudev/la-velada-web-oficial/assets/57335632/54d6d6dd-13db-40cf-b2d8-65e7c8e170b2)

### Despues:

[solucion.webm](https://github.com/midudev/la-velada-web-oficial/assets/57335632/3a5db225-ed8a-4c82-9199-9dd3154625b8)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

## Enlaces útiles

