### PR TITLE
[FIX] Corregido margin bottom info section

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -4,7 +4,7 @@ import Typography from "@/components/Typography.astro"
 ---
 
 <section
-	class="group mb-32 mt-80 flex w-full flex-col items-center justify-center px-20 font-medium text-primary"
+	class="group mb-4 mt-80 flex w-full flex-col items-center justify-center px-20 font-medium text-primary md:mb-0"
 	aria-label="descripción del evento"
 >
 	<hr


### PR DESCRIPTION
## Descripción

Hecho para igualar espacio entre secciones

## Problema solucionado

Margin bottom demasiado grande en twitch ibai (por como es el componente seccion del video)

## Cambios propuestos

Cambiar ese margin bottom

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/81626570/37eb2d56-ae81-46bc-adc1-9949f714aa35)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/81626570/e32cfed3-70c1-4668-982b-7d1724c5e741)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

No debería tener
