### PR TITLE
Se habilita el prefetching para mejorar las navegaciones

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -10,6 +10,7 @@ import { manifest, seoConfig } from "./src/utils/seoConfig"
 
 // https://astro.build/config
 export default defineConfig({
+	prefetch: true,
 	integrations: [tailwind(), sitemap()],
 	adapter: vercel({
 		webAnalytics: { enabled: true },
@@ -32,14 +33,12 @@ export default defineConfig({
 				manifest,
 				workbox: {
 					globDirectory: "dist",
-					globPatterns: [
-						"**/*.{js,css,svg,png,jpg,jpeg,gif,webp,woff,woff2,ttf,eot,ico}"
-					],
+					globPatterns: ["**/*.{js,css,svg,png,jpg,jpeg,gif,webp,woff,woff2,ttf,eot,ico}"],
 					// Don't fallback on document based (e.g. `/some-page`) requests
 					// This removes an errant console.log message from showing up.
-					navigateFallback: null
-				}
-			})
-		]
+					navigateFallback: null,
+				},
+			}),
+		],
 	},
 })


### PR DESCRIPTION
## Descripción

Se habilito el prefetching de todas las paginas cuando se haga hover en los anchors para mejorar la suavidad de las navegaciones del usuario.

## Cambios propuestos

Agregar en las configuraciones de Astro la opcion `prefetching: true`

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Enlaces útiles

- Documentación de Astro/prefetching: https://docs.astro.build/en/guides/prefetch/
