### PR TITLE
fix: ElPozo grammar

### DIFF
--- a/src/consts/sponsors.ts
+++ b/src/consts/sponsors.ts
@@ -17,7 +17,7 @@ type SponsorName =
 	| "Spotify"
 	| "Cerave"
 	| "Grefusa"
-	| "El Pozo"
+	| "ElPozo"
 	| "Maxibon"
 	| "InfoJobs"
 
@@ -88,7 +88,7 @@ export const SPONSORS: Array<Sponsors> = [
 	},
 	{
 		id: "el-pozo",
-		name: "El Pozo",
+		name: "ElPozo",
 		url: "https://elpozo.com/",
 		image: {
 			width: 134,


### PR DESCRIPTION
## Descripción

Cambio extremadamente pequeño, pero el nombre del patrocionador es ElPozo, sin espacio.

## Capturas de pantalla (si corresponde)

Como aparece en el sitio web:

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/a30e4156-67e7-4be6-831f-030e2863a566)

En LinkedIn:

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/0713f8fb-ebef-4d67-963c-38cfb2c988fe)

PDF oficial (aparece mencionada como ElPozo): https://www.elpozo.com/wp-content/uploads/2020/11/dossier-sostenibilidad-es.pdf


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.