### PR TITLE
Add is-mobile variant to tailwind config

### DIFF
--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -1,5 +1,6 @@
 import animations from "@midudev/tailwind-animations"
 import defaultTheme from "tailwindcss/defaultTheme"
+
 /** @type {import('tailwindcss').Config} */
 export default {
 	content: ["./src/**/*.{astro,html,js,jsx,md,mdx,svelte,ts,tsx,vue}"],
@@ -25,6 +26,7 @@ export default {
 		animations,
 		function ({ addVariant }) {
 			addVariant("any-hover", "@media (any-hover: hover) { &:hover }")
+			addVariant("is-mobile", "@media (any-hover: none) { & }")
 		},
 	],
 }


### PR DESCRIPTION
## Descripción

Agregé una nueva variante para aplicar estilos solo a dispositivos táctiles

## Cambios propuestos

Unicamente modifiqué el archivo de configuración de tailwind para poder user la variante `is-mobile` en las clases de los elementos, por ejemplo:

`<p class="is-mobile:text-red-500 text-blue-500">En pantallas táctiles soy rojo y en desktop soy azul</p>`

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Contexto adicional

También solucioné un error de `lint` que había por no tener espacios entre los imports.
![image](https://github.com/midudev/la-velada-web-oficial/assets/63566111/a8c72ddc-d9de-49f5-b70a-96a287d96bcb)

Funciona bastante bien! Puede ser útil para varias ocasiones 🙂
