### PR TITLE
fix: remove unused link

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -37,7 +37,6 @@ const pages = [
 				</>
 			))
 		}
-		<a href="/"><DrawnXLogo class:list={`block w-10 lg:hidden`} /></a>
 		<HamburgerButton class:list={`block lg:hidden`} id="menuButton" />
 		<div
 			class="absolute inset-0 z-[888] flex h-screen w-screen flex-col items-center overflow-x-auto bg-[var(--background-color)] px-10 lg:hidden"


### PR DESCRIPTION
## Descripción

Eliminé un anchor invisible del `Header.astro` que no aportaba utilidad además de poder ser señalado al usar TAB, sin enviar a ningún sitio.

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/660381d8-13c5-43d3-86d8-177c24605215)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.