### PR TITLE
Arreglando la imagen fallback de SelectYourBoxer

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -51,7 +51,7 @@ const msFadeLuchador = 150
 					<img
 						class:list={"boxer-photo h-auto object-contain px-10 sm:w-[30vw] sm:px-0 xl:w-[19vw] 3xl:h-[600px] 3xl:w-[480px]"}
 						alt="Fotografía de El Mariana"
-						src="/img/boxers/el-mariana-big.avif"
+						src="/img/boxers/el-mariana-big.wepb"
 						style="
 							filter: drop-shadow(0 0 20px rgba(0, 0, 0, .5));
 							mask-image: linear-gradient(to bottom, black 80%, transparent 100%);


### PR DESCRIPTION
## Descripción

He cambiado el fallback de .avif a .webp ya que tanto la etiqueta source como la etiqueta img apuntaban al mismo recurso.

## Problema solucionado

En principio ponemos los dos por si el navegador no puede cargar uno de ellos

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
