### PR TITLE
feat: add Sponsor ID types to add type checking to sponsors list

### DIFF
--- a/src/consts/sponsors.ts
+++ b/src/consts/sponsors.ts
@@ -1,5 +1,17 @@
+type SporsorsId =
+	| "vicio"
+	| "revolut"
+	| "prime"
+	| "alsa"
+	| "spotify"
+	| "cerave"
+	| "el-pozo"
+	| "grefusa"
+	| "maxibon"
+	| "infojobs"
+
 interface Sponsors {
-	id: string
+	id: SporsorsId
 	name: string
 	url: string
 	image: {


### PR DESCRIPTION
## Descripción

Se adiciono un typo para el ID del Objeto Sponsors para facilitar el checkeo de tipos cuando se utiliza el identificador como comparador

## Problema solucionado

Adicionada mas compatibilidad en el checkeo de tipos de typescript

## Cambios propuestos

1.  Se creo un tipo llamado: SponsorsId
2. Se le asigno el tipo a la propiedad id del Sponsors

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejoras en el tipado
