### PR TITLE
FIX: Problema Header volver home #578

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -43,7 +43,7 @@ const { title, description, preloadImgLCP, canonical, image } = Astro.props
 	>
 		<a
 			href="#main-content"
-			class="fixed top-0 z-20 rounded-br-md bg-secondary px-3 py-5 text-primary opacity-0 focus:opacity-100"
+			class="anchor-main-content fixed top-0 z-20 rounded-br-md bg-secondary px-3 py-5 text-primary opacity-0 focus:opacity-100"
 			>Saltar al contenido principal</a
 		>
 		<NoiseBackground />
@@ -131,6 +131,14 @@ const { title, description, preloadImgLCP, canonical, image } = Astro.props
 					scrollbar-color: theme("colors.primary") transparent;
 					scrollbar-width: thin;
 				}
+			}
+
+			.anchor-main-content {
+				pointer-events: none;
+			}
+
+			.anchor-main-content:focus {
+				pointer-events: all;
 			}
 		</style>
 	</body>


### PR DESCRIPTION
## Descripción y Problema solucionado

issue #578 

El ID #main-content del anchor del layout generaba un error en la sección de peleadores ya que en algunas dimensiones relativamente pequeñas este en lugar de volver al home, se sumaba con la id del peleador, como se ve en el vídeo y la issue

Video del error:

[error.webm](https://github.com/midudev/la-velada-web-oficial/assets/96151177/e5d9674d-fa05-449b-b721-3f34e4bb4810)

Solución:

[solución.webm](https://github.com/midudev/la-velada-web-oficial/assets/96151177/de96f22b-8cf1-4049-bf45-e550fc151aaa)


## Cambios propuestos

Cree un cambio de event pointers en css dependiendo si el anchor está en focus o no. Tal y como lo sugiere Alejandro

![soluuu](https://github.com/midudev/la-velada-web-oficial/assets/96151177/b442a106-7b48-4f60-a1b5-71335a29077a)

## Comprobación de cambios

- [ Sí] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ Sí] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [Sí ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ Sí] He actualizado la documentación, si corresponde.

## Contexto adicional
issue #578 
