### PR TITLE
Add versus on SelectYourBoxer 10vs10

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -136,6 +136,14 @@ const boxerColumns = [
 					})
 				)
 
+				if (opponents === "rey-de-la-pista") {
+					boxerLinks.forEach((link) => {
+						if (link.dataset.opponents === "rey-de-la-pista" && link.dataset.id !== id) {
+							link.classList.add("opponent")
+						}
+					})
+				}
+
 				opponents.split(",").map((opponent) =>
 					boxerLinks.forEach((link) => {
 						if (link.dataset.id === opponent) {


### PR DESCRIPTION
## Descripción

Añadir versus en los boxeadores del Rei de la pista

## Capturas de pantalla (si corresponde)

Después:

https://github.com/midudev/la-velada-web-oficial/assets/76450853/5f1f7af4-18a3-4759-ab73-411aa2bf0ac9



## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
