### PR TITLE
feat: Add boxerHref prop to ForecastBoxer component to add anchor for the article

### DIFF
--- a/src/components/ForecastBoxer.astro
+++ b/src/components/ForecastBoxer.astro
@@ -3,21 +3,59 @@ interface Props {
 	image: string
 	imageAlt: string
 	boxerName: string
+	boxerHref: string
 	percentage: number
 }
 
-const { image, imageAlt, boxerName, percentage } = Astro.props
+const { image, imageAlt, boxerName, boxerHref, percentage } = Astro.props
 ---
 
-<article>
-	<img class="image" src={image} alt={imageAlt} />
-	<h3 class:list={["text-center text-2xl font-medium uppercase text-white"]}>{boxerName}</h3>
-	<h4 class:list={["mt-1 text-center text-6xl font-semibold text-accent"]}>{percentage}%</h4>
-</article>
+<a href={boxerHref} class="underline-transition">
+	<article>
+		<img class="image" src={image} alt={imageAlt} />
+		<h3 class:list={["text-center text-2xl font-medium uppercase text-white"]}>
+			{boxerName}
+		</h3>
+		<h4 class:list={["mt-1 text-center text-6xl font-semibold text-accent"]}>{percentage}%</h4>
+	</article>
+</a>
 
 <style>
 	.image {
 		filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.5));
 		mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+	}
+
+	.underline-transition {
+		background-image: linear-gradient(transparent, transparent),
+			linear-gradient(var(--color-accent) 20%, var(--color-accent) 80%);
+		background-size: 0 3px;
+		background-position: 100% 100%;
+		background-repeat: no-repeat;
+		transition: background-size 0.3s ease-in-out;
+	}
+
+	@media (prefers-reduced-motion) {
+		.underline-transition {
+			transition: none;
+		}
+	}
+	.underline-transition:hover {
+		background-size: 100% 3px;
+		background-position: 0 100%;
+	}
+	@media (prefers-reduced-motion) {
+		.underline-transition {
+			background-image: linear-gradient(transparent, transparent),
+				linear-gradient(var(--color-accent) 20%, var(--color-accent) 80%);
+			background-size: 0 3px;
+			background-position: 100% 100%;
+			background-repeat: no-repeat;
+			transition: background-size 0s;
+		}
+		.underline-transition:hover {
+			background-size: 100% 3px;
+			background-position: 0 100%;
+		}
 	}
 </style>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -50,7 +50,7 @@ let forecastCount = 0
 
 let rivals: Boxer[] = []
 if (typeof boxer.versus === "object") {
-  for (const vs of boxer.versus) {
+	for (const vs of boxer.versus) {
 		rivals = rivals.concat(BOXERS.filter((rival: Boxer) => rival.id === vs))
 	}
 } else {

--- a/src/sections/Forecasts.astro
+++ b/src/sections/Forecasts.astro
@@ -21,6 +21,7 @@ const { count, boxers } = Astro.props
 		image={`/img/boxers/${boxers[0].id}-big.webp`}
 		imageAlt={`${boxers[0].name}`}
 		boxerName={boxers[0].name}
+		boxerHref=`/boxers/${boxers[0].id}`
 		percentage={boxers[0].forecast * 100}
 		class:list={["boxer1"]}
 	/>
@@ -35,6 +36,7 @@ const { count, boxers } = Astro.props
 		image={`/img/boxers/${boxers[1].id}-big.webp`}
 		imageAlt={`${boxers[1].name}`}
 		boxerName={boxers[1].name}
+		boxerHref=`/boxers/${boxers[1].id}`
 		percentage={boxers[1].forecast * 100}
 		class:list={["boxer1"]}
 	/>


### PR DESCRIPTION
## Descripción

Para mejorar la navegacion en el sitio web se agrego el anlace al boxeador correspondiente en la seccion de prediccion.

## Cambios propuestos

- Agregar etiqueta anchor al article de cada boxeador en la seccion de prediccion.

## Capturas de pantalla (si corresponde)

### Antes

[before.webm](https://github.com/midudev/la-velada-web-oficial/assets/35277540/68e33978-ed36-4d79-8879-2327e83017c7)

### Despues

[after.webm](https://github.com/midudev/la-velada-web-oficial/assets/35277540/b1daa54a-b6e1-45a8-86ed-abb3dc82b677)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
