### PR TITLE
Disable Header on page 404 Error 

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,17 +1,58 @@
 ---
-import Layout from "@/layouts/Layout.astro"
 import Error from "@/sections/Error.astro"
+import SEO from "@/components/SEO.astro"
+import LightsBackground from "@/components/LightsBackground.astro"
+import NoiseBackground from "@/components/NoiseBackground.astro"
+import Footer from "@/sections/Footer.astro"
+import KonamiCode from "@/components/KonamiCode.astro"
+
+interface Props {
+	description: string
+	title: string
+	preloadImgLCP?: string
+}
+
+const { preloadImgLCP } = Astro.props
 ---
 
-<Layout
-	description="Web Oficial de La Velada del Año IV, evento de boxeo entre streamers y creadores de contenido, organizado por Ibai Llanos"
-	title="La Velada del Año 4 - Página no encontrada"
->
+<html lang="es">
+	<head>
+		<SEO
+			title="La Velada del año IV - Pagina no encontrada"
+			description="Verificar que la dirección URL sea correcta "
+			preloadImgLCP={preloadImgLCP!}
+		/>
+	</head>
 	<main>
+		<NoiseBackground />
+		<LightsBackground />
 		<Error
 			error="404"
 			message="Página no encontrada"
 			contextMessage="¡Hola! Lo sentimos, pero no pudimos encontrar lo que buscabas. Verifica que la dirección URL sea correcta."
 		/>
+		<div
+			class="mx-auto min-h-screen max-w-6xl px-2 pt-16 selection:bg-[#141800] selection:text-[#333] md:pt-20 lg:px-10"
+			id="main-content"
+		>
+			<Footer />
+			<KonamiCode />
+		</div>
 	</main>
-</Layout>
+	<style>
+		:root {
+			--color-primary: #ddd;
+			--color-accent: #d5ff00;
+		}
+		@font-face {
+			font-family: Atomic;
+			font-display: swap;
+			src: url("/fonts/atomic.woff2") format("woff2");
+		}
+
+		html {
+			font-family: "Jost Variable", system-ui, sans-serif;
+			background: #141800;
+		}
+	</style>
+</html>


### PR DESCRIPTION
## Descripción

El header aparece en la page de Error 404 ya que usa el Layout. Al menos que esa sea la intención de dejarlo ignorar la PR

## Problema solucionado

<!-- Describa el problema o la tarea que aborda esta solicitud de extracción, si corresponde. Incluya el número de problema o enlace al problema si existe. -->

1. He eliminado el import del Layout
2. He extraído lo necesario del layout para que funcione la página (Posiblemente haya una mejor solución)

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->

## Capturas de pantalla (si corresponde)
Antes
![laveladaerr](https://github.com/midudev/la-velada-web-oficial/assets/18739685/446eb10a-d555-43c0-9e28-b972757f3c02)

Despues

![headererrorfixed](https://github.com/midudev/la-velada-web-oficial/assets/18739685/6d43f989-ea9b-4228-8171-98ebf39d0ff6)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial
No creo que haya un problema de compatibilidad si lo hay ignorar PR

