### PR TITLE
Corrige parpadeo del botón 'play' en Safari

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -379,7 +379,6 @@ const {
 		background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="greenyellow" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
 		filter: none;
 		transform: scale(1.23);
-		transition: 0.2s;
 	}
 
 	@media (prefers-reduced-motion) {


### PR DESCRIPTION
## Descripción

Anteriormente al hacer `hover` sobre el botón de _play_ del video de la Presentación de La Velada, se mostraba en Safari un parpadeo.

## Problema solucionado

En Safari, el botón de _play_ del reproductor del video de La Velada parpadea al hacerle `hover`.

## Cambios propuestos

1. Se eliminó una propiedad de transición declarada para las clases `lite-youtube:hover > .lty-playbtn, ite-youtube .lty-playbtn:focus`. Esta propiedad queda implícitamente definida en `lite-youtube > .lty-playbtn`, provocando que Safari malinterprete el efecto.

## Capturas de pantalla
(Se cambió el color del icono en el video para hacer más evidente el parpadeo).

- Antes:

  https://github.com/midudev/la-velada-web-oficial/assets/12474344/69e60bf2-7ca4-4be7-b533-6be48d6e1a2f

  _El parpadeo se da en este punto_:
  <img width="226" alt="Captura de pantalla 2024-03-11 a la(s) 6 28 56 p m" src="https://github.com/midudev/la-velada-web-oficial/assets/12474344/e2d8b9da-97ba-43f7-892c-8cd26f8fb4db">

- Ahora:

  https://github.com/midudev/la-velada-web-oficial/assets/12474344/12cc893c-37b6-4caa-be43-8db8401c6dc2

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.