### PR TITLE
Usar la información del boxeador en la pagina boxer

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -7,22 +7,26 @@ export function getStaticPaths() {
 		params: { id },
 	}))
 }
+
+const { id } = Astro.params
+
+const [boxer] = BOXERS.filter((boxer) => boxer.id === id)
 ---
 
 <Layout
-	description="Información del luchador X ...."
-	title="El Mariana - Información del boxeador de La Velada IV"
+	description={`Información del luchador ${boxer.name}`}
+	title={`${boxer.name} - Información del boxeador de La Velada IV`}
 >
 	<main>
 		<picture
 			transition:name="boxer-big-image"
 			class:list={"boxer-photo h-auto object-contain px-10 sm:w-[30vw] sm:px-0 xl:w-[19vw] 3xl:h-[600px] 3xl:w-[480px]"}
 		>
-			<source srcset="/img/boxers/el-mariana-big.avif" type="image/avif" />
+			<source srcset={`/img/boxers/${id}-big.avif`} type="image/avif" />
 			<img
 				class:list={"boxer-photo h-auto object-contain px-10 sm:w-[30vw] sm:px-0 xl:w-[19vw] 3xl:h-[600px] 3xl:w-[480px]"}
-				alt="Fotografía de El Mariana"
-				src="/img/boxers/el-mariana-big.avif"
+				alt={`Fotografía de ${boxer.name}`}
+				src={`/img/boxers/${id}-big.avif`}
 				style="
 							filter: drop-shadow(0 0 20px rgba(0, 0, 0, .5));
 							mask-image: linear-gradient(to bottom, black 80%, transparent 100%);


### PR DESCRIPTION
## Descripción

Se cambia la info hardcoded por la info dinamica

## Problema solucionado

Se mostraba la misma información para todos los boxeadores y se sustituye por la info real

## Cambios propuestos

- Leer id del boxeador
- Cambiar información hardcodeada por la del boxeador según el id

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/2835435/272009a4-e210-47c8-9d48-d5ae9132f231)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

NA

## Contexto adicional

NA

## Enlaces útiles

NA
