### PR TITLE
Pronostic boxers hover

### DIFF
--- a/src/components/ForecastBoxer.astro
+++ b/src/components/ForecastBoxer.astro
@@ -10,13 +10,13 @@ interface Props {
 const { image, imageAlt, boxerName, boxerHref, percentage } = Astro.props
 ---
 
-<a href={boxerHref} class="underline-transition">
+<a href={boxerHref} class="group hover:scale-105 transition-transform overflow-hidden">
 	<article>
 		<img class="image" src={image} alt={imageAlt} />
-		<h3 class:list={["text-center text-2xl font-medium uppercase text-white"]}>
+		<h3 class:list={["text-center text-2xl font-medium uppercase text-white transition-transform group-hover:scale-125 md:group-hover:scale-150"]}>
 			{boxerName}
 		</h3>
-		<h4 class:list={["mt-1 text-center text-6xl font-semibold text-accent"]}>{percentage}%</h4>
+		<h4 class:list={["mt-1 text-center text-6xl font-semibold text-accent transition-transform group-hover:scale-75"]}>{percentage}%</h4>
 	</article>
 </a>
 
@@ -24,38 +24,5 @@ const { image, imageAlt, boxerName, boxerHref, percentage } = Astro.props
 	.image {
 		filter: drop-shadow(0 0 20px rgba(0, 0, 0, 0.5));
 		mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
-	}
-
-	.underline-transition {
-		background-image: linear-gradient(transparent, transparent),
-			linear-gradient(var(--color-accent) 20%, var(--color-accent) 80%);
-		background-size: 0 3px;
-		background-position: 100% 100%;
-		background-repeat: no-repeat;
-		transition: background-size 0.3s ease-in-out;
-	}
-
-	@media (prefers-reduced-motion) {
-		.underline-transition {
-			transition: none;
-		}
-	}
-	.underline-transition:hover {
-		background-size: 100% 3px;
-		background-position: 0 100%;
-	}
-	@media (prefers-reduced-motion) {
-		.underline-transition {
-			background-image: linear-gradient(transparent, transparent),
-				linear-gradient(var(--color-accent) 20%, var(--color-accent) 80%);
-			background-size: 0 3px;
-			background-position: 100% 100%;
-			background-repeat: no-repeat;
-			transition: background-size 0s;
-		}
-		.underline-transition:hover {
-			background-size: 100% 3px;
-			background-position: 0 100%;
-		}
 	}
 </style>

--- a/src/components/ForecastBoxer.astro
+++ b/src/components/ForecastBoxer.astro
@@ -10,7 +10,11 @@ interface Props {
 const { image, imageAlt, boxerName, boxerHref, percentage } = Astro.props
 ---
 
-<a href={boxerHref} class="group hover:scale-105 transition-transform overflow-hidden">
+<a
+	href={boxerHref}
+	class="group hover:scale-105 transition-transform overflow-hidden"
+	aria-label={`Ir a la página de ${boxerName}`}
+>
 	<article>
 		<img class="image" src={image} alt={imageAlt} />
 		<h3 class:list={["text-center text-2xl font-medium uppercase text-white transition-transform group-hover:scale-125 md:group-hover:scale-150"]}>

--- a/src/components/ForecastBoxer.astro
+++ b/src/components/ForecastBoxer.astro
@@ -17,10 +17,10 @@ const { image, imageAlt, boxerName, boxerHref, percentage } = Astro.props
 >
 	<article>
 		<img class="image" src={image} alt={imageAlt} />
-		<h3 class:list={["text-center text-2xl font-medium uppercase text-white transition-transform group-hover:scale-125 md:group-hover:scale-150"]}>
+		<h3 class="text-center text-2xl font-medium uppercase text-white transition-transform group-hover:scale-125 md:group-hover:scale-150">
 			{boxerName}
 		</h3>
-		<h4 class:list={["mt-1 text-center text-6xl font-semibold text-accent transition-transform group-hover:scale-75"]}>{percentage}%</h4>
+		<h4 class="mt-1 text-center text-6xl font-semibold text-accent transition-transform group-hover:scale-75">{percentage}%</h4>
 	</article>
 </a>
 

--- a/src/sections/Forecasts.astro
+++ b/src/sections/Forecasts.astro
@@ -38,7 +38,7 @@ const { count, boxers } = Astro.props
 		boxerName={boxers[1].name}
 		boxerHref=`/boxers/${boxers[1].id}`
 		percentage={boxers[1].forecast * 100}
-		class:list={["boxer1"]}
+		class:list={["boxer2"]}
 	/>
 	<div class="action flex w-full flex-col items-center justify-center">
 		<Action


### PR DESCRIPTION
## Descripción

Antes había un underline en el enlace entero (enlace con articulo, imagen, nombre y porcentage) que parecia que marcaba el porcentaje y quedaba poco intuitivo.

## Problema solucionado

- Jugando con scale substituimos el efecto poco intuitivo y nos ahorramos algunas lineas de código.
- Agregado de aria-label
- Substituir `class:list` inecesarias por `class`

## Capturas de pantalla (si corresponde)

Antes:

https://github.com/midudev/la-velada-web-oficial/assets/76450853/1042796f-33a4-40a7-b985-0aab9fcf54f5

Después:

https://github.com/midudev/la-velada-web-oficial/assets/76450853/88e781d4-3636-4084-b738-74a68af2d345

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.