### PR TITLE
fix: dynamic alt name for boxer component

### DIFF
--- a/src/components/BoxerBigImage.astro
+++ b/src/components/BoxerBigImage.astro
@@ -32,7 +32,7 @@ const firstNames = splitName.slice(0, splitName.length - 1).join(" ")
 	<source srcset={`/img/boxers/${id}-big.avif`} type="image/avif" />
 	<img
 		class="aspect-[285/428] h-auto w-full object-contain"
-		alt="Fotografía de El Mariana"
+		alt={`Fotografía de ${name}`}
 		src={`/img/boxers/${id}-big.webp`}
 		style="
 			filter: drop-shadow(0 0 20px rgba(0, 0, 0, .5));


### PR DESCRIPTION
## Descripción

Cambio en el alt name de la foto del peleador.

## Problema solucionado

Ahora cada imágen tiene su nombre alt correspondiente.

## Cambios propuestos

![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/abc5b189-2af5-4f1d-a0ba-5cfa6b2b46b5)

## Capturas de pantalla (si corresponde)
Producción:
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/54a47a1a-645c-43fa-a167-95303e8890c1)
Localhost:
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/b2bbff03-fa35-4bd7-8f80-76d141ea88b5)


## Comprobación de cambios

- [ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
