### PR TITLE
Fix: Add scrollbar-gutter to prevent layout shift on mobile mode

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -134,6 +134,7 @@ const pages = [
 		opacity: 0;
 		pointer-events: none;
 		transition: opacity 0.3s;
+		scrollbar-gutter: stable;
 	}
 
 	#menuMobileContent.open {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -65,6 +65,7 @@ const { title, description, preloadImgLCP } = Astro.props
 			html {
 				font-family: "Jost Variable", system-ui, sans-serif;
 				background: var(--background-color);
+				scrollbar-gutter: stable;
 			}
 
 			main {


### PR DESCRIPTION
## Descripción

He añadido la propiedad scrollbar-gutter tanto en el elemento HTML principal como en el contenedor del menú de navegación para dispositivos móviles.

## Problema solucionado

Efecto de Layout Shift que se producía al abrir el menú de navegación en modo móvil. Este efecto de salto causaba una experiencia de usuario subóptima y una inconsistencia visual.

## Capturas de pantalla (si corresponde)

### Antes
![scrollbar-gutter-menunav-layout-shift](https://github.com/midudev/la-velada-web-oficial/assets/88900534/9779b14a-e6f7-44bf-82d0-6500e2d9764a)

### Después
![scrollbar-gutter-menunav-fixed](https://github.com/midudev/la-velada-web-oficial/assets/88900534/d60a3564-3637-4c25-ac03-b22e33afd5fd)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Contexto adicional

⚠ @midudev Tras horas de intentar solucionar este problema **pero con las devtools en modo móvil**, descubrí que se originaba por los estilos aplicados al scroll. Estos estilos no afectan al scrollbar global de la web (body), solo se aplican a los scrollbars del contenido, como por ejemplo el contenedor del menú de navegación. 

En el siguiente GIF, nota que los tamaños de los scrollbars son diferentes (body vs menu nav) y se produce el mismo efecto Layout Shift:

![scroll-different](https://github.com/midudev/la-velada-web-oficial/assets/88900534/8cb591d0-0b41-4f2f-928e-99700ce3b4aa)