### PR TITLE
Permitir navegación al detalle del boxeador al dar click sobre su nombre

### DIFF
--- a/src/components/BoxerBigImage.astro
+++ b/src/components/BoxerBigImage.astro
@@ -41,7 +41,7 @@ const firstNames = splitName.slice(0, splitName.length - 1).join(" ")
 	/>
 </picture>
 
-<div class="absolute bottom-14 mb-10 max-w-md text-wrap" transition:name="boxer-name">
+<div class="absolute bottom-14 z-10 mb-10 max-w-md text-wrap" transition:name="boxer-name">
 	<Typography
 		as="h4"
 		variant="boxer-title"

--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -72,10 +72,12 @@ const boxerColumns = [
 			const lastName = splitName[splitName.length - 1]
 			const firstNames = splitName.slice(0, splitName.length - 1).join(" ")
 			const spanNames = `
-				<span class="flex flex-col">
-					<span class="text-4xl">${firstNames?.toLocaleLowerCase()}</span>
-					<span>${lastName?.toLocaleLowerCase()}</span>
-				</span>
+					<a href="/boxers/${id}" class="boxer-link underline-transition transition-all duration-300 hover:text-accent motion-reduce:transition-none">
+						<span class="flex flex-col">
+							<span class="text-4xl">${firstNames?.toLocaleLowerCase()}</span>
+							<span>${lastName?.toLocaleLowerCase()}</span>
+						</span>
+					</a>
 			`
 
 			boxerNav?.querySelector(".active")?.classList.remove("active")


### PR DESCRIPTION
## Descripción

Permitir navegación al detalle del boxeador al dar click sobre su nombre desde la pantalla principal

## Problema solucionado

Mejora de accesibilidad sin tener que moverse al icono pequeño para navegar al detalle del boxeador.

## Cambios propuestos

[x]. Se agrega link (tag a) para navegar hacia el detalle de cada boxeador

## Capturas de pantalla (si corresponde)

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

