### PR TITLE
:bug: fix: bug en el header cuando el navbar esta activo

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -209,6 +209,7 @@ const pages = [
 			$("#menuMobileContent")?.classList.toggle("open")
 			nav?.classList.toggle("open")
 			document.body.classList.toggle("overflow-hidden")
+			document.body.classList.toggle("lg:overflow-auto")
 		}
 	})
 </script>


### PR DESCRIPTION
Tenemos el siguiente codigo en el navbar el cual hace que se muestre el menu del header en el archivo `Header.astro`

```js
  function toggleMenu(nav: HTMLElement | null) {
	$("#menuMobileContent")?.classList.toggle("open")
	nav?.classList.toggle("open")
	document.body.classList.toggle("overflow-hidden")
  }
```

Sin embargo cuando activamos el menu en modo mobile y re-escalamos la pagina con el menu activo esto hace que el menu desaparezca y luego la pagina no tenga scroll

Solucion, se añidio una clase adicional en esta funcion para que el scroll vuelva a su estado original despues de alcanzar el modo desktop y manteniendo el menu activo

`document.body.classList.toggle("lg:overflow-auto")` 