### PR TITLE
[FIX] overflow hidden reverted error

### DIFF
--- a/src/sections/PresentationVideo.astro
+++ b/src/sections/PresentationVideo.astro
@@ -4,7 +4,7 @@ import LiteYouTube from "@/components/LiteYouTube.astro"
 import Typography from "@/components/Typography.astro"
 ---
 
-<section class="mt-10 px-2 pb-32 pt-16 sm:pb-56 sm:pt-20 md:pb-96 md:pt-60">
+<section class="mt-10 overflow-hidden px-2 pb-32 pt-16 sm:pb-56 sm:pt-20 md:pb-96 md:pt-60">
 	<Typography as="h3" variant="h3" color="white" class:list={"text-center"}>
 		Presentación
 	</Typography>


### PR DESCRIPTION
Se había quitado el overflow hidden de la seccion presentation video en una pr que tocaba un montón de cosas. Hay que ponerlo para que no se rompa el responsive de dicha sección, ya que hace que toda la web se vea mal.