### PR TITLE
fix: focusable elements not unique 

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -2,18 +2,16 @@
 interface Props {
 	title: string
 	value?: string | number | string[]
+	id: string
 }
 
-const { title, value } = Astro.props
+const { title, value, id } = Astro.props
 ---
 
 <div class="flex justify-center text-white">
 	<div class="style flex flex-col items-start text-center">
 		<h4>{title}</h4>
-		<p
-			class:list={`text-xl font-bold ${title === "Rival/es" ? "text-accent" : ""}`}
-			id="boxer-weight"
-		>
+		<p class:list={`text-xl font-bold ${title === "Rival/es" ? "text-accent" : ""}`} id={id}>
 			{value}
 		</p>
 	</div>

--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -4,9 +4,10 @@ import type { Boxer } from "@/consts/boxers"
 interface Props {
 	title: string
 	value: Boxer[]
+	id: string
 }
 
-const { title, value } = Astro.props
+const { title, value, id } = Astro.props
 ---
 
 <div class="flex justify-center text-white">
@@ -20,9 +21,9 @@ const { title, value } = Astro.props
 					<>
 						<a
 							class:list={"text-xl font-bold text-accent hover:underline"}
-							id="boxer-weight"
 							href={item.id}
 							title={`Visita la página del boxeador ${item.name}`}
+							id={id + (index + 1)}
 						>
 							{item.name}
 						</a>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -76,11 +76,11 @@ if (forecast) {
 		<section class="flex flex-col items-center justify-center">
 			<div class="flex flex-col items-center md:flex-row md:gap-10 lg:items-start">
 				<div class="order-2 flex w-full flex-col md:order-1 md:w-auto md:gap-y-20 lg:w-1/4">
-					<BoxerDetailInfo title="Alias" value={boxer.name} />
-					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} />
-					<BoxerDetailInfo title="Edad" value={boxer.age} />
+					<BoxerDetailInfo title="Alias" value={boxer.name} id="boxer-alias" />
+					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} id="boxer-país" />
+					<BoxerDetailInfo title="Edad" value={boxer.age} id="boxer-edad" />
 					<div class="hidden md:block">
-						<BoxerDetailInfoRival title="Rival/es" value={rivals} />
+						<BoxerDetailInfoRival title="Rival/es" value={rivals} id="boxer-rival-desk" />
 					</div>
 				</div>
 
@@ -91,12 +91,12 @@ if (forecast) {
 				</div>
 
 				<div class="order-3 flex w-full flex-col md:w-auto md:gap-y-20 lg:w-1/4">
-					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} />
-					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} />
-					<BoxerDetailInfo title="Guardia" value={boxer.guard} />
-					<BoxerDetailInfo title="Alcance" value={boxer.reach} />
+					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} id="boxer-peso" />
+					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} id="boxer-altura" />
+					<BoxerDetailInfo title="Guardia" value={boxer.guard} id="boxer-guardia" />
+					<BoxerDetailInfo title="Alcance" value={boxer.reach} id="boxer-alcance" />
 					<div class="block md:hidden">
-						<BoxerDetailInfoRival title="Rival/es" value={rivals} />
+						<BoxerDetailInfoRival title="Rival/es" value={rivals} id="boxer-rival-mobile" />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Descripción

Para mejorar la accesibilidad según lighthouse, los elementos a los que se puede hacer focus deberían tener un id único.
Se aplicaba el id boxer-weight por defecto en página de detalle del boxeador.
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/8ea0eef6-7b00-495b-a1ff-f48c15c8bb11)

## Problema solucionado
![image](https://github.com/midudev/la-velada-web-oficial/assets/139919492/8fb8c7ae-e8b3-4aed-9918-56edb1e0348e)



## Cambios propuestos

Pasar por props ids correctos para cada detalle.

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
