### PR TITLE
Update HeroLogo link and height in Header component

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -105,7 +105,9 @@ const pages = [
 			>
 			</div>
 			<div class="-ml-[8px] -mr-[4px]">
-				<HeroLogo class:list={" w-full"} noEffect />
+				<a href="/">
+					<HeroLogo class:list={"h-auto w-full"} noEffect />
+				</a>
 			</div>
 
 			<div


### PR DESCRIPTION
## Descripción

Agregar link a la home al logo del header y arreglar el height del logo ya que ocupaba bastante mas que el svg

## Problema solucionado

Normalmente los logos en las webs mandan a la home y al menos en mi caso he intentando varias veces hacer click para volver a la home sin éxito, por lo que he agregado el link al logo

## Cambios propuestos

Agregar <a> al logo y agregar h-auto para evitar que el height del del svg se superponiese 


## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

