### PR TITLE
fix: Links are not crawable

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -82,8 +82,6 @@ const {
 
 			this.addNoscriptIframe()
 
-			playBtnEl.removeAttribute("href")
-
 			// On hover (or tap), warm up the TCP connections we're (likely) about to use.
 			this.addEventListener("pointerover", LiteYTEmbed.warmConnections, { once: true })
 


### PR DESCRIPTION
## Descripción

Para mejorar puntuación LightHouse ( SEO ). 

## Problema solucionado

Quitar el warning 'links are not crawable'.

> [!NOTE]  
> Production:
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/e6b3e902-a1ce-4722-80f5-e95718fcdb4b)

![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/f3a51550-7b9d-4527-9d2c-ea19fc40e77d)

## Cambios propuestos
Localhost:
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/7a22d078-5f6d-485a-9e8d-a522576ff6c6)
> [!NOTE]  
> El problema de 'Links do not have descriptive text' sólo me sale en local. 

## Capturas de pantalla (si corresponde)
Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/057b33dc-1580-42fc-9729-e05c9d86b290)
Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/0887f21b-92d1-410e-9be0-fabf86bac5eb)

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
