### PR TITLE
Fix: Center Navigation text when it's wrapped

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -24,7 +24,7 @@ const pages = [
 					<a
 						href={href}
 						class:list={[
-							"nav-item relative hidden h-full select-none flex-col items-center justify-center gap-1 px-10 text-xl uppercase text-white lg:flex",
+							"nav-item relative hidden h-full select-none flex-col items-center justify-center gap-1 px-10 text-center text-xl uppercase text-white lg:flex",
 							{ "pointer-events-none": disabled },
 							{ "current-page": active },
 						]}


### PR DESCRIPTION
## Problema
En algunas resoluciones mas bajas, cuando el texto del menu de navegación pasa a ser de mas de una línea, no se veia centrado.

![Screenshot-14-03-2024](https://github.com/midudev/la-velada-web-oficial/assets/80859657/a610f7f5-9d6a-434e-a659-74ccfd0dfb61)

## Propuesta
Se ha centrado el texto para que almenos en esas resoluciones se vea un poquito mejor.

![Screenshot-14-03-2024(1)](https://github.com/midudev/la-velada-web-oficial/assets/80859657/2157d87e-1658-4b06-a5c3-add4257b32da)
