### PR TITLE
[FIX] countdown setting to 000 when view transitions used

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -11,7 +11,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 	</p>
 
 	<div
-		class="grid w-full grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11 select-none"
+		class="grid w-full select-none grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11"
 		data-date={EVENT_TIMESTAMP}
 		role="timer"
 	>
@@ -178,5 +178,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 		updateCountdown()
 	}
 
-	init()
+	document.addEventListener("astro:page-load", () => {
+		init()
+	})
 </script>


### PR DESCRIPTION
## Descripción

FIX - se arregla que el countdown se pone a cero debido a las view transitions

## Problema solucionado

FIX - se arregla que el countdown se pone a cero debido a las view transitions

## Cambios propuestos

Poner el listener de astro:page-load para recargar script


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

 No debería

## Contexto adicional

Como ha explicado midu en el directo de hoy cuando se cambia de pagina utilizando las view transitions hay que recargar el javascript con el listener de page-load, sino se queda corrupto.
