### PR TITLE
Add: User Selected None to CountDown.

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -11,7 +11,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 	</p>
 
 	<div
-		class="grid w-full grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11"
+		class="grid w-full grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11 select-none"
 		data-date={EVENT_TIMESTAMP}
 		role="timer"
 	>


### PR DESCRIPTION
## Descripción

Se ha agregado la clase "select-none" para asi evitar que el usuario seleccione el countdown.

## Capturas de pantalla (si corresponde)

ANTES:
![image](https://github.com/midudev/la-velada-web-oficial/assets/90739340/250b235c-90cd-410b-a496-0619442c9974)

AHORA:
![image](https://github.com/midudev/la-velada-web-oficial/assets/90739340/3ca63116-9799-4b55-866c-bb037693534d)


## Comprobación de cambios

- [x ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x ] He actualizado la documentación, si corresponde.

