### PR TITLE
Add: Hover to boxer social link

### DIFF
--- a/src/components/BoxerSocialLink.astro
+++ b/src/components/BoxerSocialLink.astro
@@ -12,7 +12,7 @@ const { href } = Astro.props
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			class="inline-flex w-32 items-center justify-center bg-gradient-to-b from-gray-900 to-transparent px-10 py-2 text-white mix-blend-screen"
+			class="inline-flex w-32 items-center justify-center bg-gradient-to-b from-gray-900 to-transparent px-10 py-2 text-white mix-blend-screen transition hover:opacity-70"
 		>
 			<slot />
 		</a>


### PR DESCRIPTION
## Cambios propuestos
Se ha agregado una transisión al botón de las redes sociales del boxeador.

## Video de demostración

https://github.com/midudev/la-velada-web-oficial/assets/80859657/607a7f34-22fe-424c-b614-79a90559eb40

## Comprobación de cambios

- [ x ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ x ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ x ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.