### PR TITLE
Se arregló el botón scrolltop

### DIFF
--- a/src/components/ButtonUp.astro
+++ b/src/components/ButtonUp.astro
@@ -19,6 +19,7 @@
 </div>
 
 <script>
+		document.addEventListener("astro:page-load", () => {
 	let timeout: number = 0 // Identificador para clearTimeout
 	const $button = document.getElementById("scroll-to-top") as HTMLButtonElement
 
@@ -50,4 +51,6 @@
 	$button.addEventListener("click", () => {
 		window.scrollTo({ top: 0, behavior: "smooth" })
 	})
+})
+
 </script>


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->

## Problema solucionado

El botón de scroll top al iniciar la página funciona bien, pero a la hora de pasar a la página de algún luchador ya no aparece y a la hora de volver a la página inicial ya no vuelve a aparecer el botón. Issues #579

## Cambios propuestos

1- En el componente ButtonUp.astro se envolvió el código del script usando document.addEventListener("astro:page-load", () => {})

## Capturas de pantalla (si corresponde)

## Antes
https://github.com/midudev/la-velada-web-oficial/assets/66286368/b0dbb215-cfc7-4671-beea-440d5de9cb8b

## Despues

https://github.com/midudev/la-velada-web-oficial/assets/66286368/51536c03-96dc-4ead-b456-c80c8187d80e



## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Habría que revisar después si tiene impacto al usar document.addEventListener("astro:page-load", () => {}) en el rendimiento mientras se esté usando las viewsTransitions

-----
<a href="https://stackblitz.com/~/github.com/SubVray/la-velada-web-oficial/tree/buttonup"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/SubVray/la-velada-web-oficial/tree/buttonup)._