### PR TITLE
UI ux coherence pronostic design

### DIFF
--- a/src/components/Velocimetro.astro
+++ b/src/components/Velocimetro.astro
@@ -16,18 +16,21 @@ const { percentage } = Astro.props
 <script>
 	import { $ } from "@/consts/dom-selector"
 
+	const COLORS = {
+		accent: "#b4cd02",
+		white: "#fff",
+		"white-50": "rgba(255, 255, 255, 0.5)",
+	}
+
 	document.addEventListener("astro:page-load", () => {
 		const canvas = $("#velocimeter") as HTMLCanvasElement
 		if (!canvas) return
 		const ctx = canvas.getContext("2d")
-		// const velocimeterValueInput = $("#velocimeterValue") as HTMLInputElement
 
 		function updateVelocimeter() {
 			const velocimeterValue = Number.parseInt(canvas.getAttribute("data-percentage") ?? "50")
 			drawVelocimeter(velocimeterValue)
 		}
-
-		// function createGradient(ctx: CanvasRenderingContext2D) {}
 
 		function drawVelocimeter(value: number) {
 			if (!ctx) return
@@ -38,8 +41,8 @@ const { percentage } = Astro.props
 			const radius = (canvas.width - arcWidth * 2) / 2 - 10
 
 			const gradientArc = ctx.createLinearGradient(0, 0, 0, canvas.height)
-			gradientArc.addColorStop(0, "#222")
-			gradientArc.addColorStop(0.5, "#111")
+			gradientArc.addColorStop(0, COLORS.accent)
+			gradientArc.addColorStop(0.25, COLORS.accent)
 			gradientArc.addColorStop(1, "transparent")
 
 			ctx.strokeStyle = gradientArc
@@ -53,10 +56,11 @@ const { percentage } = Astro.props
 			const startAngle = Math.PI
 			const endAngle = (value / 100) * Math.PI + startAngle
 
-			const linePointerWidth = 8
-			const circleLineWidth = 12
+			const lineDivisionsWidth = 2
+			const linePointerWidth = 4
+			const circleLineWidth = 6
 
-			const pointerLength = radius * 1.1
+			const pointerLength = radius * 1.2
 			const pointerX = centerX + pointerLength * Math.cos(endAngle)
 			const pointerY = centerY - circleLineWidth + pointerLength * Math.sin(endAngle)
 
@@ -64,10 +68,10 @@ const { percentage } = Astro.props
 			ctx.moveTo(centerX, centerY - circleLineWidth)
 			ctx.lineTo(pointerX, pointerY)
 			ctx.lineWidth = linePointerWidth
-			ctx.strokeStyle = "#fff"
+			ctx.strokeStyle = COLORS.white
 			ctx.stroke()
 
-			// hacemos un cuadrado rojo en la parte de arriba del pointer
+			// hacemos un cuadrado blanco en la parte de arriba del pointer
 
 			ctx.beginPath()
 			ctx.moveTo(pointerX - 5 * Math.cos(endAngle), pointerY - 5 * Math.sin(endAngle))
@@ -76,22 +80,25 @@ const { percentage } = Astro.props
 				pointerX + linePointerWidth * 4 * Math.cos(endAngle),
 				pointerY + linePointerWidth * 4 * Math.sin(endAngle)
 			)
-			ctx.strokeStyle = "red"
+			ctx.strokeStyle = COLORS.white
+			ctx.stroke()
+
+			// añadimos una linea divisoria en el centro
+
+			ctx.beginPath()
+			ctx.moveTo(centerX, 0)
+			ctx.lineTo(centerX, centerY)
+			ctx.lineWidth = lineDivisionsWidth
+			ctx.setLineDash([5, 15])
+			ctx.strokeStyle = COLORS["white-50"]
 			ctx.stroke()
 
 			// hacemos un circulo en el centro abajo
-
-			const gradientCircle = ctx.createLinearGradient(0, 0, 0, canvas.height)
-			gradientCircle.addColorStop(0, "#222")
-			gradientCircle.addColorStop(0.5, "#111")
-			ctx.strokeStyle = gradientCircle
-			ctx.lineWidth = circleLineWidth
 
 			ctx.beginPath()
 			ctx.arc(centerX, centerY - circleLineWidth, circleLineWidth, 0, 2 * Math.PI)
 			ctx.fillStyle = "#fff"
 			ctx.fill()
-			ctx.stroke()
 		}
 
 		// Initial draw with default value


### PR DESCRIPTION
## Descripción

Modificación del medidor de pronosticos para que tenga coherencia con el diseño e imagen general de la web

## Capturas de pantalla

Antes:
<img width="1082" alt="Velocimetro antes" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/2ff3fbf7-c0dc-4b95-b1d2-b8d94561beb3">

Después:
<img width="1088" alt="Velocimetro después" src="https://github.com/midudev/la-velada-web-oficial/assets/76450853/43765683-c335-4bd5-bd6c-856e846321fc">


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.