### PR TITLE
fix: add select-none to ImageOverlay img

### DIFF
--- a/src/components/ImageOverlay.astro
+++ b/src/components/ImageOverlay.astro
@@ -18,7 +18,7 @@ interface Props {
 			<img
 				src={Astro.props.imgSrc}
 				alt={Astro.props.imgAlt}
-				class="max-h-full max-w-full object-cover"
+				class="max-h-full max-w-full select-none object-cover"
 			/>
 		</div>
 		<div class="content mt-1 text-center">


### PR DESCRIPTION
## Descripción

Añadido select-none a ImageOverlay para seguir la línea de diseño de no poder seleccionar imágenes.

## Capturas de pantalla (si corresponde)

Antes

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/89fbafa2-16c8-4a92-9ebf-85fd37fba314)

Después

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/dc7196f2-eb9d-4a43-ac0c-9c092c5c33b3)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

