### PR TITLE
Link the boxer info with his rival

### DIFF
--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -1,0 +1,31 @@
+---
+import type { Boxer } from "@/consts/boxers"
+
+interface Props {
+	title: string
+	value: Boxer[]
+}
+
+const { title, value } = Astro.props
+---
+
+<div class="flex justify-center text-white">
+	<div class="style text-center">
+		<h4>{title}</h4>
+		{
+			value.map((item, index) => (
+				<>
+					<a
+						class:list={"text-xl font-bold text-accent hover:underline"}
+						id="boxer-weight"
+						href={item.id}
+						title={`Visita la página del boxeador ${item.name}`}
+					>
+						{item.name}
+					</a>
+					{index !== value.length - 1 && <span class="text-xl font-bold text-accent"> y </span>}
+				</>
+			))
+		}
+	</div>
+</div>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -78,10 +78,8 @@ if (forecast) {
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
-					<BoxerDetailInfo title="Rival/es" value={rivals} />
-				</div>
 					<BoxerDetailInfoRival title="Rival/es" value={rivals} />
-				</aside>
+				</div>
 				<div
 					class="relative order-1 flex flex-col items-center justify-center md:order-2 lg:mx-4 lg:w-[800px]"
 				>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -2,6 +2,7 @@
 import BoxerBigImage from "@/components/BoxerBigImage.astro"
 import BoxerClips from "@/components/BoxerClips.astro"
 import BoxerDetailInfo from "@/components/BoxerDetailInfo.astro"
+import BoxerDetailInfoRival from "@/components/BoxerDetailInfoRival.astro"
 import BoxerSocialLink from "@/components/BoxerSocialLink.astro"
 import SectionTitle from "@/components/SectionTitle.astro"
 
@@ -46,13 +47,13 @@ const forecast = FORECASTS.find((forecast) => forecast.combatId === combat.id)
 const boxersWithForecast: BoxerWithForecast[] = []
 let forecastCount = 0
 
-let rivals = ""
+let rivals: Boxer[] = []
 if (typeof boxer.versus === "object") {
-	rivals = boxer.versus
-		.map((vs: string) => BOXERS.find((rival: Boxer) => rival.id === vs)!.name)
-		.join(" y ")
+	for (const vs of boxer.versus) {
+		rivals = rivals.concat(BOXERS.filter((rival: Boxer) => rival.id === vs))
+	}
 } else {
-	rivals = BOXERS.find((rival: Boxer) => rival.id === boxer.versus)!.name
+	rivals = BOXERS.filter((rival: Boxer) => rival.id === boxer.versus)
 }
 
 if (forecast) {
@@ -77,7 +78,7 @@ if (forecast) {
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
-					<BoxerDetailInfo title="Rival/es" value={rivals} />
+					<BoxerDetailInfoRival title="Rival/es" value={rivals} />
 				</aside>
 
 				<div class="relative -mt-24 flex flex-col items-center justify-center lg:mx-4 lg:w-[800px]">

--- a/src/sections/PresentationVideo.astro
+++ b/src/sections/PresentationVideo.astro
@@ -4,7 +4,7 @@ import LiteYouTube from "@/components/LiteYouTube.astro"
 import Typography from "@/components/Typography.astro"
 ---
 
-<section class="mt-10 overflow-hidden px-2 pb-32 pt-16 sm:pb-56 sm:pt-20 md:pb-96 md:pt-60">
+<section class="mt-10 overflow-hidden px-2 pb-48 pt-16 sm:pb-56 sm:pt-20 md:pb-96 md:pt-60">
 	<Typography as="h3" variant="h3" color="white" class:list={"text-center"}>
 		Presentación
 	</Typography>


### PR DESCRIPTION
## Descripción

Se ha agregado la navegación entre los diferentes rivales en `[id].astro` 

## Cambios propuestos

- Se ha actualizado la variable 'rivals' de `[id].astro`  para que devuelva una array
``` javascript
let rivals: Boxer[] = []
if (typeof boxer.versus === "object") {
	for (const vs of boxer.versus) {
		rivals = rivals.concat(BOXERS.filter((rival: Boxer) => rival.id === vs))
	}
} else {
	rivals = BOXERS.filter((rival: Boxer) => rival.id === boxer.versus)
}
```

- Se ha creado un componente `BoxerDetailInfoRival.astro`  para enlazar los rivales separados por `y`
```javascript
value.map((item, index) => (
	<>
		<a
			class:list={"text-xl font-bold text-accent hover:underline"}
			id="boxer-weight"
			href={item.id}
			title={`Visita la página del boxeador ${item.name}`}
		>
			{item.name}
		</a>
		{index !== value.length - 1 && <span class="text-xl font-bold text-accent"> y </span>}
	</>
))
```
## Capturas de pantalla (si corresponde)
### Un sólo rival
https://github.com/midudev/la-velada-web-oficial/assets/44408822/bb923fa8-73f5-47ac-93f0-281c3585d9c5

### Más de un rival
https://github.com/midudev/la-velada-web-oficial/assets/44408822/a0a91cb1-a333-4958-8a0e-29cb9f1b030d

## Comprobación de cambios
- Durante el desarollo he visto que hay otra PR #577 haciendo lo mismo pero en el mismo componente `BoxerDetailInfo.astro`  en vez de separarlo en otro componente `BoxerDetailInfoRival.astro` . Dejo la PR enlazada.
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.