### PR TITLE
Fix: movil width de la página de cada boxeador 

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -54,7 +54,7 @@ if (!boxer) return { notFound: true }
 				</aside>
 			</div>
 
-			<div class="mt-20 flex justify-center space-x-8">
+			<div class="mt-20 flex flex-row flex-wrap justify-center gap-8">
 				<BoxerSocialLink href={boxer.socials.twitch}>
 					<Twitch />
 				</BoxerSocialLink>


### PR DESCRIPTION
## Descripción

En Movil la página se rompia el ancho por los iconos de las redes sociales

## Problema solucionado

Ahora ya no se rompe la página

## Cambios propuestos

Agregado flex-row flex-wrap gap-8

## Capturas de pantalla (si corresponde)

Antes:
![CleanShot 2024-03-15 at 13 34 24@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/6a619772-24fc-4663-8a53-600ec3e7297f)

Ahora:
![CleanShot 2024-03-15 at 13 35 00@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/a53f10ff-5f58-431c-9a17-8b54c8bdcc1e)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

