### PR TITLE
Update ImageOverlay Height

### DIFF
--- a/src/components/ImageOverlay.astro
+++ b/src/components/ImageOverlay.astro
@@ -17,7 +17,7 @@ const { className, imgSrc, imgAlt, title, description } = Astro.props
 	]}
 	style="background: linear-gradient(180deg, transparent 0%, transparent 21%, #222222 20%, rgba(17, 17, 17, 0) 90%);"
 >
-	<img src={imgSrc} alt={imgAlt} class="h-40 w-full select-none object-cover" />
+	<img src={imgSrc} alt={imgAlt} class="h-40 w-auto select-none object-cover" />
 	<div class="content mt-1 text-center">
 		<h1 class="title mb-0.5 text-xl font-semibold text-accent lg:text-3xl">
 			{title}

--- a/src/components/ImageOverlay.astro
+++ b/src/components/ImageOverlay.astro
@@ -11,14 +11,13 @@ const { className, imgSrc, imgAlt, title, description } = Astro.props
 ---
 
 <div
-	class:list={[className, "relative flex h-full w-full flex-col items-center justify-center gap-5 px-8 sm:w-full md:px-20 lg:px-28"]}
+	class:list={[
+		className,
+		"relative flex h-full w-full flex-col items-center justify-center gap-5 px-8 sm:w-full md:px-20 lg:px-28",
+	]}
 	style="background: linear-gradient(180deg, transparent 0%, transparent 21%, #222222 20%, rgba(17, 17, 17, 0) 90%);"
 >
-	<img
-		src={imgSrc}
-		alt={imgAlt}
-		class="h-auto w-full select-none object-cover"
-	/>
+	<img src={imgSrc} alt={imgAlt} class="h-40 w-auto select-none object-cover" />
 	<div class="content mt-1 text-center">
 		<h1 class="title mb-0.5 text-xl font-semibold text-accent lg:text-3xl">
 			{title}

--- a/src/components/ImageOverlay.astro
+++ b/src/components/ImageOverlay.astro
@@ -17,7 +17,7 @@ const { className, imgSrc, imgAlt, title, description } = Astro.props
 	]}
 	style="background: linear-gradient(180deg, transparent 0%, transparent 21%, #222222 20%, rgba(17, 17, 17, 0) 90%);"
 >
-	<img src={imgSrc} alt={imgAlt} class="h-40 w-auto select-none object-cover" />
+	<img src={imgSrc} alt={imgAlt} class="h-40 w-full select-none object-cover" />
 	<div class="content mt-1 text-center">
 		<h1 class="title mb-0.5 text-xl font-semibold text-accent lg:text-3xl">
 			{title}


### PR DESCRIPTION
## Descripción

He cambiado el Height del componente ImageOverlay

## Problema solucionado

Al estar el Height en auto, los textos no cuadraban entre si. He puesto que este sea de 40 y asi estas se ven en linea (tambien cambie el w-full a w-auto por que sino la imagen se corta)

## Capturas de pantalla (si corresponde)

Antes:
![Antes](https://i.imgur.com/ZG27h0e.png)

Después:
![Despues](https://i.imgur.com/HvdOK5U.png)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
