### PR TITLE
Mejora la visualización en móvil de los detalles del boxeador (Figma)

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -21,6 +21,7 @@ const { title, value } = Astro.props
 
 <style>
 	.style {
+		width: 100%;
 		display: flex;
 		justify-content: space-between;
 		align-items: center;
@@ -35,7 +36,7 @@ const { title, value } = Astro.props
 		h4,
 		p {
 			margin: 0;
-			padding: 10px;
+			padding: 2px 10px;
 		}
 
 		h4 {

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -73,11 +73,13 @@ if (forecast) {
 	<main>
 		<section class="flex flex-col items-center justify-center">
 			<div class="flex flex-col items-center md:flex-row md:gap-10 lg:items-start">
-				<div class="order-2 flex flex-col gap-y-6 md:order-1 md:gap-y-20 lg:w-1/4">
+				<div class="order-2 flex w-full flex-col md:order-1 md:w-auto md:gap-y-20 lg:w-1/4">
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
-					<BoxerDetailInfo title="Rival/es" value={rivals} />
+					<div class="hidden md:block">
+						<BoxerDetailInfo title="Rival/es" value={rivals} />
+					</div>
 				</div>
 
 				<div
@@ -86,11 +88,14 @@ if (forecast) {
 					<BoxerBigImage id={id} name={boxer.name} country={boxer.country} />
 				</div>
 
-				<div class="order-3 flex flex-col gap-y-6 md:order-3 md:gap-y-20 lg:w-1/4">
+				<div class="order-3 flex w-full flex-col md:w-auto md:gap-y-20 lg:w-1/4">
 					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} />
 					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} />
 					<BoxerDetailInfo title="Guardia" value={boxer.guard} />
 					<BoxerDetailInfo title="Alcance" value={boxer.reach} />
+					<div class="block md:hidden">
+						<BoxerDetailInfo title="Rival/es" value={rivals} />
+					</div>
 				</div>
 			</div>
 


### PR DESCRIPTION
## Descripción / Problema solucionado

Mejora la visualización en móvil de los detalles del boxeador, adaptandose al diseño que se encuentra en Figma.  

![image](https://github.com/midudev/la-velada-web-oficial/assets/65029253/034b7ad3-85e3-41bd-ac95-68123685a37f)

## Capturas de pantalla (si corresponde)

Antes:  
![image](https://github.com/midudev/la-velada-web-oficial/assets/65029253/46a86a9f-b42f-400a-8443-30f83e6f81c1)
Después:  
![image](https://github.com/midudev/la-velada-web-oficial/assets/65029253/924fa3ae-9cbb-4310-9327-4bfce55cb769)

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.
