### PR TITLE
fix: Color on BoxerDetailInfo title Rival/es

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -8,8 +8,10 @@ const { title, value } = Astro.props
 ---
 
 <div class="flex justify-center text-white">
-	<div class="text-center">
+	<div class="style text-center">
 		<h4>{title}</h4>
-		<p class="text-xl font-bold" id="boxer-weight">{value}</p>
+		<p class={"text-xl font-bold" + (title === "Rival/es" ? " text-accent" : "")} id="boxer-weight">
+			{value}
+		</p>
 	</div>
 </div>


### PR DESCRIPTION
## Descripción

Esto es una corrección para el component de BoxerDetailInfo ya que según el figma el color de los nombres de los boxeadores rivales eran del color --text-accent el color amarillo que predomina en la pagina.  Asi que he cambiado esa partecita. 

``` src/components/BoxerDetailInfo.astro ```

## Problema solucionado

He modificado el código para cambiar el color del texto a text-accent cuando el título es "Rival/es", de acuerdo con la especificación del diseño en Figma.

## Capturas de pantalla (si corresponde)

**Antes de loscambios:**

![IMG ANTES Title rivales](https://github.com/midudev/la-velada-web-oficial/assets/108672422/1d37aa63-b278-45fd-8cc5-b4053971ee94)

**Después de los cambios:**

![IMG AHORA Title rivales](https://github.com/midudev/la-velada-web-oficial/assets/108672422/d84fde8b-3baa-4417-915c-dcec3ed58092)

## Comprobación de cambios

- [ ✔] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [✔ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [✔ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Contexto adicional

El cambio en el color del texto se realizó para reflejar el diseño proporcionado en Figma, donde el texto asociado al título "Rival/es" se muestra con un color específico llamado text-accent.