### PR TITLE
add btn back to home

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -11,9 +11,9 @@ import Twitch from "@/icons/twitch.astro"
 import X from "@/icons/x.astro"
 import YouTube from "@/icons/youtube.astro"
 
-import { COUNTRIES } from "@/consts/countries"
 import { BOXERS } from "@/consts/boxers"
 import { COMBATS } from "@/consts/combats"
+import { COUNTRIES } from "@/consts/countries"
 import { FORECASTS } from "@/consts/forecasts"
 import Layout from "@/layouts/Layout.astro"
 import CombatSection from "@/sections/Combat.astro"
@@ -74,7 +74,30 @@ if (forecast) {
 		<section class="flex flex-col items-center justify-center">
 			<div class="flex flex-col items-center lg:flex-row lg:items-start">
 				<aside class="flex flex-col gap-y-20 lg:w-1/4">
-					<BoxerDetailInfo title="Alias" value={boxer.name} />
+					<div class="flex flex-col items-center justify-center">
+						<a
+							class="mb-3 text-xl font-bold text-accent transition hover:scale-105 hover:contrast-125"
+							href={`/?boxer=${boxer.id}`}
+							title="volver atras"
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								class="h-10 w-10 transition"
+								width="40"
+								height="40"
+								viewBox="0 0 24 24"
+								stroke-width="1.5"
+								stroke="currentColor"
+								fill="none"
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								><path stroke="none" d="M0 0h24v24H0z" fill="none"></path><path d="M12 8l-4 4l4 4"
+								></path><path d="M16 12h-8"></path><path
+									d="M12 3c7.2 0 9 1.8 9 9s-1.8 9 -9 9s-9 -1.8 -9 -9s1.8 -9 9 -9z"></path></svg
+							>
+						</a>
+						<BoxerDetailInfo title="Alias" value={boxer.name} />
+					</div>
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
 					<BoxerDetailInfo title="Rival/es" value={rivals} />
@@ -128,5 +151,3 @@ if (forecast) {
 		<CombatSection combatNumber={combat.id} boxers={boxers} />
 	</main>
 </Layout>
-
-<script></script>


### PR DESCRIPTION
## Descripción

Agregue un boton en la pagina del boxeador para volver al home 


## Cambios propuestos

Botón para volver atrás 

## Capturas de pantalla (si corresponde)
Ahora 
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/a8256ccf-33cb-48ea-b953-08f6671ab7f6)

Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/37338111-33b2-4a7f-8d0d-c5e5c65c0e2b)


## Comprobación de cambios

- [ x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

## Contexto adicional
Para solventar la issue #582 

## Enlaces útiles
issue #582 
