### PR TITLE
style: add radial-gradient to the boxer background image

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -39,7 +39,7 @@ const msFadeLuchador = 150
 					style="
 						background-image: url('/img/effects/boxer-background.png');
 						background-size: 75%;
-						mask-image: linear-gradient(to bottom, black 50%, transparent 80%);
+						mask-image: radial-gradient(circle at bottom, transparent 26%, #000 40%);
 						"
 				>
 				</div>


### PR DESCRIPTION
## Descripción

Linear gradient toma más espacio del que debería 

## Problema solucionado

Cambio el linear-gradient del fondo de los boxeadores por el radial

## Cambios propuestos



## Capturas de pantalla (si corresponde)

![Captura de pantalla 2024-03-12 a las 2 36 30 p  m](https://github.com/midudev/la-velada-web-oficial/assets/56264829/77059172-1595-49ee-9a29-b22cdb4fc48b)

## Comprobación de cambios

- [ ✅] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [✅ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ✅] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
