### PR TITLE
Boxer Responsive Information

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -8,10 +8,42 @@ const { title, value } = Astro.props
 ---
 
 <div class="flex justify-center text-white">
-	<div class="style text-center">
+	<div class="style flex flex-col items-start text-center">
 		<h4>{title}</h4>
-		<p class:list={`text-xl font-bold ${title === "Rival/es" ? "text-accent" : ""}`} id="boxer-weight">
+		<p
+			class:list={`text-xl font-bold ${title === "Rival/es" ? "text-accent" : ""}`}
+			id="boxer-weight"
+		>
 			{value}
 		</p>
 	</div>
 </div>
+
+<style>
+	.style {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+	}
+
+	@media (max-width: 767px) {
+		.style {
+			flex-direction: row;
+			justify-content: space-between;
+		}
+
+		h4,
+		p {
+			margin: 0;
+			padding: 10px;
+		}
+
+		h4 {
+			margin-left: 0;
+		}
+
+		p {
+			margin-right: 0;
+		}
+	}
+</style>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -73,23 +73,25 @@ if (forecast) {
 	<main>
 		<section class="flex flex-col items-center justify-center">
 			<div class="flex flex-col items-center md:flex-row md:gap-10 lg:items-start">
-				<aside class="flex flex-col gap-y-20 lg:w-1/4">
+				<div class="order-2 flex flex-col gap-y-6 md:order-1 md:gap-y-20 lg:w-1/4">
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
 					<BoxerDetailInfo title="Rival/es" value={rivals} />
-				</aside>
+				</div>
 
-				<div class="relative -mt-24 flex flex-col items-center justify-center lg:mx-4 lg:w-[800px]">
+				<div
+					class="relative order-1 flex flex-col items-center justify-center md:order-2 lg:mx-4 lg:w-[800px]"
+				>
 					<BoxerBigImage id={id} name={boxer.name} country={boxer.country} />
 				</div>
 
-				<aside class="flex flex-col gap-y-20 lg:w-1/4">
+				<div class="order-3 flex flex-col gap-y-6 md:order-3 md:gap-y-20 lg:w-1/4">
 					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} />
 					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} />
 					<BoxerDetailInfo title="Guardia" value={boxer.guard} />
 					<BoxerDetailInfo title="Alcance" value={boxer.reach} />
-				</aside>
+				</div>
 			</div>
 
 			<div class="mt-20 flex flex-row flex-wrap justify-center gap-8">


### PR DESCRIPTION
## Descripción

He añadido estilos para hacer la que la información del boxeador (en dispositivos móviles) se vea a bajo de la imagen.

## Problema solucionado

No se podía observar correctamente la información del boxeador en dispositivos móviles.

## Cambios propuestos

He añadido estilos para hacer la que la información del boxeador (en dispositivos móviles) se vea a bajo de la imagen.

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/159711246/9e3c3a7b-40c5-4673-81ae-4df63d143853)

Después: 
![Captura de pantalla 2024-03-16 153024](https://github.com/midudev/la-velada-web-oficial/assets/159711246/80c714b6-246f-4239-9b07-e384f4c6484c)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

## Enlaces útiles

