### PR TITLE
Duplicación información del boxeador

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -57,10 +57,6 @@ if (!boxer) {
 					</div>
 					<div class="mb-10">
 						<BoxerDetailInfo title="Alcance" value={boxer.reach} />
-						<BoxerDetailInfo title="Guardia" value={boxer.guard} />
-					</div>
-					<div class="mb-10">
-						<BoxerDetailInfo title="Alcance" value={boxer.reach} />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Descripción

Duplicación de la información del boxeador (Guardia y Alcance)

## Problema solucionado

Duplicación de la información del boxeador (Guardia y Alcance)

## Cambios propuestos

Eliminado el código duplicado.

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/159711246/b865d63b-76c4-4238-a7d2-7788f56f1c36)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/159711246/b29d01a0-cc09-4f5f-b1d4-18b81ace562b)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
