### PR TITLE
Fix: Center TwitchLogo

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -10,7 +10,7 @@ import Typography from "@/components/Typography.astro"
 	<hr
 		class="-z-10 -mt-12 h-[2px] min-w-[20rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent sm:w-full sm:max-w-64 md:max-w-lg"
 	/>
-	<div class="-mt-11 transition duration-200 hover:scale-110 motion-safe:transition">
+	<div class="-mt-8 transition duration-200 hover:scale-110 motion-safe:transition md:-mt-11">
 		<a
 			href="https://www.twitch.tv/ibai"
 			target="_blank"


### PR DESCRIPTION
## Descripción

Se corrige al centrar verticalmente el logo de Twitch en diferentes dispositivos. Sin la necesidad de hacer cambios sustanciales al código. Además el efecto hover es visualmente atractivo al usuario.

## Capturas de pantalla (si corresponde)

### Antes:

<img width="220" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/57963142/bbcd3f1c-75a0-49cf-a4a8-10accd6634ba">


### Despues:

<img width="222" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/57963142/a98e2b6a-bbeb-45d4-af3a-07ba0485c927">

### Hover:

https://github.com/midudev/la-velada-web-oficial/assets/57963142/2996dfe7-a595-49e1-ba56-ae3a92efe41c

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora UX.