### PR TITLE
feat: Improve ImageOverlay

### DIFF
--- a/src/components/ImageOverlay.astro
+++ b/src/components/ImageOverlay.astro
@@ -11,7 +11,9 @@ interface Props {
 	class="image-overlay relative mb-24 w-full flex-col sm:mt-28"
 	style="background: linear-gradient(180deg, #222222 0%, rgba(17, 17, 17, 0) 61.5%);"
 >
-	<div class="flex flex-col items-center justify-center pt-24 sm:w-full">
+	<div
+		class="flex flex-col items-center justify-center pt-24 transition-transform duration-100 hover:scale-105 sm:w-full"
+	>
 		<div
 			class="image-container absolute left-1/2 top-0 flex h-56 w-56 -translate-x-1/2 -translate-y-1/2 transform items-center justify-center overflow-hidden rounded-full"
 		>
@@ -23,7 +25,7 @@ interface Props {
 		</div>
 		<div class="content mt-1 text-center">
 			<h1 class="title mb-0.5 text-xl" style="color: var(--color-accent);">{Astro.props.title}</h1>
-			<p class="description text-xs text-gray-400">{Astro.props.description}</p>
+			<p class="description text-sm text-gray-400">{Astro.props.description}</p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
## Descripción

Agregué una sutil animación de hover y aumenté ligeramente el tamaño de la descripción en ImageOverlay ya que era muy pequeña y difícil de leer.

## Cambios propuestos

- Agregada animación hover que aumenta el tamaño del div un 5% con corta duración
- Cambiado tamaño de texto de la descripción de xs a sm

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
