### PR TITLE
fix: los números superiores e inferiores de la cuenta atrás podían seleccionarse con el ratón

### DIFF
--- a/src/components/Date.astro
+++ b/src/components/Date.astro
@@ -32,7 +32,7 @@ const thirdDigitHeight = (1 / (maxThird + 1)) * 100
 					Array.from({ length: maxFirst + 1 }, () => 0).map((_, index) => (
 						// + 1 porque hay que tener en cuenta el 0 para las transiciones
 						<div data-num={index} style={`height: ${firstDigitHeight}%`}>
-							<span class:list={`tabular-nums ${className}`}>{index}</span>
+							<span class:list={`tabular-nums ${className} block h-fit overflow-hidden`}>{index}</span>
 						</div>
 					))
 				}
@@ -50,7 +50,7 @@ const thirdDigitHeight = (1 / (maxThird + 1)) * 100
 					Array.from({ length: maxSecond + 1 }, () => 0).map((_, index) => (
 						// + 1 porque hay que tener en cuenta el 0 para las transiciones
 						<div data-num={index} style={`height: ${secondDigitHeight}%`}>
-							<span class:list={`tabular-nums ${className}`}>{index}</span>
+							<span class:list={`tabular-nums ${className} block h-fit overflow-hidden`}>{index}</span>
 						</div>
 					))
 				}
@@ -72,7 +72,7 @@ const thirdDigitHeight = (1 / (maxThird + 1)) * 100
 						{Array.from({ length: maxThird + 1 }, () => 0).map((_, index) => (
 							// + 1 porque hay que tener en cuenta el 0 para las transiciones
 							<div data-num={index} style={`height: ${thirdDigitHeight}%`}>
-								<span class:list={`tabular-nums ${className}`}>{index}</span>
+								<span class:list={`tabular-nums ${className} block h-fit overflow-hidden`}>{index}</span>
 							</div>
 						))}
 						<div


### PR DESCRIPTION
## Descripción

Arreglado error, los números superiores e inferiores de la cuenta atrás podían seleccionarse con el ratón

## Problema solucionado

los números superiores e inferiores de la cuenta atrás podían seleccionarse con el ratón

## Cambios propuestos

corregir la altura de su span y añadir display: hidden

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/102947598/7f32a7d7-68be-4cad-ac81-1ba5e221ebe8)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

