### PR TITLE
Upgrade astro to latest safe version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@fontsource-variable/jost": "5.0.18",
     "@vercel/analytics": "1.2.2",
-    "astro": "4.2.0"
+    "astro": "4.3.7"
   },
   "devDependencies": {
     "@antfu/eslint-config": "0.43.1",


### PR DESCRIPTION
## Descripción

Se actualizó la versión de Astro a la última versión donde la transición de los boxeadores funciona perfecto. Me refiero a la versión `4.3.7`

Es decir, las transiciones dejan de funcionar a partir de la versión[ `4.4.0`](https://github.com/withastro/astro/releases/tag/astro%404.4.0) (Útil saberlo si se quiere abrir una issue)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
