### PR TITLE
Fix de memory leak al hacer hover en cada card de los luchadores

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -144,10 +144,12 @@ const msFadeLuchador = 150
 	const boxerCountry = document.querySelector(".boxer-flag") as HTMLImageElement
 
 	boxerLinks.forEach((link) => {
+		let timeout: number
+
 		link.addEventListener("mouseenter", (event) => {
 			const { id, name, country, countryName } = (event.currentTarget as HTMLElement)?.dataset
 			link.classList.add("active")
-			setTimeout(
+			timeout = setTimeout(
 				() => {
 					const boxerSrc = `/img/boxers/${id}-big`
 
@@ -164,6 +166,7 @@ const msFadeLuchador = 150
 		})
 		link.addEventListener("mouseleave", () => {
 			link.classList.remove("active")
+			clearTimeout(timeout)
 		})
 	})
 </script>


### PR DESCRIPTION
## Descripción

Se resolvió un memory leak causado al hacer hover en cada card de los luchadores.

## Problema solucionado

El problema abordado en esta solicitud de extracción es un memory leak que ocurría cuando se pasaba el cursor sobre las tarjetas de los luchadores. Este problema podría provocar un consumo excesivo de memoria y un rendimiento degradado en la aplicación.

## Cambios propuestos

Se modificó el código que maneja el evento `mouseenter` y `mouseleave` en los enlaces de los luchadores. Se introdujo una variable `timeout` que almacena el ID del temporizador (`setTimeout`) utilizado para retrasar la actualización de la información del luchador. Al salir del enlace (`mouseleave`), se limpia el temporizador utilizando `clearTimeout(timeout)`. Esto garantiza que no haya temporizadores pendientes que puedan causar fugas de memoria.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde. (No aplica)

## Impacto potencial

No se prevé ningún impacto potencial significativo, ya que se trata de un cambio localizado en el manejo de eventos de los enlaces de los luchadores.