### PR TITLE
fix: horizontal page scroll caused by mobile menu

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -40,7 +40,7 @@ const pages = [
 		<a href="/"><DrawnXLogo class:list={`block w-10 lg:hidden`} /></a>
 		<HamburgerButton class:list={`block lg:hidden`} id="menuButton" />
 		<div
-			class="absolute inset-0 z-[888] flex h-screen w-screen flex-col items-center overflow-x-auto bg-[var(--background-color)] px-10 lg:hidden"
+			class="absolute inset-0 z-[888] flex h-screen flex-col items-center overflow-x-auto bg-[var(--background-color)] px-10 lg:hidden"
 			id="menuMobileContent"
 		>
 			<aside class="flex min-h-16 w-full items-center justify-between">


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
Se eliminó la clase "w-screen" en el menú móvil del componente Header.

## Problema solucionado

<!-- Describa el problema o la tarea que aborda esta solicitud de extracción, si corresponde. Incluya el número de problema o enlace al problema si existe. -->
Scroll horizontal en la página en resoluciones inferiores a 1024px.

## Cambios propuestos

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->

Eliminación de la clase ```w-screen``` en el div contenedor del menú móvil en el componente Header.

## Capturas de pantalla

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

antes:

![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/27c6cfde-6874-4c22-9f24-7bf22bf12686)

después:

![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/41dfc0f2-07b4-407a-8850-b9f384d6840a)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
