### PR TITLE
refactor: remove CSS to use tailwindcss

### DIFF
--- a/src/components/Action.astro
+++ b/src/components/Action.astro
@@ -6,73 +6,12 @@ type Props<Tag extends HTMLTag> = Polymorphic<{ as: Tag }>
 const { as: Tag, class: className, ...props } = Astro.props
 ---
 
-<Tag class:list={["action *:duration-500 motion-reduce:*:duration-0", className]} {...props}>
-	<span><slot /></span>
+<Tag
+	class:list={[
+		"inline-block skew-x-[-21deg] cursor-pointer border-2 border-primary px-5 py-2.5 font-semibold uppercase ease-in before:absolute before:-inset-0.5 before:origin-right before:scale-x-0 before:bg-primary hover:scale-110 hover:text-secondary hover:before:origin-left hover:before:scale-x-100 aria-disabled:pointer-events-none aria-disabled:border-[#666] aria-disabled:bg-[#666] aria-disabled:text-[#111] motion-safe:transition-[color,transform] motion-safe:before:transition-transform motion-safe:before:duration-300 motion-safe:before:ease-in motion-safe:hover:delay-100 motion-safe:hover:ease-out motion-safe:hover:before:delay-100 motion-safe:hover:before:ease-out",
+		className,
+	]}
+	{...props}
+>
+	<span class="inline-block skew-x-[21deg]"><slot /></span>
 </Tag>
-
-<style>
-	.action {
-		padding: 10px 20px;
-		display: inline-block;
-		font-weight: 600;
-		text-transform: uppercase;
-		cursor: pointer;
-		transform: skew(-21deg);
-		color: var(--color-primary);
-		border: 2px solid var(--color-primary);
-	}
-
-	.action[aria-disabled="true"] {
-		background: #666;
-		color: #111;
-		pointer-events: none;
-		border-color: #666;
-	}
-
-	.action > span {
-		display: inline-block;
-		transform: skew(21deg);
-	}
-
-	.action::before {
-		content: "";
-		position: absolute;
-		inset: -2px;
-		background: var(--color-primary);
-		transform: scaleX(0);
-		transform-origin: right; /* To end from left to right */
-	}
-
-	.action:hover {
-		color: var(--color-secondary);
-		scale: 1.1;
-	}
-
-	.action:hover::before {
-		transform: scaleX(1);
-		transform-origin: left; /* To start from left to right */
-	}
-
-	@media (prefers-reduced-motion: no-preference) {
-		.action {
-			transition:
-				color 0.15s ease-in,
-				scale 0.15s ease-in;
-		}
-		.action::before {
-			transition: transform 0.3s ease-in;
-		}
-
-		/* Added delay to simulate a hover attempt */
-		.action:hover {
-			transition:
-				color 0.15s ease-out 0.1s,
-				scale 0.15s ease-out 0.1s;
-		}
-
-		/* Added delay to simulate a hover attempt */
-		.action:hover::before {
-			transition: transform 0.3s ease-out 0.1s;
-		}
-	}
-</style>


### PR DESCRIPTION
## Descripción

Se elimina CSS para usar Tailwind CSS en su lugar, en el componente ```Action.astro```.

## Video

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

Vídeo para demostrar que no se cambia el diseño del componente, a excepción de la duración de las transiciones, ya que tenía distintos tiempos de duración en CSS y en las clases de Tailwind. Por lo tanto, se optó por la duración de los estilos en CSS, que a mi parecer se ve mejor.

https://github.com/midudev/la-velada-web-oficial/assets/79766563/a2faf2b8-2122-4eec-acab-4ec7776f88a5

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
