### PR TITLE
FIX: Optimized images for KonamiCode 'midu'

### DIFF
--- a/src/function/miduCode.ts
+++ b/src/function/miduCode.ts
@@ -13,13 +13,14 @@ export async function showContributors($miduContainer: HTMLDivElement) {
 		setTimeout(() => {
 			const { avatar_url, login } = contributors[i]
 			const img = document.createElement("img")
-			img.src = avatar_url
 			img.alt = login
 			img.title = login
 			img.classList.add("bubbles")
 			if (login === "midudev") {
 				img.setAttribute("id", "midu")
+				img.src = `${avatar_url}&size=150`
 			} else {
+				img.src = `${avatar_url}&size=60`
 				img.style.left = `${generateRandomNumber()}vw`
 				const startRotation = Math.floor(Math.random() * (90 - -90 + 1)) + -45
 				img.style.transform = `rotate(${startRotation}deg)`


### PR DESCRIPTION
## Descripción

Al utilizar el KonamiCode 'midu' cargan las imagenes en su tamaño original.
[Picture MiduDev](https://avatars.githubusercontent.com/u/1561955?v=4)

## Cambios propuestos
Al llamar la url de la imagenes de contributors se puede añadir el parametro '`size=` para indicar el tamaño de la imagen que queremos descargar.
[Picture MiduDev 150px](https://avatars.githubusercontent.com/u/1561955?v=4&size=150)

- Basandome en el tamaño que carga según el css 
```css
.bubbles {
	width: 60px;
	height: 60px;
}

#midu {
	width: 150px;
	height: 150px;
}
```
- Podriamos modificar la función que llama a las imagenes para que cargen el tamaño correcto
```js
const { avatar_url, login } = contributors[i]
const img = document.createElement("img")
// other things
img.classList.add("bubbles")
if (login === "midudev") {
	img.setAttribute("id", "midu")
	img.src = `${avatar_url}&size=150` //añadido
} else {
	img.src = `${avatar_url}&size=60` //añadido
	// other things
}
```
->

## Capturas de pantalla (si corresponde)
## Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/44408822/4e075fd0-0e1d-454e-b8b3-c7a603e2db16)

## Después
![image](https://github.com/midudev/la-velada-web-oficial/assets/44408822/67e2f50e-4e8e-47e1-89e8-7f405293b982)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles
[Get GitHub avatar from email or name (primera respuesta)](https://stackoverflow.com/a/36380674)
