### PR TITLE
feat: add reduced motion support

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,3 @@
+. "$(dirname -- "$0")/_/husky.sh"
+
+pnpm exec commitlint --edit

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: ["@commitlint/config-conventional"]
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "@astrojs/check": "0.5.6",
     "@astrojs/tailwind": "5.1.0",
     "@astrojs/vercel": "7.3.5",
+    "@commitlint/cli": "19.0.3",
+    "@commitlint/config-conventional": "19.0.3",
     "@midudev/tailwind-animations": "0.0.7",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",

--- a/src/components/Date.astro
+++ b/src/components/Date.astro
@@ -25,7 +25,7 @@ const thirdDigitHeight = (1 / (maxThird + 1)) * 100
 <div
 	class:list=`w-full ${position} text-center -skew-x-6 flex flex-col items-center justify-center bg-gradient-to-b from-white/5 via-transparent to-transparent`
 >
-	<div class:list={["font-atomic relative flex overflow-hidden", wrapperClassName]} {...attribute}>
+	<div class:list={["relative flex overflow-hidden font-atomic", wrapperClassName]} {...attribute}>
 		<div class:list={`float-left block ${height} overflow-hidden`} data-first-group>
 			<div class="" data-wrapper>
 				{

--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -19,7 +19,7 @@ const {
 	tabindex="0"
 	role="button"
 >
-  <a
+	<a
 		href={`https://youtube.com/watch?v=${videoId}`}
 		class="lty-playbtn"
 		title={title}

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -11,7 +11,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 	</p>
 
 	<div
-		class="grid grid-cols-2 md:grid-cols-3 w-full flex-col items-center justify-center gap-y-20 uppercase text-primary gap-4 md:gap-x-6 md:gap-y-11"
+		class="grid w-full grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11"
 		data-date={EVENT_TIMESTAMP}
 		role="timer"
 	>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -42,4 +42,23 @@ import HeroLogo from "@/components/HeroLogo.astro"
 		transform: scaleX(1);
 		transform-origin: left;
 	}
+	@media (prefers-reduced-motion) {
+		a::before {
+			content: "";
+			position: absolute;
+			left: 0;
+			bottom: -2px;
+			width: 100%;
+			height: 3px;
+			background-color: white;
+			transform-origin: right;
+			transform: scaleX(0);
+			transition: transform 0s;
+		}
+
+		a:hover::before {
+			transform: scaleX(1);
+			transform-origin: left;
+		}
+	}
 </style>

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -181,4 +181,18 @@ import Typography from "@/components/Typography.astro"
 		background-size: 100% 3px;
 		background-position: 0 100%;
 	}
+	@media (prefers-reduced-motion) {
+		.underline-transition {
+			background-image: linear-gradient(transparent, transparent),
+				linear-gradient(var(--color-accent) 20%, var(--color-accent) 80%);
+			background-size: 0 3px;
+			background-position: 100% 100%;
+			background-repeat: no-repeat;
+			transition: background-size 0s;
+		}
+		.underline-transition:hover {
+			background-size: 100% 3px;
+			background-position: 0 100%;
+		}
+	}
 </style>


### PR DESCRIPTION
## Descripción

Añadido soporte para reducción de animaciones.

## Problema solucionado

Con los cambios introducidos para la consistencia de links, no se añadió soporte a las personas que tenga activada la reducción de animaciones.

## Cambios propuestos

1. Añadir `@media (prefers-reduced-motion)`
2. Como en la PR #422, se podría crear un estilo global con ello. (A la espera de comentarios para implementarlo o ayudar en esa PR)

## Capturas de pantalla (si corresponde)

Sin reduced motion:

https://github.com/midudev/la-velada-web-oficial/assets/71392160/1ecab578-b8c3-4421-a313-d94ebab1c167

Con reduced motion:

https://github.com/midudev/la-velada-web-oficial/assets/71392160/37892a9f-815a-4e57-89b3-587d697ea594

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la accesibilidad de las personas que tengan reducción de animaciones.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
