### PR TITLE
Enhanced: Improved underline transition twitch link

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -33,12 +33,13 @@ import HeroLogo from "@/components/HeroLogo.astro"
 		width: 100%;
 		height: 3px;
 		background-color: white;
-		transform-origin: left;
+		transform-origin: right;
 		transform: scaleX(0);
 		transition: transform 0.2s ease-in-out;
 	}
 
 	a:hover::before {
 		transform: scaleX(1);
+		transform-origin: left;
 	}
 </style>


### PR DESCRIPTION
## Descripción

Mejorado la transición del subrayado en el hover, manteniendo la consistencia con la transición de subrayado del enlace del Santiago Bernabéu de la PR #375.

## Cambios propuestos

Cambio para que la transición del subrayado comience y termine de izquierda a derecha cambiando la propiedad por defecto a ```transform-origin: right;``` y al hacer hover cambie a ```transform-origin: left;```.

## Capturas de pantalla

### Antes

https://github.com/midudev/la-velada-web-oficial/assets/151189780/ae5ae639-4d35-4b48-868f-f8b184486655

### Después

https://github.com/midudev/la-velada-web-oficial/assets/151189780/f7fe2ce8-a045-4877-9218-84d9b9aceca2

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x]  He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.