### PR TITLE
fix: Eliminar zona muerta en anchor

### DIFF
--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -15,23 +15,14 @@ import Typography from "@/components/Typography.astro"
 			href="https://www.twitch.tv/ibai"
 			target="_blank"
 			rel="nofollow noopener"
-			class="mx-auto mb-8 flex flex-col items-center"
+			class="mx-auto flex flex-col items-center"
 			aria-hidden="true"
 			tabindex="-1"
-		>
-			<div class="w-14 md:w-20">
-				<TwitchLogo />
-			</div>
-		</a>
-
-		<a
-			class="flex flex-col items-center"
-			href="https://www.twitch.tv/ibai"
-			target="_blank"
-			rel="noopener"
-			title="Enlace al canal de Twitch de Ibai Llanos"
 			aria-label="Enlace al canal de Twitch de Ibai Llanos"
 		>
+			<div class="mb-8 w-14 md:w-20">
+				<TwitchLogo />
+			</div>
 			<span
 				class="-rotate-6 skew-x-6 text-center font-atomic text-xl text-white underline-offset-8 transition sm:text-3xl md:text-5xl"
 				>en directo


### PR DESCRIPTION
## Descripción

Cambié los dos anchors a solo uno en `Info.astro` para eliminar una zona muerta que había donde el anchor no funcionaba, a pesar de tener el efecto de hover como que sí funcionara. El estilo quedó idéntico.

## Capturas de pantalla (si corresponde)
 
Antes:

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/02f60adb-ef36-4132-bcc6-c57251832217)

Después:

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/d7758602-5580-46b7-94e2-2457e15a8f28)


## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.