### PR TITLE
fix: responsive boxers page

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -74,8 +74,8 @@ if (forecast) {
 >
 	<main>
 		<section class="flex flex-col items-center justify-center">
-			<div class="flex flex-col items-center md:flex-row md:gap-10 lg:items-start">
-				<div class="order-2 flex w-full flex-col md:order-1 md:w-auto md:gap-y-20 lg:w-1/4">
+			<div class="flex w-full flex-col items-center md:flex-row md:gap-10">
+				<div class="order-2 flex w-full flex-col md:order-1 md:w-1/4 md:gap-y-20">
 					<BoxerDetailInfo title="Alias" value={boxer.name} />
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
 					<BoxerDetailInfo title="Edad" value={boxer.age} />
@@ -85,12 +85,12 @@ if (forecast) {
 				</div>
 
 				<div
-					class="relative order-1 -mt-20 flex flex-col items-center justify-center md:order-2 lg:mx-4 lg:w-[800px]"
+					class="relative order-1 -mt-20 flex flex-col items-center justify-center md:order-2 md:w-1/2 lg:mx-4"
 				>
 					<BoxerBigImage id={id} name={boxer.name} country={boxer.country} />
 				</div>
 
-				<div class="order-3 flex w-full flex-col md:w-auto md:gap-y-20 lg:w-1/4">
+				<div class="order-3 flex w-full flex-col md:w-1/4 md:gap-y-20">
 					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} />
 					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} />
 					<BoxerDetailInfo title="Guardia" value={boxer.guard} />


### PR DESCRIPTION
## Descripción

El diseño responsive de la web se estropea, específicamente en la página del boxeador.

## Problema solucionado

Quitar el ancho de 800px a un div y en su lugar agregarle un ancho del 50%, evita que se estropee el diseño responsive.

## Capturas de pantalla 

En las siguientes screenshot se puede observar como el diseño responsive de la web se estropea

El problema en el navegador  Edge

![version edge](https://github.com/midudev/la-velada-web-oficial/assets/29683351/9d1c3c42-1806-4627-91db-9fa8ccbbd42b)

El problema en el navegador  mozilla firefox

![version mozilla firefox](https://github.com/midudev/la-velada-web-oficial/assets/29683351/8ee49f03-ac74-43a3-adab-0bb346f56b8b)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
