### PR TITLE
feat(Layout): accessibility feature, added skip to main content

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -41,6 +41,11 @@ const { title, description, preloadImgLCP, canonical, image } = Astro.props
 	<body
 		class="selection:bg-primary selection:text-secondary [&_:focus-visible]:outline-none [&_:focus-visible]:ring-2 [&_:focus-visible]:ring-primary"
 	>
+		<a
+			href="#main-content"
+			class="fixed top-0 z-20 rounded-br-md bg-secondary px-3 py-5 text-primary opacity-0 focus:opacity-100"
+			>Saltar al contenido principal</a
+		>
 		<NoiseBackground />
 		<LightsBackground />
 		<Header />


### PR DESCRIPTION
## Descripción

Añadido un link para saltar a `#main-content`.

## Problema solucionado

Proporcionar soporte a las personas que solo puedan o tengan un teclado o similares para navegar.

## Cambios propuestos

1. Añadido `<a href="#main-content">`
2. Mostar el link solo al estar en `focus`.

## Capturas de pantalla (si corresponde)

<img width="946" alt="Skip to main content display" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/f154604e-1059-4780-a966-63c1ba897152">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora de accesibilidad.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
