### PR TITLE
Fix/grid bottom bar component

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -99,15 +99,17 @@ const pages = [
 	<div class="relative flex h-2 w-full flex-col items-center">
 		<div class="gridBottomBarContainer absolute grid w-full items-center justify-between">
 			<div
-				class="h-[2px] w-full border-t-0"
+				class="h-[2px] w-full rounded-l-[30%] border-t-0"
 				style="background:linear-gradient(to right, transparent 3%, white 35%, white 100%)"
 			>
 			</div>
-			<div class="-mx-2 -ml-4"><HeroLogo class:list={" w-full"} noEffect /></div>
+			<div class="-ml-[8px] -mr-[4px]">
+				<HeroLogo class:list={" w-full"} noEffect />
+			</div>
 
 			<div
-				class="h-[2px] w-full border-t-0"
-				style="background:linear-gradient(to left, transparent 3%, white 35%, white 100%)"
+				class="h-[2px] w-full rounded-r-[30%] border-t-0 bg-white"
+				style="background:linear-gradient(to left, transparent 3%, white 35%, white 100%);"
 			>
 			</div>
 		</div>

--- a/src/components/TwitchLogo.astro
+++ b/src/components/TwitchLogo.astro
@@ -31,7 +31,7 @@
 			}
 		}
 	}
-@keyframes eyesMotion {
+	@keyframes eyesMotion {
 		0%,
 		7%,
 		13%,


### PR DESCRIPTION
## Descripción

Había un pequeñísimo "desajuste" en los estilos de la línea del navbar.

## Problema solucionado

Se ajusta el css para solucionarlo. Jugando también con los márgenes (como se hacia anteriormente) para centrar el logo. Si quitamos los márgenes el logo queda centrado, pero visualmente parece que no. Aparte queda un pequeño espacio entre el logo y las líneas de los laterales no respetando así el diseño original.

## Cambios propuestos

Cambios en el CSS y clases de Tailwindcss

## Capturas de pantalla (si corresponde)

### Antes

![la-velada-before](https://github.com/midudev/la-velada-web-oficial/assets/28290142/c2833fac-df55-425a-a7e5-d990f3869641)

### Después

![la-velada-after](https://github.com/midudev/la-velada-web-oficial/assets/28290142/0ef83e23-1e9f-4060-b1b5-58e65f0c114b)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
