### PR TITLE
change player bar

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -204,6 +204,7 @@ const {
 			const params = new URLSearchParams(this.getAttribute("params") || [])
 			params.append("autoplay", "1")
 			params.append("playsinline", "1")
+			params.append("color", "white")
 			return params
 		}
 


### PR DESCRIPTION
## Descripción

He cambiado el color de la barra del reproductor del video.

## Cambios propuestos

La barra del reproductor del video en color blanco encaja mejor con el diseño de la web.

## Capturas de pantalla

Antes

![oldDesign](https://github.com/midudev/la-velada-web-oficial/assets/29683351/53750408-192c-40e6-907f-3313d89ab924)

Ahora

![newDesign](https://github.com/midudev/la-velada-web-oficial/assets/29683351/538e5971-79c5-4eb2-bd8b-fd4cb58b8ed5)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Enlaces útiles
- [Youtube API de IFrame](https://developers.google.com/youtube/player_parameters#Parameters)
- [Lite youtube embed](https://github.com/paulirish/lite-youtube-embed/tree/master)
