### PR TITLE
Fix responsive SelectYourBoxer in mobile

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -20,7 +20,7 @@ const boxerColumns = [
 ]
 ---
 
-<section class="my-40 hidden md:block">
+<section class="my-40">
 	<Typography
 		as="h3"
 		variant="atomic-title"
@@ -115,7 +115,7 @@ const boxerColumns = [
 
 <style>
 	.boxers-lists {
-		@apply relative md:h-[480px] xl:h-32 w-screen overflow-x-scroll;
+		@apply relative w-screen overflow-x-scroll md:h-[480px] xl:h-32;
 		scrollbar-width: none;
 	}
 


### PR DESCRIPTION
## Descripción

## Problema solucionado

La sección "Elige tu Luchador" no aparece en mobile. #529 

## Cambios propuestos

Eliminar el estilo "hidden" de la sección y a su vez el breakpoint medium.

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/61757709/59a4f2e4-72af-42bc-bfb8-f304af29809b)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/61757709/032d00e5-6a77-42fa-ae81-5ceab5fa624c)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
