### PR TITLE
Fix Countdown component for responsive like Figma

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -11,14 +11,14 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 	</p>
 
 	<div
-		class="grid w-full select-none grid-cols-2 flex-col items-center justify-center gap-4 gap-y-20 uppercase text-primary md:grid-cols-3 md:gap-x-6 md:gap-y-11"
+		class="grid w-full select-none grid-cols-3 flex-col items-center justify-center gap-y-20 uppercase text-primary md:gap-x-6 md:gap-y-11"
 		data-date={EVENT_TIMESTAMP}
 		role="timer"
 	>
 		<Date
 			dateType="Días"
 			attribute={{ "data-days": "" }}
-			position="md:col-span-3"
+			position="col-span-3"
 			className="text-7xl text-accent md:text-[20rem]"
 			wrapperClassName="my-8 md:my-0 md:-mt-16"
 			height={"h-[3.80rem] md:h-[20rem]"}


### PR DESCRIPTION
## Descripción

El componente Countdown en môvil no era como el Figma, estaba dividido en una grid 2x2.

## Problema solucionado

La grid ahora es siempre de 3 columnas y en móvil no hay gap entre estas como en el Figma.

## Capturas de pantalla (si corresponde)

Antes:
<img width="384" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/48435302/be58c72e-4bf1-439c-a986-2afb96920d3e">

Ahora:
<img width="385" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/48435302/3f6c18cc-ea42-469c-8c9e-f44401115e30">


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
