### PR TITLE
fix(#366): Added implicit sponsors images' width and height

### DIFF
--- a/src/consts/sponsors.ts
+++ b/src/consts/sponsors.ts
@@ -1,47 +1,93 @@
-export const SPONSORS = [
+interface Sponsors {
+	id: string
+	name: string
+	url: string
+	image: {
+		width: number | string
+		height: number | string
+	}
+}
+
+export const SPONSORS: Sponsors[] = [
 	{
 		id: "vicio",
 		name: "Vicio",
 		url: "https://www.ganasdevicio.com/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "revolut",
 		name: "Revolut",
 		url: "https://revolut.com/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "prime",
 		name: "Prime",
 		url: "https://drinkprime.com/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "alsa",
 		name: "Alsa",
 		url: "https://alsa.es/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "spotify",
 		name: "Spotify",
 		url: "https://spotify.com/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "cerave",
 		name: "Cerave",
 		url: "https://cerave.es/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "el-pozo",
 		name: "El Pozo",
 		url: "https://elpozo.com/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "grefusa",
 		name: "Grefusa",
 		url: "https://grefusa.com/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 	{
 		id: "maxibon",
 		name: "Maxibon",
 		url: "https://maxibon.es/",
+		image: {
+			width: 128,
+			height: 70,
+		},
 	},
 ] as const

--- a/src/consts/sponsors.ts
+++ b/src/consts/sponsors.ts
@@ -14,8 +14,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Vicio",
 		url: "https://www.ganasdevicio.com/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 164,
+			height: 35,
 		},
 	},
 	{
@@ -23,8 +23,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Revolut",
 		url: "https://revolut.com/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 177,
+			height: 32,
 		},
 	},
 	{
@@ -32,8 +32,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Prime",
 		url: "https://drinkprime.com/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 144,
+			height: 49,
 		},
 	},
 	{
@@ -41,8 +41,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Alsa",
 		url: "https://alsa.es/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 133,
+			height: 38,
 		},
 	},
 	{
@@ -50,8 +50,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Spotify",
 		url: "https://spotify.com/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 207,
+			height: 52,
 		},
 	},
 	{
@@ -59,8 +59,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Cerave",
 		url: "https://cerave.es/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 180,
+			height: 53,
 		},
 	},
 	{
@@ -68,8 +68,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "El Pozo",
 		url: "https://elpozo.com/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 134,
+			height: 72,
 		},
 	},
 	{
@@ -77,8 +77,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Grefusa",
 		url: "https://grefusa.com/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 144,
+			height: 69,
 		},
 	},
 	{
@@ -86,8 +86,8 @@ export const SPONSORS: Sponsors[] = [
 		name: "Maxibon",
 		url: "https://maxibon.es/",
 		image: {
-			width: 128,
-			height: 70,
+			width: 176,
+			height: 73,
 		},
 	},
 ] as const

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -12,7 +12,7 @@ import { SPONSORS } from "@/consts/sponsors"
 	</Typography>
 	<div class="mt-12 grid select-none grid-cols-2 gap-8 md:grid-cols-3">
 		{
-			SPONSORS.map(({ id, name, url }) => (
+			SPONSORS.map(({ id, name, url, image }) => (
 				<a
 					class="company-link group relative flex h-24 items-center justify-center overflow-hidden md:h-32"
 					title={`Visita la página del patrocinador ${name}`}
@@ -24,7 +24,9 @@ import { SPONSORS } from "@/consts/sponsors"
 						loading="lazy"
 						src={`/img/sponsors/${id}.svg`}
 						alt={`Logo del patrocinador ${name}`}
-						class="company-logo w-30 h-auto px-4 transition group-hover:scale-110"
+						width={image.width}
+						height={image.height}
+						class="company-logo px-4 transition group-hover:scale-110"
 					/>
 				</a>
 			))
@@ -45,7 +47,9 @@ import { SPONSORS } from "@/consts/sponsors"
 				loading="lazy"
 				src="/img/sponsors/infojobs.svg"
 				alt="Logo de InfoJobs"
-				class="inline-block h-auto w-32 select-none"
+				width={128}
+				height={70}
+				class="inline-block select-none"
 			/>
 		</a>
 	</div>


### PR DESCRIPTION
## Descripción

Añadidos alto y ancho de las imágenes en `src/consts/sponsors.ts` y una interface para el tipado con TypeScript.

> El alto dado es el máximo de uno de los sponsors, no cambia el alto de la imagen perse

interface Sponsors:

```typescript
interface Sponsors {
  id: string
  name: string
  url: string
  image: {
    width: number | string
    height: number | string
  }
}
```

> width y height tienen como opción string por si se decidiese poner por ejemplo: 128 o "128" o "auto"

## Problema solucionado

Problema con LightHouse First Contentful Paint detallado en #366 por @midudev

## Cambios propuestos

1. Añadir `interface Sponsors` en `src/consts/sponsors.ts"
2. Añadir entrada de `image: { width, height } en cada sponsor
3. Aplicar los cambios en `src/sections/Sponsors.astro` 

## Capturas de pantalla (si corresponde)

<img width="556" alt="Screenshot 2024-03-09 at 04 17 54" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/743c603c-2c18-4aae-ae00-f33fc978e55d">


## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar a la performance de la página