### PR TITLE
Ajusta color `hover` de algunos elementos

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -369,7 +369,7 @@ const {
 
 	lite-youtube:hover > .lty-playbtn,
 	lite-youtube .lty-playbtn:focus {
-		background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="greenyellow" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
+		background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="%23d5ff00" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
 		transition: 0.2s;
 		filter: none;
 		transform: scale(1.23);

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -27,7 +27,7 @@ import GithubIcon from "@/icons/github.astro"
 					rel="noopener"
 					aria-label="Instagram de la velada, se abrirá en una nueva pestaña"
 					href="https://www.instagram.com/infolavelada"
-					class="inline-block any-hover:scale-125 any-hover:opacity-70 motion-safe:transition"
+					class="inline-block any-hover:scale-125 motion-safe:transition"
 				>
 					<InstagramIcon class="text-primary transition-colors duration-300 hover:text-accent" />
 				</a>
@@ -38,7 +38,7 @@ import GithubIcon from "@/icons/github.astro"
 					rel="noopener"
 					aria-label="X de la velada, se abrirá en una nueva pestaña"
 					href="https://x.com/infoLaVelada"
-					class="inline-block any-hover:scale-125 any-hover:opacity-70 motion-safe:transition"
+					class="inline-block any-hover:scale-125 motion-safe:transition"
 				>
 					<XIcon class="text-primary transition-colors duration-300 hover:text-accent" />
 				</a>
@@ -49,7 +49,7 @@ import GithubIcon from "@/icons/github.astro"
 					rel="noopener"
 					aria-label="Github de la velada, se abrirá en una nueva pestaña"
 					href="https://github.com/midudev/la-velada-web-oficial"
-					class="inline-block any-hover:scale-125 any-hover:opacity-70 motion-safe:transition"
+					class="inline-block any-hover:scale-125 motion-safe:transition"
 				>
 					<GithubIcon class="text-primary transition-colors duration-300 hover:text-accent" />
 				</a>


### PR DESCRIPTION
## Descripción

Algunos elementos tenían una variante del color definido como `--color-accent`. Para mantener la uniformidad de colores en la página, se ajustaron algunos elementos que no coincidían con el original.

## Problema solucionado

El color del botón _play_ del reproductor del video de la Presentación de La Velada IV así como los iconos de enlace a Instagram, X y Github no utilizan el color `--color-accent`.

## Cambios propuestos

1. Se ajustó el atributo `fill` del SVG del componente LiteYouTube al estar en _hover_.
    Dado que no es posible utilizar variables de CSS en los atributos de un SVG insertado como `background-image`, y que es muy poco probable que la definición de `--color-accent` cambie pues es uno de los colores principales de la paleta de La Velada IV se escribió directamente el código hexadecimal de este.

2. Se eliminaron los `opacity` de los iconos de enlace a Instagram, X y Github.
   Esta opacidad se heredó del _landing page_ de la Presentación de La Velada, donde en su momento se tenían tonos grisáceos. Al hacer `hover` sobre los iconos, la opacidad hacía que resaltaran. Sin embargo, dada la nueva paleta de colores esta opacidad ya no es necesaria.

## Capturas de pantalla

- Antes:

  <img width="786" alt="Captura de pantalla 2024-03-10 a la(s) 11 37 34 p m" src="https://github.com/midudev/la-velada-web-oficial/assets/12474344/17398640-ee33-401d-9664-9a1ac71d55fc">

- Después:

  <img width="786" alt="Captura de pantalla 2024-03-10 a la(s) 11 37 12 p m" src="https://github.com/midudev/la-velada-web-oficial/assets/12474344/a1d4a614-9aca-4a29-9ed5-14e90dda0e2b">

## Comprobación de cambios

- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.