### PR TITLE
fix: rotating photos correctly for symmetry

### DIFF
--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -11,10 +11,10 @@ const { boxers, class: className = "" } = Astro.props
 
 <div class:list={`flex flex-col ${className}`}>
 	{
-		boxers.map(({ id, name, country, countryName, weight }) => (
+		boxers.map(({ id, name, country, countryName, weight, rotate }) => (
 			<a
 				href={`/boxers/${id}`}
-				class="boxer-link"
+				class:list={`boxer-link ${rotate ? "rotate-y-180" : ""}`}
 				title={`Visita la página del boxeador ${name}`}
 				data-id={id}
 				data-name={name}
@@ -64,10 +64,16 @@ const { boxers, class: className = "" } = Astro.props
 	.boxer-link.active .boxer-image {
 		transform: scale(1.05);
 		filter: grayscale(0%);
+		& .rotate-y-180 {
+			transform: rotateY(180deg);
+		}
 	}
 
 	.boxer-link.active .boxer-link-background,
 	.boxer-link:hover .boxer-link-background {
 		filter: brightness(0.5);
+	}
+	.rotate-y-180 {
+		transform: rotateY(180deg);
 	}
 </style>

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -22,6 +22,7 @@ export interface Boxer {
 		text: string
 		url: string
 	}>
+	rotate?: boolean
 }
 
 const addAgeGetter = (boxersWithoutAge: Omit<Boxer, "age">[]): Boxer[] => {
@@ -118,6 +119,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 			youtube: "https://youtube.com/c/shelao",
 			tiktok: "https://tiktok.com/@shelao",
 		},
+		rotate: true
 	},
 	{
 		id: "viruzz",
@@ -137,6 +139,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 			youtube: "https://youtube.com/c/byViruZz",
 			tiktok: "https://tiktok.com/@victormelida",
 		},
+		rotate: true
 	},
 	{
 		id: "ama-blitz",
@@ -208,6 +211,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 			youtube: "https://www.youtube.com/channel/UCjUjTl1MiPdAwRxklFLNklg",
 			tiktok: "https://tiktok.com/@nissaxter_",
 		},
+		rotate: true
 	},
 	{
 		id: "guanyar",
@@ -227,6 +231,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 			youtube: "https://www.youtube.com/channel/UCEy75s5IJw-ISYDu1d7HzlA?view_as=subscriber",
 			tiktok: "https://tiktok.com/@guanyar",
 		},
+		rotate: true
 	},
 	{
 		id: "la-cobra",


### PR DESCRIPTION
## Descripción

Se corrige la orientacion de las fotos de los boxeadores en la seccion "Elige tu Luchador" para que su postura/fijacion de la foto sea orientada hacia el centro.

## Cambios propuestos

Se añade una clase de css que rota la foto del luchador si tiene el atributo en la interface Boxers que indica que debe ser rotada.

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/47311955/45ed43f1-0f78-4a2d-9ef4-aade3ba11ad3)

Ahora:
![image](https://github.com/midudev/la-velada-web-oficial/assets/47311955/c008633b-f729-4743-88eb-07aca546ec04)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Poco, ya que se usa un transform
