### PR TITLE
fix: different size of "ir a la tienda oficial" button

### DIFF
--- a/src/components/Date.astro
+++ b/src/components/Date.astro
@@ -25,7 +25,7 @@ const thirdDigitHeight = (1 / (maxThird + 1)) * 100
 <div
 	class:list=`w-full ${position} text-center -skew-x-6 flex flex-col items-center justify-center bg-gradient-to-b from-white/5 via-transparent to-transparent`
 >
-	<div class:list={["font-atomic relative flex overflow-hidden", wrapperClassName]} {...attribute}>
+	<div class:list={["relative flex overflow-hidden font-atomic", wrapperClassName]} {...attribute}>
 		<div class:list={`float-left block ${height} overflow-hidden`} data-first-group>
 			<div class="" data-wrapper>
 				{

--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -19,7 +19,7 @@ const {
 	tabindex="0"
 	role="button"
 >
-  <a
+	<a
 		href={`https://youtube.com/watch?v=${videoId}`}
 		class="lty-playbtn"
 		title={title}

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -11,7 +11,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 	</p>
 
 	<div
-		class="grid grid-cols-2 md:grid-cols-3 w-full flex-col items-center justify-center gap-y-20 uppercase text-primary gap-4 md:gap-x-6 md:gap-y-11"
+		class="grid w-full grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11"
 		data-date={EVENT_TIMESTAMP}
 		role="timer"
 	>

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -54,7 +54,14 @@ import Typography from "@/components/Typography.astro"
 			</Typography>
 		</div>
 		<div>
-			<Action as="a" href="https://lavelada.store/" target="_blank" rel="noopener noreferrer">
+			<Action
+				class="!w-full !text-base xs:!text-xl"
+				as="a"
+				href="https://lavelada.store/"
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label="Ir a la tienda oficial, se abrirá en una nueva pestaña"
+			>
 				Ir a la tienda oficial
 			</Action>
 		</div>


### PR DESCRIPTION
## Descripción

Arreglar el tamaño del nuevo boton para que sean los dos iguales.

## Problema solucionado

Arreglar el tamaño del nuevo boton para que sean los dos iguales.

## Cambios propuestos

- Usar el mismo Action component pero arreglar el size para que sean los mismos.

## Capturas de pantalla (si corresponde)

BEFORE: 
![image](https://github.com/midudev/la-velada-web-oficial/assets/18328629/9e17fe9d-6044-4e23-a604-5302ff149120)

AFTER:
![image](https://github.com/midudev/la-velada-web-oficial/assets/18328629/9b7a90be-ea30-4c62-b3b4-d14eb826040b)


## Comprobación de cambios

- [✅] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [✅] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [✅] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

## Impacto potencial

- none.