### PR TITLE
fix(Header): responsive navbar in small laptops (1080p)

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,7 +24,7 @@ const pages = [
 					<a
 						href={disabled ? "/" : href}
 						class:list={[
-							"nav-item relative hidden h-full select-none flex-col items-center justify-center gap-1 px-10 text-xl uppercase text-white lg:flex",
+							"nav-item relative hidden h-full select-none flex-col items-center justify-center gap-1 text-xl uppercase text-white lg:flex lg:px-7 xl:px-10",
 							{ "cursor-not-allowed": disabled },
 							{ "current-page": active },
 						]}


### PR DESCRIPTION
Arreglados errores de linter y formatter para poder commitear.

## Descripción

En pantallas de 1080p hasta que se oculta el navbar con los elementos, no era del todo responsivo.

## Problema solucionado

Mejoras en la responsividad de `Header.astro`

## Cambios propuestos

1. Cambios de padding según tamaños de pantalla.
2. Errores de linter y formatter

## Capturas de pantalla (si corresponde)
Antes:

![image](https://github.com/midudev/la-velada-web-oficial/assets/71392160/cf79f588-5815-4b6d-8bf2-c319e4216ecb)

Después:

![image](https://github.com/midudev/la-velada-web-oficial/assets/71392160/f6ef8af7-2174-485e-9b6b-ff11bfbcac2a)

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la responsividad.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->