### PR TITLE
Fix countdown and animatedX after page:load (issue #609)

### DIFF
--- a/src/components/AnimatedX.astro
+++ b/src/components/AnimatedX.astro
@@ -141,19 +141,23 @@
 	>
 </span>
 <script>
+	let intervalId: NodeJS.Timeout
 	type AnimatedXElement = SVGGElement | null
 
 	const INTERVAL_TIME = 100
 	const STROKES = { none: "none", accent: "var(--color-accent)" }
 
-	const $svgGroup1 = document.getElementById("layer1") as AnimatedXElement
-	const $svgGroup2 = document.getElementById("layer2") as AnimatedXElement
-	const $svgGroup3 = document.getElementById("layer3") as AnimatedXElement
-
 	const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches
-	if (!prefersReducedMotion) {
-		setInterval(() => drawGroup([$svgGroup1, $svgGroup2, $svgGroup3]), INTERVAL_TIME)
-	}
+	document.addEventListener("astro:page-load", () => {
+		if (prefersReducedMotion) return
+
+		intervalId && clearInterval(intervalId)
+		const $svgGroup1 = document.getElementById("layer1") as AnimatedXElement
+		const $svgGroup2 = document.getElementById("layer2") as AnimatedXElement
+		const $svgGroup3 = document.getElementById("layer3") as AnimatedXElement
+
+		intervalId = setInterval(() => drawGroup([$svgGroup1, $svgGroup2, $svgGroup3]), INTERVAL_TIME)
+	})
 
 	function drawGroup($svgGroups: AnimatedXElement[]): void {
 		$svgGroups.forEach((gElement: AnimatedXElement) => {

--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -58,23 +58,72 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 	import { $ } from "@/lib/dom-selector"
 	import createCountdown from "@/lib/countdown"
 
-	const $countdown = $("[data-date]")
-	const $days = {
-		firstDigit: $("[data-days] [data-first-group]", $countdown),
-		secondDigit: $("[data-days] [data-second-group]", $countdown),
-		thirdDigit: $("[data-days] [data-third-group]", $countdown),
-	}
-	const $hours = {
-		firstDigit: $("[data-hours] [data-first-group]", $countdown),
-		secondDigit: $("[data-hours] [data-second-group]", $countdown),
-	}
-	const $minutes = {
-		firstDigit: $("[data-minutes] [data-first-group]", $countdown),
-		secondDigit: $("[data-minutes] [data-second-group]", $countdown),
-	}
-	const $seconds = {
-		firstDigit: $("[data-seconds] [data-first-group]", $countdown),
-		secondDigit: $("[data-seconds] [data-second-group]", $countdown),
+	function initCountdown() {
+		const $countdown = $("[data-date]")
+		const $days = {
+			firstDigit: $("[data-days] [data-first-group]", $countdown),
+			secondDigit: $("[data-days] [data-second-group]", $countdown),
+			thirdDigit: $("[data-days] [data-third-group]", $countdown),
+		}
+		const $hours = {
+			firstDigit: $("[data-hours] [data-first-group]", $countdown),
+			secondDigit: $("[data-hours] [data-second-group]", $countdown),
+		}
+		const $minutes = {
+			firstDigit: $("[data-minutes] [data-first-group]", $countdown),
+			secondDigit: $("[data-minutes] [data-second-group]", $countdown),
+		}
+		const $seconds = {
+			firstDigit: $("[data-seconds] [data-first-group]", $countdown),
+			secondDigit: $("[data-seconds] [data-second-group]", $countdown),
+		}
+		const timestamp = Number($countdown?.getAttribute("data-date") ?? 0)
+		const countdown = createCountdown(timestamp, {
+			onTick({ days, hours, minutes, seconds }) {
+				if (
+					$days.firstDigit instanceof HTMLElement &&
+					$days.secondDigit instanceof HTMLElement &&
+					$days.thirdDigit instanceof HTMLElement
+				) {
+					animateDigit($days.firstDigit, days[0])
+					animateDigit($days.secondDigit, days[1])
+					animateDigit($days.thirdDigit, days[2])
+				}
+
+				if ($hours.firstDigit instanceof HTMLElement && $hours.secondDigit instanceof HTMLElement) {
+					animateDigit($hours.firstDigit, hours[0])
+					animateDigit($hours.secondDigit, hours[1])
+				}
+
+				if (
+					$minutes.firstDigit instanceof HTMLElement &&
+					$minutes.secondDigit instanceof HTMLElement
+				) {
+					animateDigit($minutes.firstDigit, minutes[0])
+					animateDigit($minutes.secondDigit, minutes[1])
+				}
+
+				if (
+					$seconds.firstDigit instanceof HTMLElement &&
+					$seconds.secondDigit instanceof HTMLElement
+				) {
+					animateDigit($seconds.firstDigit, seconds[0])
+					animateDigit($seconds.secondDigit, seconds[1])
+				}
+			},
+
+			onComplete() {
+				$(".countdown-text")?.remove()
+
+				if (!$countdown) return
+
+				$countdown.innerHTML = "¡El evento de presentación ha empezado! 🎉"
+				$countdown.className =
+					"text-primary uppercase font-semibold animate-fade-in text-3xl text-center"
+			},
+		})
+
+		return countdown
 	}
 
 	function animateDigit(group: HTMLElement, value: string) {
@@ -103,53 +152,8 @@ import { EVENT_TIMESTAMP } from "@/consts/event-date"
 		}
 	}
 
-	const timestamp = Number($countdown?.getAttribute("data-date") ?? 0)
-	const countdown = createCountdown(timestamp, {
-		onTick({ days, hours, minutes, seconds }) {
-			if (
-				$days.firstDigit instanceof HTMLElement &&
-				$days.secondDigit instanceof HTMLElement &&
-				$days.thirdDigit instanceof HTMLElement
-			) {
-				animateDigit($days.firstDigit, days[0])
-				animateDigit($days.secondDigit, days[1])
-				animateDigit($days.thirdDigit, days[2])
-			}
-
-			if ($hours.firstDigit instanceof HTMLElement && $hours.secondDigit instanceof HTMLElement) {
-				animateDigit($hours.firstDigit, hours[0])
-				animateDigit($hours.secondDigit, hours[1])
-			}
-
-			if (
-				$minutes.firstDigit instanceof HTMLElement &&
-				$minutes.secondDigit instanceof HTMLElement
-			) {
-				animateDigit($minutes.firstDigit, minutes[0])
-				animateDigit($minutes.secondDigit, minutes[1])
-			}
-
-			if (
-				$seconds.firstDigit instanceof HTMLElement &&
-				$seconds.secondDigit instanceof HTMLElement
-			) {
-				animateDigit($seconds.firstDigit, seconds[0])
-				animateDigit($seconds.secondDigit, seconds[1])
-			}
-		},
-
-		onComplete() {
-			$(".countdown-text")?.remove()
-
-			if (!$countdown) return
-
-			$countdown.innerHTML = "¡El evento de presentación ha empezado! 🎉"
-			$countdown.className =
-				"text-primary uppercase font-semibold animate-fade-in text-3xl text-center"
-		},
-	})
-
 	document.addEventListener("astro:page-load", () => {
+		const countdown = initCountdown()
 		countdown.start()
 	})
 </script>


### PR DESCRIPTION
## Descripción

Luego de una viewTransition los elementos del dom cambian, por lo que hay que volver a recuperarlos con javascript, al no hacerlo se ejecuta todo el javascript pero con la referencia incorrecta a los elementos del dom, haciendo que no se vean las animaciones ni el countdown

## Problema solucionado

issue #609 (bug logo animado y countdown)

## Cambios propuestos

. obtener los elementos del dom luego de una view transition

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
