### PR TITLE
minifix: Actualizar link de ver perfil en el <a> de ver perfil del article

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -91,7 +91,7 @@ const listOfBoxers = BOXERS.map((boxer) => {
 					<p id="boxer-weight" class="text-lg font-bold">87kg</p>
 					<a
 						href="#"
-						class="mt-10 inline-block font-semibold text-accent transition-transform hover:scale-110"
+						class="boxer-profile mt-10 inline-block font-semibold text-accent transition-transform hover:scale-110"
 					>
 						Ver perfil
 					</a>
@@ -134,6 +134,7 @@ const listOfBoxers = BOXERS.map((boxer) => {
 		const boxerTitle = document.querySelector(".boxer-title") as HTMLImageElement
 		const boxerPhoto = document.querySelector(".boxer-photo") as HTMLPictureElement
 		const boxerCountry = document.querySelector(".boxer-flag") as HTMLImageElement
+		const boxerProfile = document.querySelector(".boxer-profile") as HTMLAnchorElement
 		const boxerFooter = document.getElementById("boxer-footer") as HTMLElement
 		const boxerCountryElement = document.getElementById("boxer-country") as HTMLElement
 		const boxerWeightElement = document.getElementById("boxer-weight") as HTMLElement
@@ -155,7 +156,7 @@ const listOfBoxers = BOXERS.map((boxer) => {
 			boxerPhoto.getElementsByTagName("img")[0].src = `${boxerSrc}.webp`
 			boxerTitle.innerText = name?.toLocaleLowerCase() ?? ""
 			boxerCountry.src = `/img/flags/${country}.webp`
-
+			boxerProfile.href = `/boxers/${id}`
 			boxerPhoto.getElementsByTagName("img")[0].alt = `Fotografía de ${name}`
 			boxerCountry.alt = `Bandera de ${countryName}`
 


### PR DESCRIPTION
## Descripción

Agregar Link del perfil de cada Boxeador al apartado ver perfil

## Problema solucionado

No se puso el link en ese apartado

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.