### PR TITLE
Add new  comments section of page boxer

### DIFF
--- a/src/components/Comments.astro
+++ b/src/components/Comments.astro
@@ -1,0 +1,60 @@
+---
+import Typography from "@/components/Typography.astro"
+
+interface Comments {
+	comment: string
+	url_clip: string
+	click_enabled: boolean
+}
+
+const COMMENTNS: Comments[] = [
+	{
+		comment: "no me he preparado, pero voy a pisarle la cabeza",
+		url_clip: "",
+		click_enabled: false,
+	},
+	{
+		comment: "me da igual ganar. solo dar hostias",
+		url_clip: "",
+		click_enabled: true,
+	},
+
+	{
+		comment: "lo importante es nunca perder la compostura",
+		url_clip: "",
+		click_enabled: true,
+	},
+]
+---
+
+<div class="mt-10 grid select-none grid-cols-3 place-content-center gap-2 gap-x-8 md:gap-4">
+	{
+		COMMENTNS.map(({ comment, url_clip, click_enabled }) => (
+			<article class="flex flex-col justify-between bg-gradient-to-b p-5 hover:from-zinc-600/25">
+				<main>
+					<Typography
+						as="h3"
+						variant="atomic-title"
+						color="primary"
+						class:list={"text-balance text-center"}
+					>
+						"{comment}"
+					</Typography>
+				</main>
+				{click_enabled === true && (
+					<footer class="mt-6 flex items-end justify-center p-5 text-center">
+						<Typography
+							as="a"
+							href={url_clip}
+							variant="body"
+							color="neutral"
+							class:list={"mt-4 text-center "}
+						>
+							Ver clip
+						</Typography>
+					</footer>
+				)}
+			</article>
+		))
+	}
+</div>

--- a/src/sections/Comment.astro
+++ b/src/sections/Comment.astro
@@ -1,0 +1,15 @@
+---
+import Comments from "@/components/Comments.astro"
+import Typography from "@/components/Typography.astro"
+---
+
+<section class="my-44">
+	<Typography as="h3" variant="h3" color="white" class:list={"text-center"}>
+		Declaraciones
+	</Typography>
+	<Typography as="p" variant="body" color="neutral" class:list={"mt-4 text-center"}>
+		Citas previas del combate
+	</Typography>
+
+	<Comments />
+</section>


### PR DESCRIPTION
## Descripción

Agregue la sección de comentarios para la pagina de los boxeadores 

## Cambios propuestos
Nueva seccion de comentarios para la pagina de los boxeadores 

## Capturas de pantalla (si corresponde)
### Ahora
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/402149db-6671-4563-b2d1-06028fbfb131)

### Antes 
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/70a19d92-d475-4e18-8afa-8f9884be3241)

## Comprobación de cambios

- [x ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ x] He actualizado la documentación, si corresponde.


## Contexto adicional
Para habilitar la sección hay que agregar el componente no lo agregue para que no tuviera conflictos con los cambios que están haciendo en la sección de los boxeadores

![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/51ce0aed-d005-4b79-bdb8-ec9f73ee8bbb)
 


