### PR TITLE
FIX: Add margin bottom to the .boxer-link

### DIFF
--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -38,7 +38,7 @@ const { boxers, class: className = "" } = Astro.props
 
 <style>
 	.boxer-link {
-		@apply relative flex flex-col items-center justify-center transition-opacity duration-300 ease-in-out md:size-28 xl:size-36;
+		@apply relative flex flex-col mb-2 items-center justify-center transition-opacity duration-300 ease-in-out md:size-28 xl:size-36;
 
 		&:hover {
 			@apply opacity-90;


### PR DESCRIPTION
## Descripción

Se añadio una clase tailwind ( mb-2 ) que inserta margin bottom con el fin the resolver glith a la hora de seleccionar un boxeador.

## Problema solucionado

Al momento de poner el cursor entre el margen de 2 boxeadores ocurre un glitch que alterna la imagen mostrada entre 2 boxeadores repetitivamente.

## Cambios propuestos

bastaria con añadir una clase que haga un poco de espacio entre la seleccion de boxeadores para que el cursor no ocacione el glicth.

## Capturas de pantalla (si corresponde)

< BEFORE > 

[before.webm](https://github.com/midudev/la-velada-web-oficial/assets/149793793/af1db7af-a407-458b-98c7-b085e8b57da2)

< AFTER >
[after.webm](https://github.com/midudev/la-velada-web-oficial/assets/149793793/643b0f25-b7d4-4b71-baec-bbba42d0f38e)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
