### PR TITLE
doc: Ensure good practices and improve DX

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,6 +16,7 @@
 
 ## Comprobación de cambios
 
+- [ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
 - [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
 - [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
 - [ ] He actualizado la documentación, si corresponde.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@
 
 #### 2. Trabaja en tus cambios
 
+- **Sincroniza el fork**: Puedes hacerlo desde `github.com/tu-usuario/tu-repositorio-de-la-velada` y haciendo click en `Sync fork`. También puedes hacerlo desde la terminal `gh repo sync -b main` o `git checkout main && git fetch upstream && git merge upstream/main`. Más información en la [documentación oficial de Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)
 - **Crea una nueva rama**: Antes de empezar a trabajar en tus cambios, crea una nueva rama utilizando `git checkout -b nombre-de-tu-rama`.
 - **Desarrolla tus cambios**: Implementa tus cambios o mejoras en tu rama local. Asegúrate de seguir las prácticas y estándares de código del proyecto.
 - **Prueba tus cambios**: Ejecuta `pnpm run dev` para iniciar el servidor de desarrollo de Astro y revisa tus cambios en el navegador.
@@ -38,7 +39,8 @@
 
 ### Buenas prácticas 🌟
 
-- **Revisa los PRs abiertos** para asegurarte de que no estás trabajando en algo que ya está en progreso.
+- **Revisa los issues abiertos** antes de abrir una PR, si crees que puedes solucionarlo y no hay ninguna otra PR ya abierta, usa `#numero-de-la-issue` en tu commit para que se añada a la issue. No está demás dejar algún comentario para que se sepa que PR está siendo usada para la issue.
+- **Revisa los PRs abiertos** para asegurarte de que no estás trabajando en algo que ya está en progreso. Siempre puedes ayudar en PRs ya abiertas, aportando cambios, comentarios, revisiones, etc..
 - **Mantén tus commits limpios y descriptivos**.
 - **Sigue las convenciones de código del proyecto**.
 - **Actualiza tu rama con frecuencia** para mantenerla al día con la rama principal del proyecto.


### PR DESCRIPTION
## Descripción

Mantener a la comunidad unida a la hora de crear PRs

## Problema solucionado

Hay muchas PRs que se abren habiendo otras ya abiertas, en vez de aportar a las que están abiertas con comentarios, sugerencias, revisiones ...

## Cambios propuestos

1. Reducir número de PRs a revisar.
2. Fomentar colaborar entre personas en una misma PR si han tenido una idea similar.
3. Mejorar la experiencia de desarrollo, algunos comandos útiles.

## Capturas de pantalla (si corresponde)

<img width="683" alt="Screenshot 2024-03-10 at 09 14 57" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/18667418-16a7-4748-9171-f7c7f9949d18">

Estas 3 PRs tienen el mismo fin, cada una con su variante "artística" pero con el fin de crear cohesión con el diseño global de los links que se encuentran en la sección `Hero.astro`.

Estaría bien, ver que hay una primera abierta y trabajar las 3 personas en conjunto, en vez de crear PRs adicionales que hacen que haya más PRs a revisar.

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Reducir el número de PRs abiertas y que tienen que ser revisadas, fomentando una mejor experiencia para todos, contribuidores y mantenedores. También intentar fomentar el trabajo entre varias personas con ideas similares en una misma PR.

## Contexto adicional

No he añadido nada al respecto porque prefiero esperar a opiniones, pero deberíamos establecer unas normas básicas para los commits.

Ejemplo (en inglés):
- Empezar con verbos seguidos de `:`: `add:`, `fix:`, `feat:`, `doc:` ...
- Si hay una issue abierta añadir el número en la PR: `fix(#000):`, `feat(#000):` ...

## Enlaces útiles

- Documentación sobre sincronización de forks de [Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
