### PR TITLE
Eliminación de Código Muerto de la Pre-Landing

### DIFF
--- a/src/components/SmokeBackground.astro
+++ b/src/components/SmokeBackground.astro
@@ -1,6 +1,5 @@
 <div id="smoke-bkg" class="fixed top-0 -z-10 h-full w-full">
-	<canvas id="smoke-canvas" aria-label="Efecto de fondo de humo" class="opacity-70 dark:opacity-40"
-	></canvas>
+	<canvas id="smoke-canvas" aria-label="Efecto de fondo de humo" class="opacity-70"></canvas>
 </div>
 
 <script>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -27,15 +27,12 @@ const { title, description, preloadImgLCP } = Astro.props
 	</head>
 
 	<body
-		class="dark selection:bg-accent [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
+		class="selection:bg-primary selection:text-secondary [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
 	>
 		<!-- <SmokeBackground /> -->
 		<NoiseBackground />
 		<LightsBackground />
-		<div
-			class="mx-auto max-w-6xl px-2 pt-16 selection:bg-primary selection:text-secondary md:pt-20 lg:px-10"
-			id="main-content"
-		>
+		<div class="mx-auto max-w-6xl px-2 pt-16 md:pt-20 lg:px-10" id="main-content">
 			<slot />
 			<Footer />
 			<KonamiCode />

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -22,10 +22,7 @@ import XIcon from "@/icons/x.astro"
 		class="my-12 h-[2px] w-full min-w-[20rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent bg-center md:hidden"
 	/>
 	<nav>
-		<ul
-			class="flex flex-row items-center gap-x-6"
-			aria-label="redes sociales y botón para alternar tema"
-		>
+		<ul class="flex flex-row items-center gap-x-6" aria-label="Redes sociales">
 			<li>
 				<a
 					target="_blank"


### PR DESCRIPTION
## Descripción

Esta pull request elimina el código muerto de la pre-landing para cambiar entre el tema claro y oscuro.

## Problema solucionado

Uso del tema claro/oscuro que había en la pre-landing.

## Cambios propuestos

Eliminación de las clases 'dark' de tailwind y modificación de un aria-label en el footer.

## Capturas de pantalla (si corresponde)

No se modifica nada visualmente.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.