### PR TITLE
Improve accessibility on mobile menu

### DIFF
--- a/src/components/HamburgerButton.astro
+++ b/src/components/HamburgerButton.astro
@@ -1,15 +1,19 @@
 ---
+import { MOBILE_MENU_CONTENT_ID } from "@/consts/mobile-menu"
+
 const width = "w-6"
 const genericHamburgerLine = `h-[2px] ${width} bg-gray-300 transition ease transform duration-300`
 ---
 
 <button
 	id={Astro.props.id}
+	aria-expanded="false"
+	aria-controls={MOBILE_MENU_CONTENT_ID}
 	class:list={[
 		"hamburgerButton group relative flex h-[20px] flex-col items-center justify-between lg:hidden",
 		width,
 	]}
-	aria-label="hamburger menu button"
+	aria-label="Abrir menú de navegación"
 >
 	<div class:list={["group-[.open]:translate-y-2 group-[.open]:rotate-45", genericHamburgerLine]}>
 	</div>
@@ -38,6 +42,12 @@ const genericHamburgerLine = `h-[2px] ${width} bg-gray-300 transition ease trans
 			button.addEventListener("click", () => {
 				const hamburgerButton = $(DISPLAY.hamburgerMenuClass)
 				hamburgerButton.classList.toggle(DISPLAY.open)
+				const isMenuOpen = hamburgerButton.classList.contains(DISPLAY.open)
+				hamburgerButton.setAttribute("aria-expanded", String(isMenuOpen))
+				hamburgerButton.setAttribute(
+					"aria-label",
+					isMenuOpen ? "Cerrar menú de navegación" : "Abrir menú de navegación"
+				)
 				const hamburgerButtonClick = new CustomEvent(DISPLAY.hamburgerButtonClicked)
 				hamburgerButton.dispatchEvent(hamburgerButtonClick)
 			})

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -4,6 +4,7 @@ import HeroLogo from "@/components/HeroLogo.astro"
 import DrawnXLogo from "@/components/DrawnXLogo.astro"
 import FooterContent from "@/components/FooterContent.astro"
 import SocialButtons from "@/components/SocialButtons.astro"
+import { MOBILE_MENU_CONTENT_ID } from "@/consts/mobile-menu"
 
 const pages = [
 	{ name: "El Evento", href: "/" },
@@ -45,7 +46,7 @@ const pages = [
 		<HamburgerButton class:list={"block lg:hidden"} id="menuButton" />
 		<div
 			class="fixed inset-0 z-[888] flex w-screen flex-col items-center overflow-x-auto bg-[var(--background-color)] px-10 lg:hidden"
-			id="menuMobileContent"
+			id={MOBILE_MENU_CONTENT_ID}
 		>
 			<aside class="flex min-h-16 w-full items-center justify-between">
 				<span class="text-xl font-semibold uppercase text-primary">Menú</span>

--- a/src/consts/mobile-menu.ts
+++ b/src/consts/mobile-menu.ts
@@ -1,0 +1,1 @@
+export const MOBILE_MENU_CONTENT_ID = "menuMobileContent"


### PR DESCRIPTION
## Descripción

Mejorar la accesibilidad del menú de navegación mobile para usuarios que utilicen lectores de pantalla.

## Problema solucionado

Anteriormente, los usuarios que utilizan lectores de pantalla no tenían forma de conocer el estado del menú de navegación, es decir, si este se encontraba en estado "expanded" o "collapsed". Además, el mensaje anunciado por el lector de pantalla cuando el botón del menú estaba en estado "focused" era poco descriptivo.

## Cambios propuestos

- Colocar un atributo `aria-label` mas descriptivo al botón.
- Agregar el atributo `aria-expanded`.
- Agregar el atributo `aria-controls` para identificar el elemento cuya presencia es controlada por estos botones.
- Modificar los atributos `aria-label` y `aria-expanded` ante un evento del tipo click sobre estos botones.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.