### PR TITLE
feat: 404 modified design

### DIFF
--- a/src/components/Date.astro
+++ b/src/components/Date.astro
@@ -25,7 +25,7 @@ const thirdDigitHeight = (1 / (maxThird + 1)) * 100
 <div
 	class:list=`w-full ${position} text-center -skew-x-6 flex flex-col items-center justify-center bg-gradient-to-b from-white/5 via-transparent to-transparent`
 >
-	<div class:list={["font-atomic relative flex overflow-hidden", wrapperClassName]} {...attribute}>
+	<div class:list={["relative flex overflow-hidden font-atomic", wrapperClassName]} {...attribute}>
 		<div class:list={`float-left block ${height} overflow-hidden`} data-first-group>
 			<div class="" data-wrapper>
 				{

--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -19,7 +19,7 @@ const {
 	tabindex="0"
 	role="button"
 >
-  <a
+	<a
 		href={`https://youtube.com/watch?v=${videoId}`}
 		class="lty-playbtn"
 		title={title}

--- a/src/sections/Error.astro
+++ b/src/sections/Error.astro
@@ -9,17 +9,14 @@ const { error, message, contextMessage } = Astro.props
 <section
 	class="m-auto flex w-full flex-wrap place-items-center items-center justify-center text-primary"
 >
-	<HeroLogo
-		class="m-5 h-auto w-[300px] overflow-visible text-primary animate-duration-0 md:w-[500px]"
-		disableAnimation
-	/>
+	<a href="/">
+		<HeroLogo
+			class="m-5 h-auto w-[300px] overflow-visible text-primary animate-duration-0 md:w-[500px]"
+			disableAnimation
+		/>
+	</a>
 	<div class="m-5 mt-16 text-center">
-		<Typography
-			as="h1"
-			variant="atomic-title"
-			color="neutral"
-			class:list={"mb-10 font-bold text-white"}
-		>
+		<Typography as="h1" variant="atomic-title" color="primary" class:list={"mb-10 font-bold"}>
 			error {error}
 		</Typography>
 		<Typography as="h2" variant="h2" color="neutral" class:list={"text-white"}>


### PR DESCRIPTION
## Descripción

Añadir el `--color-accent` al tipo de error y hacer logo clicable.

## Problema solucionado

Hasta ahora, quedaba muy plano. Con este cambio se asegura mejor reconocimiento del error y mejorar la experiencia de usuario, habilitando el uso del logo como volver a la landing.

## Capturas de pantalla (si corresponde)

Antes:

<img width="964" alt="Screenshot 2024-03-11 at 17 29 27" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/404c169d-2715-40aa-8425-f65ec6d31b5d">

Después:

<img width="964" alt="Screenshot 2024-03-11 at 17 29 21" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/781d26a0-1e35-47d1-97c7-f060fbcd0f12">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar el reconocimiento de errores y la experiencia del usuario. Al ser una práctica extendida el uso del logo como vuelta a la landing.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
