### PR TITLE
Fix images path to relative URL in head

### DIFF
--- a/src/components/RichResults.astro
+++ b/src/components/RichResults.astro
@@ -6,13 +6,13 @@ const organizationSchema = {
 	"@context": "https://schema.org",
 	"@type": "Organization",
 	"url": "https://lavelada.es",
-	"image": "https://lavelada.es/og.png",
+	"image": "/og.png",
 	"sameAs": [
 		"https://www.instagram.com/infolavelada",
 		"https://x.com/infoLaVelada",
 		"https://github.com/midudev/la-velada-web-oficial",
 	],
-	"logo": "https://lavelada.es/img/logo.png",
+	"logo": "/img/logo.png",
 	"name": "La Velada del Año 4",
 	"alternateName": "La Velada del Año IV",
 	"description":
@@ -40,7 +40,7 @@ const eventSchema = {
 			"addressCountry": "ES",
 		},
 	},
-	"image": ["https://lavelada.es/og.png"],
+	"image": ["/og.png"],
 	"description":
 		"La Velada del Año es un evento de boxeo aficionado entre streamers, creadores de contenido y celebridades, organizado por Ibai Llanos.",
 	/* "offers": {}, // Añadir cuando las entradas estén disponibles https://schema.org/Offer */

--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -35,9 +35,9 @@ const { title, description, preloadImgLCP } = Astro.props
 <meta name="twitter:creator" content="@IbaiLlanos" />
 <meta name="twitter:title" content={title} />
 <meta name="twitter:description" content={description} />
-<meta name="twitter:image" content="https://lavelada.es/og.jpg" />
+<meta name="twitter:image" content="/og.jpg" />
 
-<meta name="og:image" content="https://lavelada.es/og.jpg" />
+<meta name="og:image" content="/og.jpg" />
 <meta name="og:title" content={title} />
 <meta name="og:description" content={description} />
 <meta name="og:url" content="https://lavelada.es" />
@@ -76,10 +76,12 @@ const { title, description, preloadImgLCP } = Astro.props
 
 <!-- Worker Registration -->
 {
-  !import.meta.env.DEV && (
-    <script is:inline src="/registerSW.js"></script>
-    <link rel="manifest" href="/manifest.webmanifest" />
-  )
+	!import.meta.env.DEV && (
+		<>
+			<script is:inline src="/registerSW.js" />
+			<link rel="manifest" href="/manifest.webmanifest" />
+		</>
+	)
 }
 
 <RichResults />


### PR DESCRIPTION
## Descripción

Se corrigio la dirección de la imagen en las etiquetas meta og

## Problema solucionado

La url apuntaba a https://lavelada.es/og.jpg lo cual daba un 404. Se cambio a "/og.jpg"

## Cambios propuestos

<meta name="twitter:image" content="/og.jpg" />

## Comprobación de cambios

- [ x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
