### PR TITLE
Cambiar orden boxeadores para que quede simétrica la vista

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -10,12 +10,30 @@ interface Boxer {
 
 export const BOXERS: Boxer[] = [
 	{
+		id: "zeling",
+		name: "Zeling",
+		realName: "Alicia González",
+		age: 28,
+		weight: 65, // No encontrado
+		height: 1.7, // No es seguro
+		country: "es",
+	},
+	{
 		id: "el-mariana",
 		name: "El Mariana",
 		realName: "Osvaldo Palacios Flores",
 		age: 25,
 		weight: 87,
 		height: 1.95,
+		country: "mx",
+	},
+	{
+		id: "alana",
+		name: "Alana",
+		realName: "Alana Flores",
+		age: 23,
+		weight: 55,
+		height: 1.7,
 		country: "mx",
 	},
 	{
@@ -55,30 +73,21 @@ export const BOXERS: Boxer[] = [
 		country: "mx",
 	},
 	{
-		id: "alana",
-		name: "Alana",
-		realName: "Alana Flores",
-		age: 23,
-		weight: 55,
-		height: 1.7,
-		country: "mx",
-	},
-	{
-		id: "zeling",
-		name: "Zeling",
-		realName: "Alicia González",
-		age: 28,
-		weight: 65, // No encontrado
-		height: 1.7, // No es seguro
-		country: "es",
-	},
-	{
 		id: "nissaxter",
 		name: "Nissaxter",
 		realName: "Cristina Magadán",
 		age: 29,
 		weight: 55, // No es seguro
 		height: 1.64,
+		country: "es",
+	},
+	{
+		id: "guanyar",
+		name: "Guanyar",
+		realName: "Diego Iglesias",
+		age: 25,
+		weight: 85,
+		height: 1.88,
 		country: "es",
 	},
 	{
@@ -89,15 +98,6 @@ export const BOXERS: Boxer[] = [
 		weight: 105,
 		height: 1.83,
 		country: "ar",
-	},
-	{
-		id: "guanyar",
-		name: "Guanyar",
-		realName: "Diego Iglesias",
-		age: 25,
-		weight: 85,
-		height: 1.88,
-		country: "es",
 	},
 	{
 		id: "agustin-51",


### PR DESCRIPTION
## Descripción

Se ha cambiado el orden de los boxeadores para que la vista quede simétrica.

## Problema solucionado

Al salir los boxeadores de perfil queda raro que miren indistintamente a un lado o a otro.

## Cambios propuestos

Se ha reordenado el array de los boxeadores sobre el que se itera para pintar el componente de Selector de Boxeador.

## Capturas de pantalla (si corresponde)

ANTES:
![imagen](https://github.com/midudev/la-velada-web-oficial/assets/83401208/57324459-438e-4501-95e7-e9bc1ae62d12)

DESPUÉS:
![imagen](https://github.com/midudev/la-velada-web-oficial/assets/83401208/3eda9321-c675-4332-9b9f-2912ea45d24f)

ALTERNATIVA (todas hacia el mismo lado haciéndole mirror horizontal a algunas imágenes)
![imagen](https://github.com/midudev/la-velada-web-oficial/assets/83401208/b13922bc-b84b-47bd-960d-852c948cf021)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Ningún impacto.