### PR TITLE
Remove unused import

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,6 @@
 import HamburgerButton from "@/components/HamburgerButton.astro"
 import HeroLogo from "@/components/HeroLogo.astro"
 import DrawnXLogo from "@/components/DrawnXLogo.astro"
-import Footer from "@/sections/Footer.astro"
 import FooterContent from "@/components/FooterContent.astro"
 import SocialButtons from "@/components/SocialButtons.astro"
 


### PR DESCRIPTION
## Descripción

Eliminar import footer en header, ya que no se usa.

## Problema solucionado

Eliminar import footer en header, ya que no se usa.

## Cambios propuestos

Eliminar import footer en header, ya que no se usa.

## Comprobación de cambios

- [ X ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ X ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ X ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ X ] He actualizado la documentación, si corresponde.

## Impacto potencial

Ninguno

## Contexto adicional

Nada

## Enlaces útiles

Nada
