### PR TITLE
Fix: reducir alto uso de cpu al navegar a causa del transition:persist

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -16,7 +16,7 @@ const pages = [
 }))
 ---
 
-<header class="mb-10 h-16 max-w-[100vw] lg:h-24" transition:persist>
+<header class="mb-10 h-16 max-w-[100vw] lg:h-24">
 	<nav class="group flex h-full w-full items-center justify-between px-10 lg:justify-center">
 		{
 			pages.map(({ disabled, name, href, active, soonDate }, key) => (

--- a/src/components/LightsBackground.astro
+++ b/src/components/LightsBackground.astro
@@ -1,4 +1,4 @@
-<div transition:persist></div>
+<div></div>
 
 <style>
 	@keyframes lights {

--- a/src/components/NoiseBackground.astro
+++ b/src/components/NoiseBackground.astro
@@ -1,8 +1,5 @@
-<canvas
-	id="noise"
-	aria-label="Efecto de ruido de fondo"
-	class="fixed top-0 -z-10 animate-fade-in"
-	transition:persist></canvas>
+<canvas id="noise" aria-label="Efecto de ruido de fondo" class="fixed top-0 -z-10 animate-fade-in"
+></canvas>
 
 <script>
 	let wWidth: number, wHeight: number

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -5,7 +5,6 @@ import SocialButtons from "@/components/SocialButtons.astro"
 
 <footer
 	class="relative mt-20 flex w-full flex-col place-items-center pb-20 pt-14 md:flex-row md:justify-between md:pt-16"
-	transition:persist
 >
 	<hr
 		class="absolute top-0 h-[2px] w-full min-w-[20rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent bg-center md:my-9"


### PR DESCRIPTION
## Descripción

Alto uso de cpu a causa de usar innecesariamente la propiedad transition:persist de Astro.

## Problema solucionado

Hace poco comence a tener problemas de rendimiento al abrir la pagina, me puse a revisar y me di cuenta que el mal uso de `transition:persist` aumenta muchisimo la carga a la cpu y en equipos de gama baja como es el mio se nota mucho la perdida de rendimiento.

## Cambios propuestos

Se elimina el `transition:persist` usado en el `header`, `footer`, `noise and lights background`, no es necesario usarlo en esos casos y solo empeora el rendimiento.

## Capturas de pantalla (si corresponde)

- Con `transition:persist` alcance a registrar uso del cpu hasta de 28%
![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/737a26c9-2461-4bdd-a9d4-3300ad600a00)

- Sin `transition:persist` se registro como mucho un uso del cpu de 17%
![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/d8eb562c-b516-4538-9494-587e0b80c01e)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
