### PR TITLE
fix: Accessibility issues with astro audit

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -18,6 +18,7 @@ import Typography from "@/components/Typography.astro"
 			class="mx-auto mb-8 flex flex-col items-center"
 			aria-hidden="true"
 			tabindex="-1"
+			aria-label="Link con el logo de Twitch que lleva al canal de Twitch de Ibai Llanos"
 		>
 			<div class="w-14 md:w-20">
 				<TwitchLogo />

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -20,6 +20,7 @@ import { SPONSORS } from "@/consts/sponsors"
 					href={url}
 					target="_blank"
 					rel="noopener noreferrer"
+					aria-label={`Link con el logo de ${name} que lleva a ${url}`}
 				>
 					<SponsorLogo
 						logo={id}
@@ -38,9 +39,10 @@ import { SPONSORS } from "@/consts/sponsors"
 
 		<a
 			class="transition hover:scale-110"
-			href="https://infojobs.net"
+			href="https://www.infojobs.net"
 			title="Ir a la página de InfoJobs"
 			target="_blank"
+			aria-label="Link con el logo de Infojobs que lleva a https://www.infojobs.net"
 		>
 			<SponsorLogo
 				logo="infojobs"


### PR DESCRIPTION
## Descripción

Los sponsors y el logo de Twitch tenían problemas de accesibilidad.

## Problema solucionado

Añadido `aria-label` a las etiquetas que presentaban problemas.

## Cambios propuestos

1. Añadir `aria-label`
2. Hay un problema con el `href` del componentes `src/components/LiteYouTube.astro`. Haría falta modificar el componente, porque el `href` está puesto pero no lo genera en el html.

## Capturas de pantalla (si corresponde)

Antes:

<img width="777" alt="Screenshot 2024-03-09 at 18 14 10" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/83e950b5-74db-482d-8a2c-aec9991445b2">

Después:

<img width="777" alt="Screenshot 2024-03-09 at 18 25 17" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/6e75107a-4c8c-4c58-8485-5f1018f49259">

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora de accesibilidad.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
