### PR TITLE
Se válida que el elemento canvas exista dentro de la página

### DIFF
--- a/src/components/Velocimetro.astro
+++ b/src/components/Velocimetro.astro
@@ -19,11 +19,12 @@ const { percentage } = Astro.props
 
 	document.addEventListener("astro:page-load", () => {
 		const canvas = $("#velocimeter") as HTMLCanvasElement
+		if (!canvas) return
 		const ctx = canvas.getContext("2d")
 		const velocimeterValueInput = $("#velocimeterValue") as HTMLInputElement
 
 		function updateVelocimeter() {
-			const velocimeterValue = parseInt(canvas.getAttribute("data-percentage") ?? "50")
+			const velocimeterValue = Number.parseInt(canvas.getAttribute("data-percentage") ?? "50")
 			drawVelocimeter(velocimeterValue)
 		}
 
@@ -67,7 +68,7 @@ const { percentage } = Astro.props
 			ctx.strokeStyle = "#fff"
 			ctx.stroke()
 
-			//hacemos un cuadrado rojo en la parte de arriba del pointer
+			// hacemos un cuadrado rojo en la parte de arriba del pointer
 
 			ctx.beginPath()
 			ctx.moveTo(pointerX - 5 * Math.cos(endAngle), pointerY - 5 * Math.sin(endAngle))
@@ -79,7 +80,7 @@ const { percentage } = Astro.props
 			ctx.strokeStyle = "red"
 			ctx.stroke()
 
-			//hacemos un circulo en el centro abajo
+			// hacemos un circulo en el centro abajo
 
 			const gradientCircle = ctx.createLinearGradient(0, 0, 0, canvas.height)
 			gradientCircle.addColorStop(0, "#222")


### PR DESCRIPTION
## Descripción

Actualmente esta apareciendo un error en la consola que dice **Uncaught TypeError: Cannot read properties of null (reading 'getContext')**

## Problema solucionado

Cuando se redirige al detalle del boexador y luego se retorna a la página principal aparece el mensaje **Uncaught TypeError: Cannot read properties of null (reading 'getContext')**

## Cambios propuestos

- [x] Se añade validación para verificar si existe el elemento canvas

## Capturas de pantalla (si corresponde)
![image](https://github.com/midudev/la-velada-web-oficial/assets/82130680/5ad05791-ee2e-4368-99eb-d64cc1485f5d)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.