### PR TITLE
Avoid dynamic href on header links

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -22,10 +22,10 @@ const pages = [
 			pages.map(({ disabled, name, href, active }, key) => (
 				<>
 					<a
-						href={disabled ? "/" : href}
+						href={href}
 						class:list={[
 							"nav-item relative hidden h-full select-none flex-col items-center justify-center gap-1 px-10 text-xl uppercase text-white lg:flex",
-							{ "cursor-not-allowed": disabled },
+							{ "pointer-events-none": disabled },
 							{ "current-page": active },
 						]}
 						id={`nav-link-${key}`}


### PR DESCRIPTION
## Descripción

En el header hay algunos links que están deshabilitados. Actualmente, esos links tienen como href `/` y reciben la clase `cursor-not-allowed`, mas sin embargo al hacer click en estos links se hace un refresh.

Esto se corrige usando la clase `pointer-events-none` en su lugar. Además, ya no hay necesidad de cambiar el href real puesto que el usuario no puede clicar en estos links.

## Antes

https://github.com/midudev/la-velada-web-oficial/assets/56328053/638310d8-9839-4102-963b-1b9af9682bc7

> Nótese que al clicar en los links, la animación de fondo se reinicia.

## Después

https://github.com/midudev/la-velada-web-oficial/assets/56328053/96aa3847-3423-452a-9f6e-c71db15dc411

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
