### PR TITLE
fix(#401): resizing bug on resize

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -211,6 +211,10 @@ const {
 			if (this.classList.contains("lyt-activated")) return
 			this.classList.add("lyt-activated")
 
+			if (this.style.backgroundImage !== "unset") {
+				this.style.backgroundImage = "unset"
+			}
+
 			if (this.needsYTApi) {
 				return this.addYTPlayerIframe(this.getParams())
 			}
@@ -378,7 +382,6 @@ const {
 	/* Post-click styles */
 	lite-youtube.lyt-activated {
 		cursor: unset;
-		background-image: unset !important;
 	}
 	lite-youtube.lyt-activated::before,
 	lite-youtube.lyt-activated > .lty-playbtn {

--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -378,6 +378,7 @@ const {
 	/* Post-click styles */
 	lite-youtube.lyt-activated {
 		cursor: unset;
+		background-image: unset !important;
 	}
 	lite-youtube.lyt-activated::before,
 	lite-youtube.lyt-activated > .lty-playbtn {


### PR DESCRIPTION
## Descripción

Al hacer click se oculta la imagen de previsualización de `src/components/LiteYouTube.astro`

## Problema solucionado

Al redimensionar el vídeo se quedaba la imagen por detrás y no se redimensionaba a la vez.

## Cambios propuestos

1. `background-image: unset !important`

## Capturas de pantalla (si corresponde)
Antes:

Ver el Issue #401

Después:

https://github.com/midudev/la-velada-web-oficial/assets/71392160/eda8074e-38ee-4b4e-b8a2-8d43da6a67fc

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

## Impacto potencial

Mejora del rendimiento y la experiencia de usuario

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
