### PR TITLE
feat: Enlace de los contrincantes en la pagina del boxeador

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -1,17 +1,43 @@
 ---
+import { BOXERS, type Boxer } from "@/consts/boxers"
+
 interface Props {
 	title: string
 	value?: string | number | string[]
 }
 
 const { title, value } = Astro.props
+
+let rivals: Boxer[] = []
+if (title === "Rival/es") {
+	if (typeof value === "object") {
+		rivals = value.map((vs: string) => BOXERS.find((rival: Boxer) => rival.id === vs)) as Boxer[]
+	} else {
+		rivals = [BOXERS.find((rival: Boxer) => rival.id === value)] as Boxer[]
+	}
+}
 ---
 
 <div class="flex justify-center text-white">
 	<div class="style text-center">
 		<h4>{title}</h4>
-		<p class={"text-xl font-bold" + (title === "Rival/es" ? " text-accent" : "")} id="boxer-weight">
-			{value}
-		</p>
+		{
+			title === "Rival/es" ? (
+				rivals.map((rival, index: number) => (
+					<>
+						<a href={`/boxers/${rival.id}`} class="text-xl font-bold text-accent " id="boxer-rival">
+							{rival.name}
+						</a>
+						<span class="text-xl font-bold text-accent">
+							{index < rivals.length - 1 ? " y " : ""}
+						</span>
+					</>
+				))
+			) : (
+				<p class="text-xl font-bold" id="boxer-weight">
+					{value}
+				</p>
+			)
+		}
 	</div>
 </div>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -46,15 +46,6 @@ const forecast = FORECASTS.find((forecast) => forecast.combatId === combat.id)
 const boxersWithForecast: BoxerWithForecast[] = []
 let forecastCount = 0
 
-let rivals = ""
-if (typeof boxer.versus === "object") {
-	rivals = boxer.versus
-		.map((vs: string) => BOXERS.find((rival: string) => rival.id === vs).name)
-		.join(" y ")
-} else {
-	rivals = BOXERS.find((rival: string) => rival.id === boxer.versus).name
-}
-
 if (forecast) {
 	forecast.forecastData.map((forecastData) => {
 		const boxer = boxers.find((boxer) => boxer.id === forecastData.boxerId)
@@ -77,7 +68,7 @@ if (forecast) {
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
-					<BoxerDetailInfo title="Rival/es" value={rivals} />
+					<BoxerDetailInfo title="Rival/es" value={boxer.versus} />
 				</aside>
 
 				<div class="relative -mt-24 flex flex-col items-center justify-center lg:mx-4 lg:w-[800px]">


### PR DESCRIPTION
## Descripción

Se agrega enlace a los contrincantes del peleador en la pagina boxers/[id].

## Cambios propuestos
Los nombres de los contrincantes ahora redirigen a la pagina del boxeador.

## Captura de video

https://github.com/midudev/la-velada-web-oficial/assets/47311955/3c11bacc-d4a4-4c18-9cb5-d2753db3fda2

https://github.com/midudev/la-velada-web-oficial/assets/47311955/d530bd99-c3e4-4a97-abc5-bf2cac76eb21


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial
Ninguno.

