### PR TITLE
Formateo de rivales

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -50,7 +50,7 @@ let rivals = ""
 if (typeof boxer.versus === "object") {
 	rivals = boxer.versus
 		.map((vs: string) => BOXERS.find((rival: Boxer) => rival.id === vs)!.name)
-		.join(" y ")
+		.join(" / ")
 } else {
 	rivals = BOXERS.find((rival: Boxer) => rival.id === boxer.versus)!.name
 }


### PR DESCRIPTION
## Descripción

Con el "y" se veía un poco mal para varios rivales, considerando que hay 10 boxeadores para El Rey de la Pista

## Problema solucionado

Se cambió la **y** por una **/** para que cuando tenga más rivales el boxeador se vea bien

## Cambios propuestos

## Capturas de pantalla (si corresponde)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

## Enlaces útiles
