### PR TITLE
Fix README and CONTRIBUTING - Replace git checkout with git switch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,8 +26,8 @@
 
 #### 2. Trabaja en tus cambios
 
-- **Sincroniza el fork**: Puedes hacerlo desde `github.com/tu-usuario/tu-repositorio-de-la-velada` y haciendo click en `Sync fork`. También puedes hacerlo desde la terminal `gh repo sync -b main` o `git checkout main && git fetch upstream && git merge upstream/main`. Más información en la [documentación oficial de Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)
-- **Crea una nueva rama**: Antes de empezar a trabajar en tus cambios, crea una nueva rama utilizando `git checkout -b nombre-de-tu-rama`.
+- **Sincroniza el fork**: Puedes hacerlo desde `github.com/tu-usuario/tu-repositorio-de-la-velada` y haciendo click en `Sync fork`. También puedes hacerlo desde la terminal `gh repo sync -b main` o `git switch main && git fetch upstream && git merge upstream/main`. Más información en la [documentación oficial de Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)
+- **Crea una nueva rama**: Antes de empezar a trabajar en tus cambios, crea una nueva rama utilizando `git switch -b nombre-de-tu-rama`.
 - **Desarrolla tus cambios**: Implementa tus cambios o mejoras en tu rama local. Asegúrate de seguir las prácticas y estándares de código del proyecto.
 - **Prueba tus cambios**: Ejecuta `pnpm run dev` para iniciar el servidor de desarrollo de Astro y revisa tus cambios en el navegador.
 
@@ -51,4 +51,3 @@
 Si tienes alguna pregunta o necesitas ayuda, no dudes en abrir un "issue" en el repositorio. Nuestro equipo y la comunidad estarán encantados de ayudarte.
 
 ¡Gracias por contribuir a 'La velada del año 4'! Juntos estamos construyendo algo increíble. 🚀
-

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@
 #### 2. Trabaja en tus cambios
 
 - **Sincroniza el fork**: Puedes hacerlo desde `github.com/tu-usuario/tu-repositorio-de-la-velada` y haciendo click en `Sync fork`. También puedes hacerlo desde la terminal `gh repo sync -b main` o `git switch main && git fetch upstream && git merge upstream/main`. Más información en la [documentación oficial de Github](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork)
-- **Crea una nueva rama**: Antes de empezar a trabajar en tus cambios, crea una nueva rama utilizando `git switch -b nombre-de-tu-rama`.
+- **Crea una nueva rama**: Antes de empezar a trabajar en tus cambios, crea una nueva rama utilizando `git switch -c nombre-de-tu-rama`.
 - **Desarrolla tus cambios**: Implementa tus cambios o mejoras en tu rama local. Asegúrate de seguir las prácticas y estándares de código del proyecto.
 - **Prueba tus cambios**: Ejecuta `pnpm run dev` para iniciar el servidor de desarrollo de Astro y revisa tus cambios en el navegador.
 

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Aquí tienes una guía rápida:
 1. Haz un [_fork_](https://github.com/midudev/la-velada-web-oficial/fork) del Proyecto
 2. Clona tu [_fork_](https://github.com/midudev/la-velada-web-oficial/fork) (`git clone <URL del fork>`)
 3. Añade el repositorio original como remoto (`git remote add upstream <URL del repositorio original>`)
-4. Crea tu Rama de Funcionalidad (`git switch -b feature/CaracteristicaIncreible`)
+4. Crea tu Rama de Funcionalidad (`git switch -c feature/CaracteristicaIncreible`)
 5. Realiza tus Cambios (`git commit -m 'Add: alguna CaracterísticaIncreible'`)
 6. Haz Push a la Rama (`git push origin feature/CaracteristicaIncreible`)
 7. Abre una [_pull request_](https://github.com/midudev/la-velada-web-oficial/pulls)

--- a/README.md
+++ b/README.md
@@ -52,11 +52,11 @@ La Velada IV es una competición de boxeo que enfrenta a streamers, creadores de
 
 - NVM (recomendado para asegurar versión de Node) ver [documentación oficial](https://github.com/nvm-sh/nvm?tab=readme-ov-file#installing-and-updating)
 
-	```sh
-	nvm use
-	# o
-	nvm use <version>
-	```
+  ```sh
+  nvm use
+  # o
+  nvm use <version>
+  ```
 
 > Si quieres automatizar el proceso, puedes crear un script siguiendo la [documentación oficial](https://github.com/nvm-sh/nvm?tab=readme-ov-file#calling-nvm-use-automatically-in-a-directory-with-a-nvmrc-file)
 
@@ -105,7 +105,7 @@ Aquí tienes una guía rápida:
 1. Haz un [_fork_](https://github.com/midudev/la-velada-web-oficial/fork) del Proyecto
 2. Clona tu [_fork_](https://github.com/midudev/la-velada-web-oficial/fork) (`git clone <URL del fork>`)
 3. Añade el repositorio original como remoto (`git remote add upstream <URL del repositorio original>`)
-4. Crea tu Rama de Funcionalidad (`git checkout -b feature/CaracteristicaIncreible`)
+4. Crea tu Rama de Funcionalidad (`git switch -b feature/CaracteristicaIncreible`)
 5. Realiza tus Cambios (`git commit -m 'Add: alguna CaracterísticaIncreible'`)
 6. Haz Push a la Rama (`git push origin feature/CaracteristicaIncreible`)
 7. Abre una [_pull request_](https://github.com/midudev/la-velada-web-oficial/pulls)


### PR DESCRIPTION
## Descripción

Actualicé la documentación del proyecto cambiando `git checkout` por `git switch` tanto en el README como en el CONTRIBUTING

## Cambios propuestos

Actualización de la documentación

## Comprobación de cambios

- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Contexto adicional

Git recomienda usar `switch` en vez de `checkout`
