### PR TITLE
add anchor link to boxer-image

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -58,6 +58,8 @@ const boxerColumns = [
 		const boxerLinks = document.querySelectorAll(
 			".boxer-link"
 		) as globalThis.NodeListOf<HTMLAnchorElement>
+		const boxerImageLink = document.createElement("a")
+		boxerImageLink.classList.add("max-w-[450px]", "z-10")
 		const boxerNav = document.querySelector(".boxers-nav")
 		const boxerTitle = document.querySelector(".boxer-title") as HTMLImageElement
 		const boxerPhoto = document.querySelector(".boxer-photo") as HTMLPictureElement
@@ -79,7 +81,7 @@ const boxerColumns = [
 						</span>
 					</a>
 			`
-
+			boxerImageLink.href = `/boxers/${id}`
 			boxerNav?.querySelector(".active")?.classList.remove("active")
 			link.classList.add("active")
 			if (replaceUrl) {
@@ -93,6 +95,8 @@ const boxerColumns = [
 			boxerTitle.innerHTML = spanNames ?? ""
 			boxerCountry.src = `/img/flags/${country}.webp`
 			boxerPhoto.getElementsByTagName("img")[0].alt = `Fotografía de ${name}`
+			boxerPhoto.parentNode?.insertBefore(boxerImageLink, boxerPhoto.nextSibling)
+			boxerImageLink.appendChild(boxerPhoto)
 			boxerCountry.alt = `Bandera de ${countryName}`
 		}
 
@@ -115,7 +119,7 @@ const boxerColumns = [
 
 <style>
 	.boxers-lists {
-		@apply relative md:h-[480px] xl:h-32 w-screen overflow-x-scroll;
+		@apply relative w-screen overflow-x-scroll md:h-[480px] xl:h-32;
 		scrollbar-width: none;
 	}
 


### PR DESCRIPTION
## Descripción

imagen de boxerPhoto en la  seccion de SelectYourBoxer.astro no es clickeable para el usuario

## Problema solucionado

cree un elemento anchor que envuelva la misma para que el la imagen pueda dirigir al usuario a la pagina del boxeador

## Cambios propuestos

cree una nueva etiqueta html  de tipo anchor en el script ubicado en archivo SelectYourBoxer.astro 

![Captura de pantalla 2024-03-17 150755](https://github.com/midudev/la-velada-web-oficial/assets/122571870/af1da1b4-e2e5-45d8-a095-21c732cf1016)

## Capturas de pantalla (si corresponde)

antes: 

https://github.com/midudev/la-velada-web-oficial/assets/122571870/1e9da55d-5b1a-43dc-a1af-c50eba15fa9a

despues: 

https://github.com/midudev/la-velada-web-oficial/assets/122571870/6e575b15-58e0-4243-80b2-aa29be1bf49f


## Comprobación de cambios

- [👍 ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ 👍] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ 👍] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial
## Contexto adicional
## Enlaces útiles
