### PR TITLE
Fix rivals name view boxers and view array names

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -42,7 +42,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 87,
 		height: 1.95,
 		country: "mx",
-		versus: "Yo Soy Plex",
+		versus: "Yo soy Plex",
 		guard: "Izquierda",
 		reach: 168,
 		socials: {

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -42,7 +42,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 87,
 		height: 1.95,
 		country: "mx",
-		versus: "Yo Soy Plex",
+		versus: "Yo soy Plex",
 		guard: "Izquierda",
 		reach: 168,
 		socials: {
@@ -71,7 +71,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 65, // No encontrado
 		height: 1.7, // No es seguro
 		country: "es",
-		versus: ["alana", "ama-blitz"],
+		versus: ["Alana", "Amablitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -90,7 +90,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55,
 		height: 1.7,
 		country: "mx",
-		versus: ["nissaxter", "zeling"],
+		versus: ["Nissaxter", "Zeling"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -109,7 +109,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 93,
 		height: 1.88,
 		country: "cl",
-		versus: "viruzz",
+		versus: "Viruzz",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -127,7 +127,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 85,
 		height: 1.82,
 		country: "es",
-		versus: "shelao",
+		versus: "Shelao",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -146,7 +146,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55, // No es seguro
 		height: 1.58,
 		country: "mx",
-		versus: ["zeling", "nissaxter"],
+		versus: ["Zeling", "Nissaxter"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -165,7 +165,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 70,
 		height: 1.97,
 		country: "es",
-		versus: "el-mariana",
+		versus: "El Mariana",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -198,7 +198,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55, // No es seguro
 		height: 1.64,
 		country: "es",
-		versus: ["alana", "ama-blitz"],
+		versus: ["Alana", "Amablitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -217,7 +217,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 85,
 		height: 1.88,
 		country: "es",
-		versus: "la-cobra",
+		versus: "La Cobra",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -236,7 +236,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 105,
 		height: 1.83,
 		country: "ar",
-		versus: "guanyar",
+		versus: "Guanyar",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -255,7 +255,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 62, // No es seguro
 		height: 1.7,
 		country: "es",
-		versus: "carreraaa",
+		versus: "Carreraaa",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -274,7 +274,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 61,
 		height: 1.65,
 		country: "ar",
-		versus: "agustin-51",
+		versus: "Agustin51",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -42,7 +42,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 87,
 		height: 1.95,
 		country: "mx",
-		versus: "Yo soy Plex",
+		versus: "Yo Soy Plex",
 		guard: "Izquierda",
 		reach: 168,
 		socials: {
@@ -71,7 +71,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 65, // No encontrado
 		height: 1.7, // No es seguro
 		country: "es",
-		versus: ["Alana", "Amablitz"],
+		versus: ["alana", "ama-blitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -90,7 +90,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55,
 		height: 1.7,
 		country: "mx",
-		versus: ["Nissaxter", "Zeling"],
+		versus: ["nissaxter", "zeling"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -109,7 +109,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 93,
 		height: 1.88,
 		country: "cl",
-		versus: "Viruzz",
+		versus: "viruzz",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -127,7 +127,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 85,
 		height: 1.82,
 		country: "es",
-		versus: "Shelao",
+		versus: "shelao",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -146,7 +146,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55, // No es seguro
 		height: 1.58,
 		country: "mx",
-		versus: ["Zeling", "Nissaxter"],
+		versus: ["zeling", "nissaxter"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -165,7 +165,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 70,
 		height: 1.97,
 		country: "es",
-		versus: "El Mariana",
+		versus: "el-mariana",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -198,7 +198,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55, // No es seguro
 		height: 1.64,
 		country: "es",
-		versus: ["Alana", "Amablitz"],
+		versus: ["alana", "ama-blitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -217,7 +217,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 85,
 		height: 1.88,
 		country: "es",
-		versus: "La Cobra",
+		versus: "la-cobra",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -236,7 +236,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 105,
 		height: 1.83,
 		country: "ar",
-		versus: "Guanyar",
+		versus: "guanyar",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -255,7 +255,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 62, // No es seguro
 		height: 1.7,
 		country: "es",
-		versus: "Carreraaa",
+		versus: "carreraaa",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -274,7 +274,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 61,
 		height: 1.65,
 		country: "ar",
-		versus: "Agustin51",
+		versus: "agustin-51",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -42,7 +42,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 87,
 		height: 1.95,
 		country: "mx",
-		versus: "plex",
+		versus: "Yo Soy Plex",
 		guard: "Izquierda",
 		reach: 168,
 		socials: {
@@ -71,7 +71,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 65, // No encontrado
 		height: 1.7, // No es seguro
 		country: "es",
-		versus: ["alana", "ama-blitz"],
+		versus: ["Alana", "Amablitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -90,7 +90,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55,
 		height: 1.7,
 		country: "mx",
-		versus: ["nissaxter", "zeling"],
+		versus: ["Nissaxter", "Zeling"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -109,7 +109,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 93,
 		height: 1.88,
 		country: "cl",
-		versus: "viruzz",
+		versus: "Viruzz",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -127,7 +127,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 85,
 		height: 1.82,
 		country: "es",
-		versus: "shelao",
+		versus: "Shelao",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -146,7 +146,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55, // No es seguro
 		height: 1.58,
 		country: "mx",
-		versus: ["zeling", "nissaxter"],
+		versus: ["Zeling", "Nissaxter"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -165,7 +165,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 70,
 		height: 1.97,
 		country: "es",
-		versus: "el-mariana",
+		versus: "El Mariana",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -198,7 +198,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 55, // No es seguro
 		height: 1.64,
 		country: "es",
-		versus: ["alana", "ama-blitz"],
+		versus: ["Alana", "Amablitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -217,7 +217,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 85,
 		height: 1.88,
 		country: "es",
-		versus: "la-cobra",
+		versus: "La Cobra",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -236,7 +236,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 105,
 		height: 1.83,
 		country: "ar",
-		versus: "guanyar",
+		versus: "Guanyar",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -255,7 +255,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 62, // No es seguro
 		height: 1.7,
 		country: "es",
-		versus: "carreraaa",
+		versus: "Carreraaa",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
@@ -274,7 +274,7 @@ export const BOXERS: Boxer[] = addAgeGetter([
 		weight: 61,
 		height: 1.65,
 		country: "ar",
-		versus: "agustin-51",
+		versus: "Agustin51",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -39,7 +39,10 @@ if (!boxer) return { notFound: true }
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
-					<BoxerDetailInfo title="Rival/es" value={boxer.versus} />
+					<BoxerDetailInfo
+						title="Rival/es"
+						value={Array.isArray(boxer.versus) ? boxer.versus.join(" y ") : boxer.versus}
+					/>
 				</aside>
 
 				<div class="relative -mt-24 flex flex-col items-center justify-center lg:mx-4 lg:w-[800px]">
@@ -77,7 +80,6 @@ if (!boxer) return { notFound: true }
 			boxer.clips && boxer.clips.length > 0 && (
 				<section class="my-44">
 					<SectionTitle title="Declaraciones" description="Citas previas del combate" />
-
 					<BoxerClips clips={boxer.clips} />
 				</section>
 			)


### PR DESCRIPTION
## Descripción

Esto es una corrección para el component de BoxerDetailInfo a peticion de @AlejandroSuero  ya que según el figma los nombres se muestran en mayúsculas al inicial de los boxeadores rivales, además he corregido la parte de cuando se muestran los rivales, pero cuando son mas de uno, que se mostraba todo junto, lo he solucionado con esto: Y he agregado " Y " como conector lógico  

**Modificación: **
```
<BoxerDetailInfo title="Rival/es" value={Array.isArray(boxer.versus) ? boxer.versus.join(" y ") : boxer.versus} />
```

## Problema solucionado

Lo que he solucionado posiblemente sea un problema, pero de diseño más que todo, simplemente mostré el nombre perfectamente y he modificado los nombres en boxers.ts

## Capturas de pantalla (si corresponde)

**ANTES:**
![IMG Antes view name array](https://github.com/midudev/la-velada-web-oficial/assets/108672422/8a0bb62b-21eb-441d-8a56-409295aaf31b)


**AHORA:**
![IMG Ahora view name array](https://github.com/midudev/la-velada-web-oficial/assets/108672422/ceb07742-8be9-4c9d-a78e-38f099549095)

## Comprobación de cambios

- [ ✔] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [✔ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [✔ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.


## Contexto adicional
Realmente no se por qué me dice ``` Can’t automatically merge```. Don’t worry, you can still create the pull request. Si realmente lo que he modificado es los nombres de los versus en el apartado de cada boxeador, para que se vea incluso mejor a petición de @AlejandroSuero 