### PR TITLE
fix: Update BoxerBigImage component to use full width and max-width

### DIFF
--- a/src/components/BoxerBigImage.astro
+++ b/src/components/BoxerBigImage.astro
@@ -26,7 +26,7 @@ const firstNames = splitName.slice(0, splitName.length - 1).join(" ")
 >
 </div>
 <picture
-	class:list={"boxer-photo aspect-[285/428] h-auto w-[450px]"}
+	class:list={"boxer-photo aspect-[285/428] h-auto w-full max-w-[450px]"}
 	transition:name="boxer-big-image"
 >
 	<source srcset={`/img/boxers/${id}-big.avif`} type="image/avif" />


### PR DESCRIPTION
## Descripción

El boxeador en mobile desbordaba la página al tener un ancho fijo de 450px. Estaba tambien relacioando este desbordamiento con #563 pero he separado los commits por si hay alguien ya tocando no crear conflictos de tocar avrios archivos

## Problema solucionado

Arreglado el desbordamiento junto a #563 

## Cambios propuestos

Modificado el w-[450px] por w-full max-w-[450px] para que fuese responsive

## Capturas de pantalla (si corresponde)

Antes:
![CleanShot 2024-03-15 at 13 48 54@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/cb28ac48-4a93-47f9-bf9b-fc12856950e6)

Ahora:
![CleanShot 2024-03-15 at 13 49 36@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/87ba3c8d-3494-4fd6-bdc6-a7895a5f385c)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
