### PR TITLE
Refactor(Enhance Twitch Logo): Agregado un pequeño padding para corregir la superposición del logo.

### DIFF
--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -73,7 +73,7 @@ const { boxers, class: className = "" } = Astro.props
 
 	@media (min-width: 1280px) {
 		.boxer-link {
-			@apply flex w-full items-center justify-center;
+			@apply flex items-center justify-center;
 		}
 	}
 </style>

--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -11,7 +11,7 @@ const { boxers, class: className = "" } = Astro.props
 
 <div class:list={`flex flex-col ${className}`}>
 	{
-		boxers.map(({ id, name, country, countryName, weight }, index) => (
+		boxers.map(({ id, name, country, countryName, weight }) => (
 			<a
 				href={`/boxers/${id}`}
 				class:list={["boxer-link"]}
@@ -36,7 +36,7 @@ const { boxers, class: className = "" } = Astro.props
 
 <style>
 	.boxer-link {
-		@apply relative flex size-36 flex-col items-center transition-opacity duration-300 ease-in-out;
+		@apply relative flex size-36 flex-col items-center justify-center transition-opacity duration-300 ease-in-out;
 
 		&:hover {
 			@apply opacity-90;
@@ -69,11 +69,5 @@ const { boxers, class: className = "" } = Astro.props
 	.boxer-link.active .boxer-link-background,
 	.boxer-link:hover .boxer-link-background {
 		filter: brightness(0.5);
-	}
-
-	@media (min-width: 1280px) {
-		.boxer-link {
-			@apply flex items-center justify-center;
-		}
 	}
 </style>

--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -4,7 +4,7 @@ import Typography from "@/components/Typography.astro"
 ---
 
 <section
-	class="group my-40 flex w-full flex-col items-center justify-center px-20 font-medium text-primary md:mt-80"
+	class="group my-40 flex w-full flex-col items-center justify-center px-20 font-medium text-primary md:mt-80 md:pt-16"
 	aria-label="descripción del evento"
 >
 	<hr


### PR DESCRIPTION
## Descripción

Se agregó un pequeño padding a la section Info para corregir la superposición del logo de twitch con la bandera del boxeador.

## Problema solucionado

https://github.com/midudev/la-velada-web-oficial/assets/78511737/c0c4299f-7265-4615-ad8a-0b72d9311b4b


## Cambios propuestos

https://github.com/midudev/la-velada-web-oficial/assets/78511737/632adbaf-53a8-4680-853e-8fe93aef2230

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.


