### PR TITLE
fix(#536): linting errors and imports

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,7 @@
 - **Sigue las convenciones de código del proyecto**.
 - **Actualiza tu rama con frecuencia** para mantenerla al día con la rama principal del proyecto.
 - **Participa en las discusiones** de tu PR si hay comentarios o sugerencias.
+- **Uso de objetos y typos globales** como `new Date` -> `new window.Date`, `NodeListOf` -> `globalThis.NodeListOf`, `NodeJS` -> `globalThis.NodeJS`. En caso de no saber que usar, referenciad en [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis) o en la documentación del framework [Astro](https://docs.astro.build/en/guides/typescript/#extending-window-and-globalthis)
 
 ### ¿Necesitas ayuda? 🆘
 

--- a/src/components/BoxerBigImage.astro
+++ b/src/components/BoxerBigImage.astro
@@ -1,5 +1,5 @@
 ---
-import Typography from "@/components/Typography"
+import Typography from "@/components/Typography.astro"
 
 interface Props {
 	readonly id: string
@@ -8,7 +8,7 @@ interface Props {
 	readonly countryName: string
 }
 
-const { name, country, countryName, id } = Astro.props
+const { _name, country, countryName, id } = Astro.props
 ---
 
 <div

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -64,7 +64,7 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 		const $countdown = document.querySelector("[data-date]")
 		if (!$countdown) return
 
-		let intervalId: NodeJS.Timer
+		let intervalId: globalThis.NodeJS.Timer
 
 		const $days = {
 			firstDigit: $countdown.querySelector("[data-days] [data-first-group]"),

--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -103,7 +103,9 @@ const boxerColumns = [
 
 <script>
 	document.addEventListener("astro:page-load", () => {
-		const boxerLinks = document.querySelectorAll(".boxer-link") as NodeListOf<HTMLAnchorElement>
+		const boxerLinks = document.querySelectorAll(
+			".boxer-link"
+		) as globalThis.NodeListOf<HTMLAnchorElement>
 		const boxerNav = document.querySelector(".boxers-nav")
 		const boxerTitle = document.querySelector(".boxer-title") as HTMLImageElement
 		const boxerPhoto = document.querySelector(".boxer-photo") as HTMLPictureElement


### PR DESCRIPTION
## Descripción

Errores al use `NodeListOf` and `NodeJS` types.

## Problema solucionado

Problemas de linting.

## Cambios propuestos

1. Uso de `globalThis`
2. Importar componentes con `.astro`
3. Añadir `_` a variables no usadas por el momento ej: `name` -> `_name`.
4. Añadida entrada en [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md) (cuando esté mergeada, links de referencia abajo)

## Capturas de pantalla (si corresponde)

<img width="951" alt="pnpm run lint output" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/03ecd4a7-234f-411a-9130-51e540acc195">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Evitar problemas de linting y hacer buen uso de las variables globales.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- [globalThis MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis)
- [extendiendo window y globalThis Astro](https://docs.astro.build/en/guides/typescript/#extending-window-and-globalthis)
