### PR TITLE
FIX: Problem when hovering between two boxers

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -103,7 +103,7 @@ const boxerColumns = [
 			const lastName = splitName[splitName.length - 1]
 			const firstNames = splitName.slice(0, splitName.length - 1).join(" ")
 			const spanNames = `
-					<a href="/boxers/${id}" class="boxer-link underline-transition transition-all duration-300 hover:text-accent motion-reduce:transition-none">
+					<a href="/boxers/${id}" class="boxer-link underline-transition transition-all duration-300 hover:text-accent motion-reduce:transition-none mb-1">
 						<span class="flex flex-col">
 							<span class="text-4xl">${firstNames?.toLocaleLowerCase()}</span>
 							<span>${lastName?.toLocaleLowerCase()}</span>

--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -103,7 +103,7 @@ const boxerColumns = [
 			const lastName = splitName[splitName.length - 1]
 			const firstNames = splitName.slice(0, splitName.length - 1).join(" ")
 			const spanNames = `
-					<a href="/boxers/${id}" class="boxer-link underline-transition transition-all duration-300 hover:text-accent motion-reduce:transition-none mb-1">
+					<a href="/boxers/${id}" class="boxer-link underline-transition transition-all duration-300 hover:text-accent motion-reduce:transition-none mb-2">
 						<span class="flex flex-col">
 							<span class="text-4xl">${firstNames?.toLocaleLowerCase()}</span>
 							<span>${lastName?.toLocaleLowerCase()}</span>


### PR DESCRIPTION
## Descripción

Se añadio una clase tailwind ( mb-2 ) que inserta margin bottom con el fin the resolver glith a la hora de seleccionar un boxeador.

## Problema solucionado

Al momento de poner el cursor entre el margen de 2 boxeadores ocurre un glitch que alterna la imagen mostrada entre 2 boxeadores repetitivamente.

## Cambios propuestos

bastaria con añadir una clase que haga un poco de espacio entre la seleccion de boxeadores para que el cursor no ocacione el glicth.

## Capturas de pantalla (si corresponde)

< BEFORE > 
[before.webm](https://github.com/midudev/la-velada-web-oficial/assets/149793793/4ec4c210-bcbb-4451-b139-2be5a1d55fc0)

< AFTER >
[after.webm](https://github.com/midudev/la-velada-web-oficial/assets/149793793/447f3592-553e-4010-b1ed-c18c25cc4e03)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
