### PR TITLE
Add active class to boxer links and update image filter

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -146,7 +146,7 @@ const msFadeLuchador = 150
 	boxerLinks.forEach((link) => {
 		link.addEventListener("mouseenter", (event) => {
 			const { id, name, country, countryName } = (event.currentTarget as HTMLElement)?.dataset
-
+			link.classList.add("active")
 			setTimeout(
 				() => {
 					const boxerSrc = `/img/boxers/${id}-big`
@@ -161,6 +161,9 @@ const msFadeLuchador = 150
 				},
 				article.getAttribute("data-transition-duration") as unknown as number
 			)
+		})
+		link.addEventListener("mouseleave", () => {
+			link.classList.remove("active")
 		})
 	})
 </script>
@@ -224,7 +227,14 @@ const msFadeLuchador = 150
 	.boxer-link:hover .boxer-image {
 		transform: scale(1.05);
 	}
+	.boxer-link .boxer-image {
+		filter: grayscale(100%);
+		transition: filter 0.3s ease;
+	}
 
+	.boxer-link.active .boxer-image {
+		filter: grayscale(0%);
+	}
 	.boxer-link:hover .boxer-link-background {
 		filter: brightness(0.5);
 	}


### PR DESCRIPTION
## Descripción

Agregar efecto de blanco y negro a color cuando el boxeador esta activo


## Cambios propuestos

Agregado la class active al box-link cuando hace mouseenter y un mouseleave para quitar la class de esta forma tendremos a todos los boxeadores desactivados y el cuando hagamos hover se vera como seleccionado

## Capturas de pantalla (si corresponde)

![CleanShot 2024-03-12 at 21 39 32@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/669e2627-f2aa-448c-bcad-d225c389862f)

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.