### PR TITLE
fix the ibai audio volume very loud when starting

### DIFF
--- a/src/components/KonamiCode.astro
+++ b/src/components/KonamiCode.astro
@@ -107,7 +107,10 @@
 				document.body.appendChild($miduContainer)
 				showContributors($miduContainer)
 				const audio = audioManager.getAudioInstance()
-				if (audio !== null) audio.play()
+				if (audio !== null) {
+					audio.volume = 0.5
+					audio.play
+				}
 			},
 			onFinish: () => {
 				checkAndRemoveContainer($miduContainer)

--- a/src/components/KonamiCode.astro
+++ b/src/components/KonamiCode.astro
@@ -109,7 +109,7 @@
 				const audio = audioManager.getAudioInstance()
 				if (audio !== null) {
 					audio.volume = 0.5
-					audio.play
+					audio.play()
 				}
 			},
 			onFinish: () => {


### PR DESCRIPTION
## Descripción

El audio de ibai es demasiado fuerte al iniciar el código "midu", se puede bajar el audio a 0.5 por el motivo de que sea molesto para el usuario

## Problema solucionado

Agregamos en el componente el volumen = 0.5


