### PR TITLE
Se agrega precarga de las imagenes big de los luchadores

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,6 +9,7 @@ import NoiseBackground from "@/components/NoiseBackground.astro"
 import SEO from "@/components/SEO.astro"
 import Footer from "@/sections/Footer.astro"
 import "@fontsource-variable/jost"
+import { BOXERS } from "@/consts/boxers"
 
 interface Props {
 	description: string
@@ -17,6 +18,8 @@ interface Props {
 }
 
 const { title, description, preloadImgLCP } = Astro.props
+
+const imagesToPreload = BOXERS.map((boxer) => `/img/boxers/${boxer.id}-big.avif`)
 ---
 
 <!doctype html>
@@ -24,6 +27,7 @@ const { title, description, preloadImgLCP } = Astro.props
 	<head>
 		<SEO title={title} description={description} preloadImgLCP={preloadImgLCP!} />
 		<ViewTransitions />
+		{imagesToPreload.map((src) => <link rel="preload" href={src} as="image" />)}
 	</head>
 
 	<body


### PR DESCRIPTION
## Descripción

Se agrega una precarga de las imagenes big de los luchadores para mejorar la respuesta al seleccionar el luchador.

## Problema solucionado

Cuando se selecciona un luchador, este tiene cierto delay ya que tiene que cargar y renderizar la imagen big del luchador.

## Cambios propuestos

Se agrega una precarga de las imagenes de los luchadores en el head para que al  seleccionar uno de los luchadores brinde una respuesta mas inmediata.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.


## Contexto adicional

Por el momento solo se precargaran las imagenes en formato avif, ya que precargar las imagenes en ambos formatos consumiria muchos mb al usuario.
