### PR TITLE
minifix: Reducir scroll y peso visual en la versión mobile de los Sponsors

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -27,7 +27,7 @@ import { SPONSORS } from "@/consts/sponsors"
 						width={image.width}
 						height={image.height}
 						class:list={[
-							"company-logo px-4 text-white transition group-hover:scale-110 group-focus:scale-110",
+							"company-logo px-5 text-white transition group-hover:scale-110 group-focus:scale-110 md:px-4",
 						]}
 					/>
 				</a>

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -11,7 +11,7 @@ import { SPONSORS } from "@/consts/sponsors"
 	<Typography as="p" variant="body" color="neutral" class:list={"mt-4 text-center"}>
 		La Velada puede llevarse a cabo gracias a la colaboración de...
 	</Typography>
-	<div class="mt-12 grid select-none grid-cols-2 gap-8 md:grid-cols-3">
+	<div class="mt-12 grid select-none grid-cols-3 gap-2 md:grid-cols-3 md:gap-8">
 		{
 			SPONSORS.filter(({ id }) => id !== "infojobs").map(({ id, name, url, image }) => (
 				<a


### PR DESCRIPTION
## Descripción

Toc visual del logo de Maxibon que se quedaba solo + reducción de scroll en mobile como consecuencia

## Problema solucionado

El logo de Maxibon se quedaba descolgado provocando que el diseño pesase mas en el lado izquierdo

## Cambios propuestos

Se propone aumentar a 3 las columnas en mobile y reducir el gap

## Capturas de pantalla (si corresponde)

Antes:
![CleanShot 2024-03-14 at 11 47 22@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/3249dcf0-2fd6-4c6d-8bdf-b5fafd2a6122)


Ahora:
![CleanShot 2024-03-14 at 11 47 45@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/258caaa9-45c3-475f-81ef-d1fe23a4ce4f)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
