### PR TITLE
[FIX] layout-shifting-header grid instead flex

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,7 +16,7 @@ const pages = [
 }))
 ---
 
-<header class="mb-10 h-16 lg:h-24">
+<header class="mb-10 h-16 max-w-[100vw] lg:h-24">
 	<nav class="group flex h-full w-full items-center justify-between px-10 lg:justify-center">
 		{
 			pages.map(({ disabled, name, href, active }, key) => (
@@ -97,16 +97,19 @@ const pages = [
 		</div>
 	</nav>
 	<div class="relative flex h-2 w-full flex-col items-center">
-		<div class="absolute flex h-full w-full items-center">
-			<hr
+		<div class="gridBottomBarContainer absolute grid w-full items-center justify-between">
+			<div
 				class="h-[2px] w-full border-t-0"
 				style="background:linear-gradient(to right, transparent 3%, white 35%, white 100%)"
-			/>
-			<HeroLogo class:list={"-mx-2 h-60 w-auto lg:-ml-5 lg:h-80"} noEffect />
-			<hr
+			>
+			</div>
+			<div class="-mx-2 -ml-4"><HeroLogo class:list={" w-full"} noEffect /></div>
+			<!-- <div class="bg-red-500">la velada del año</div> -->
+			<div
 				class="h-[2px] w-full border-t-0"
 				style="background:linear-gradient(to left, transparent 3%, white 35%, white 100%)"
-			/>
+			>
+			</div>
 		</div>
 	</div>
 </header>
@@ -160,6 +163,17 @@ const pages = [
 		height: 10px;
 		border-radius: 100%;
 		transform: translateY(-50%);
+	}
+
+	.gridBottomBarContainer {
+		grid-template-columns: 1fr 6rem 1fr;
+		grid-template-rows: 4px;
+	}
+
+	@media (min-width: 1024px) {
+		.gridBottomBarContainer {
+			grid-template-columns: 1fr 9rem 1fr;
+		}
 	}
 	@media (prefers-reduced-motion) {
 		.nav-item .background {


### PR DESCRIPTION
## Descripción

Cambiar el menú de flex a grid para poder solucionar layout shifting #513 

## Problema solucionado

layout shifting #513

## Cambios propuestos

Cambiar parte del menú de flex a grid


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
