### PR TITLE
`lite-youtube`: Add rounded border and improved color border, shadow, play

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -13,6 +13,7 @@ const {
 ---
 
 <lite-youtube
+	class="rounded-lg"
 	videoid={videoId}
 	style={`background-image: url('${backgroundImage}')`}
 	tabindex="0"
@@ -286,11 +287,9 @@ const {
 		aspect-ratio: 16/9;
 		width: 100%;
 		height: auto;
-		border: 2px solid;
-		border-image-slice: 1;
-		border-image-source: linear-gradient(30deg, #999, white, #999);
+		border: 2px solid var(--color-accent);
 		transition: all 0.3s ease;
-		box-shadow: 0px 3px 15px 5px #000000a8;
+		box-shadow: 0px 0px 15px rgb(212, 255, 0, 0.1);
 	}
 
 	/* gradient */
@@ -319,11 +318,6 @@ const {
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		box-sizing: border-box;
-	}
-
-	lite-youtube:hover {
-		border-image-source: linear-gradient(30deg, #767c00d1, #fff, #b9c201a1);
-		box-shadow: 0px 3px 15px 5px #000000e3;
 	}
 
 	lite-youtube:hover::before {
@@ -369,7 +363,7 @@ const {
 
 	lite-youtube:hover > .lty-playbtn,
 	lite-youtube .lty-playbtn:focus {
-		background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="greenyellow" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
+		background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="%23d5ff00" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
 		transition: 0.2s;
 		filter: none;
 		transform: scale(1.23);


### PR DESCRIPTION
## Descripción

Se agrega un borde redondeado al componente `lite-youtube`, junto con una mejora en el color del borde (`border`), sombreado (`shadow`) y del icono de reproducción (`play`).

## Cambios propuestos

1. Se incorpora un borde redondeado para mejorar la estética (`class: rounded-lg`).
2. Mejora en el color de los siguientes elementos:
   1. `border`: Se utiliza el color específico de la aplicación.
   2. `shadow`: Se aplica el mismo color de la aplicación para el sombreado.
   3. `play`: Se añade el color correspondiente de la aplicación al ícono de reproducción al pasar el cursor sobre el componente.

## Capturas de pantalla (si corresponde)

***Antes***

![961shots_so](https://github.com/midudev/la-velada-web-oficial/assets/101532359/a43cb054-e7c8-4dd8-a93d-4eecf4684701)

***Ahora: No `hover`***:

![608shots_so](https://github.com/midudev/la-velada-web-oficial/assets/101532359/e04f1e1a-5876-4068-9822-87dd6ac1b9f0)

***Ahora:  `Hover`***:

![809shots_so](https://github.com/midudev/la-velada-web-oficial/assets/101532359/0a5953fd-a55a-419b-8eda-8f0b46d18e23)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
