### PR TITLE
feat: add lint staged pre commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,1 @@
-#!/usr/bin/env sh
-. "$(dirname "$0")/_/husky.sh"
-
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,4 @@
-npm run lint
-npm run format:check
+#!/usr/bin/env sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,6 @@
+{
+	"src/**/*.{astro,ts,js,tsx,jsx}": [
+			"eslint --ext",
+			"prettier --check"
+		]
+}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint-plugin-jsx-a11y": "6.8.0",
     "husky": "9.0.11",
     "lightningcss": "1.24.0",
+    "lint-staged": "15.2.2",
     "postcss-nesting": "12.1.0",
     "prettier": "3.2.5",
     "prettier-plugin-astro": "0.13.0",


### PR DESCRIPTION
## Descripción

Como me dijo @joelmh-112 en 2 PRs, tenía que añadir cambios porque prettier se quejaba de fallos de formato en archivos en los que no estaba trabajando.

## Problema solucionado

Con [lint-staged](https://github.com/lint-staged/lint-staged), este problema se solucionaría.

Además de mejorar la experiencia de desarrollo.

## Cambios propuestos

1. Solo lintear y comprobar en archivos que se van a añadir al commit.
2. Reducción de tiempos de espera a la hora de de hacer un commit, ya que no mirará en todos los archivos, solo los que estén `staged` o añadidos al commit.

## Capturas de pantalla (si corresponde)

Vídeo sobre esta dependecia:

<a href="https://www.youtube.com/watch?v=YWBrzwSDp" target="_blank" rel="noopener noreferrer">
<img alt="Vídeo sobre lint-staged con husky" src="https://i.ytimg.com/vi/YWBrzwSDpo8/maxresdefault.jpg" />
</a>


## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Reducir tiempo en el desarrollo y asegurar que no se producen commits innecesarios.

Mejorar la adición de features como por ejemplo: si añadimos test, simplemente añadir el comando del test que utilicemos a lint-staged, evitando así modificar el pre-commit.

## Contexto adicional

`.lintstagedrc` se puede transformar en una clave dentro de `package.json` si se prefiere.

```json
"lint-staged": {
  "src/**/*.{astro,ts,js,tsx,jsx}": [
      "eslint --ext",
      "prettier --check"
  ]
}
```

## Enlaces útiles

- Documentación del proyecto: [GitHub de lint-staged](https://github.com/lint-staged/lint-staged), [Vídeo sobre el uso](https://www.youtube.com/watch?v=YWBrzwSDp)
