### PR TITLE
feat: add scrollbar style when webkit-scrollbar is not supported

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -80,28 +80,37 @@ scroll-behavior: smooth;
 				width: 1px;
 			}
 
-			::-webkit-scrollbar {
-				width: 10px;
-				border-radius: 10px;
+			@supports selector(::-webkit-scrollbar) {
+				::-webkit-scrollbar {
+					width: 10px;
+					border-radius: 10px;
+				}
+
+				::-webkit-scrollbar-thumb {
+					border-radius: 10px;
+					background-color: theme("colors.primary");
+					border: 2px solid transparent;
+					background-clip: content-box;
+				}
+
+				::-webkit-scrollbar-thumb:active {
+					background-color: #666;
+				}
+
+				::-webkit-scrollbar-track {
+					background: var(--background-image);
+				}
+
+				::-webkit-scrollbar-corner {
+					background: var(--background-image);
+				}
 			}
 
-			::-webkit-scrollbar-thumb {
-				border-radius: 10px;
-				background-color: theme("colors.primary");
-				border: 2px solid transparent;
-				background-clip: content-box;
-			}
-
-			::-webkit-scrollbar-thumb:active {
-				background-color: #666;
-			}
-
-			::-webkit-scrollbar-track {
-				background: var(--background-image);
-			}
-
-			::-webkit-scrollbar-corner {
-				background: var(--background-image);
+			@supports not selector(::-webkit-scrollbar) {
+				* {
+					scrollbar-color: theme("colors.primary") transparent;
+					scrollbar-width: thin;
+				}
 			}
 		</style>
 	</body>


### PR DESCRIPTION
## Descripción

Añadido estilos al scrollbar cuando el selector `::webkit-scrollbar` no está soportado, como por ejemplo en Firefox. Priorizando los estilos del **webkit-scrollbar** cuando esté soportado.

## Cambios propuestos

Utilizar el `@supports selector(::-webkit-scrollbar)` y el `@supports not selector(::-webkit-scrollbar)` para aplicar los estilos al scrollbar.

## Capturas de pantalla (si corresponde)
- Antes

![scroll-bar-firefox-antes](https://github.com/midudev/la-velada-web-oficial/assets/151189780/3f30cd6f-a8c8-4683-8845-a22aaf3c0d16)

- Después

![scroll-bar-firefox-despues](https://github.com/midudev/la-velada-web-oficial/assets/151189780/fab74a92-63b0-4d03-b5ca-a00929dbf22f)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.