### PR TITLE
Fix: Precarga de la fuente Atomic para evitar salto de fuente

### DIFF
--- a/src/components/SEO.astro
+++ b/src/components/SEO.astro
@@ -1,5 +1,7 @@
 ---
+import atomic from "/fonts/atomic.woff2"
 import jost from "@fontsource-variable/jost/files/jost-latin-wght-normal.woff2"
+
 import RichResults from "./RichResults.astro"
 
 interface Props {
@@ -17,6 +19,8 @@ const { title, description, preloadImgLCP } = Astro.props
 <meta name="description" content={description} />
 
 <link rel="preload" href={jost} as="font" type="font/woff2" crossorigin />
+<link rel="preload" href={atomic} as="font" type="font/woff2" crossorigin />
+
 {
 	preloadImgLCP && (
 		<link rel="preload" href={preloadImgLCP} as="image" type="image/webp" crossorigin />


### PR DESCRIPTION
## Descripción

Se implementa la solución sugerida por @Cristian021195 en el issue #462 en donde se precarga la fuente Atomic para evitar el salto de fuente, especialmente en el texto "twitch.tv/ibai"

## Capturas de pantalla

### Antes de la implemetación

https://github.com/midudev/la-velada-web-oficial/assets/30879476/f83b7b70-e422-4489-af4b-ff12c2d8b9c0

### Después de la implemetación

https://github.com/midudev/la-velada-web-oficial/assets/30879476/4fdf7d09-899a-42ae-af22-d16eaba63de3

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

