### PR TITLE
Feature/add e2e suite test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,8 @@ yarn.lock
 
 # generated vercel output
 .vercel/
+
+# cypress
+cypress/screenshots
+cypress/videos
+cypress/downloads

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from "cypress"
+
+export default defineConfig({
+	e2e: {
+		supportFile: false,
+		video: false,
+		baseUrl: "http://localhost:4321",
+	},
+})

--- a/cypress/consts/index.ts
+++ b/cypress/consts/index.ts
@@ -1,0 +1,4 @@
+export const META_TITLE = "La Velada del Año 4 - Evento de Boxeo de Ibai Llanos"
+export const META_DESCRIPTION = "Web Oficial de La Velada del Año IV, evento de boxeo entre streamers y creadores de contenido, organizado por Ibai Llanos"
+export const META_CANONICAL = "https://lavelada.es"
+export const META_OG_IMAGE = "https://lavelada.es/og.png"

--- a/cypress/e2e/index.cy.ts
+++ b/cypress/e2e/index.cy.ts
@@ -1,0 +1,9 @@
+describe("Homepage", () => {
+	beforeEach(() => {
+		cy.visit("/")
+	})
+
+	it("should display the main header with the event name", () => {
+		cy.get("h1").should("have.text", "Presentación de la Velada del Año IV")
+	})
+})

--- a/cypress/e2e/seo.cy.ts
+++ b/cypress/e2e/seo.cy.ts
@@ -1,0 +1,55 @@
+import {
+	META_CANONICAL,
+	META_DESCRIPTION,
+	META_OG_IMAGE,
+	META_TITLE
+} from "../consts"
+
+describe("SEO", () => {
+	beforeEach(() => {
+		cy.visit("/")
+	})
+
+	it("should have the correct meta title and description", () => {
+		cy.get("head title").should("have.text", META_TITLE)
+		cy.get("head meta[name=description]").should("have.attr", "content", META_DESCRIPTION)
+	})
+
+	it("should have the correct charset", () => {
+		cy.get("head meta[charset]").should("have.attr", "charset", "UTF-8")
+	})
+
+	it("should have the correct viewport", () => {
+		cy.get("head meta[name=viewport]").should("have.attr", "content", "width=device-width")
+	})
+
+	it("should have the correct lang attribute", () => {
+		cy.get("html").should("have.attr", "lang", "es")
+	})
+
+	it("should have correct meta links", () => {
+		cy.get("head link[rel=icon]").should("have.attr", "href", "/favicon.svg")
+		cy.get("head link[rel=canonical]").should("have.attr", "href", META_CANONICAL)
+	})
+
+	it("should have the meta og and twitter tags", () => {
+		cy.get("head meta[name='twitter:card']").should("have.attr", "content", "summary_large_image")
+		cy.get("head meta[name='twitter:site']").should("have.attr", "content", "@infoLaVelada")
+		cy.get("head meta[name='twitter:creator']").should("have.attr", "content", "@IbaiLlanos")
+		cy.get("head meta[name='twitter:title']").should("have.attr", "content", META_TITLE)
+		cy.get("head meta[name='twitter:description']").should("have.attr", "content", META_DESCRIPTION)
+		cy.get("head meta[name='twitter:image']").should("have.attr", "content", META_OG_IMAGE)
+		cy.get("head meta[name='og:image']").should("have.attr", "content", META_OG_IMAGE)
+		cy.get("head meta[name='og:title']").should("have.attr", "content", META_TITLE)
+		cy.get("head meta[name='og:description']").should("have.attr", "content", META_DESCRIPTION)
+		cy.get("head meta[name='og:url']").should("have.attr", "content", META_CANONICAL)
+		cy.get("head meta[name='og:site_name']").should("have.attr", "content", "La Velada 4")
+		cy.get("head meta[name='og:type']").should("have.attr", "content", "website")
+		cy.get("head meta[name='og:locale']").should("have.attr", "content", "es_ES")
+	})
+
+	it("should have the meta robots index,follow value", () => {
+		cy.get("head meta[name=robots]").should("have.attr", "content", "index, follow")
+		cy.get("head meta[name=googlebot]").should("have.attr", "content", "index, follow")
+	})
+})

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "lint:fix": "eslint --ext .astro,.ts,.js,.tsx . --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src",
+    "test:e2e": "cypress run",
+    "test:e2e:ui": "cypress open",
     "prepare": "husky"
   },
   "dependencies": {
@@ -26,6 +28,7 @@
     "@astrojs/tailwind": "5.1.0",
     "@astrojs/vercel": "7.3.5",
     "@midudev/tailwind-animations": "0.0.7",
+    "cypress": "^13.6.6",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-astro": "0.31.4",


### PR DESCRIPTION
## Descripción

Añadir tests e2e con Cypress. Es una propuesta, si se acepta podemos ir añadiendo algún test que otro y añadir a Github actions un workflow al hacer pull request hacia main que pase estos tests.


## Cambios propuestos

1. Añadida dependencia Cypress
2. Añadidos tests para los metas de head

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Capturas de pantalla

<img width="723" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/78902209/06ad5447-5ec9-4cc5-8073-fe6db1ec9322">


## Impacto potencial

Más confianza a la hora de hacer cambios en el código

## Contexto adicional

He mirado si hay alguna alternativa para hacer test unitarios con Astro y no he encontrado nada.
También he buscado implementar Testing Library con Cypress, pero me da error al extender con los métodos de Testing Library, dice que no los encuentra.

## Enlaces útiles

- [Testing Astro with Cypress](https://docs.astro.build/en/guides/testing/#cypress)
- [Cypress](https://www.cypress.io/)
- [Testing Library](https://testing-library.com/)
