### PR TITLE
(a11y) add alt attribute to country flags

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -59,6 +59,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 87,
 		height: 1.95,
 		country: "mx",
+		countryName: "México",
 		versus: "plex",
 		guard: "Izquierda",
 		reach: 168,
@@ -88,6 +89,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 65, // No encontrado
 		height: 1.7, // No es seguro
 		country: "es",
+		countryName: "España",
 		versus: ["alana", "ama-blitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -107,6 +109,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 55,
 		height: 1.7,
 		country: "mx",
+		countryName: "México",
 		versus: ["nissaxter", "zeling"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -130,6 +133,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 93,
 		height: 1.88,
 		country: "cl",
+		countryName: "Chile",
 		versus: "viruzz",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -149,6 +153,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 85,
 		height: 1.82,
 		country: "es",
+		countryName: "España",
 		versus: "shelao",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -169,6 +174,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 55, // No es seguro
 		height: 1.58,
 		country: "mx",
+		countryName: "México",
 		versus: ["zeling", "nissaxter"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -188,6 +194,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 85, // No encontrado
 		height: 1.84,
 		country: "es",
+		countryName: "España",
 		socials: {
 			twitch: "https://www.twitch.tv/karchez",
 			instagram: "https://www.instagram.com/karchezz/",
@@ -206,10 +213,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.91, // No es seguro
 		guard: "Derecha",
 		country: "es",
-    workout: {
+		countryName: "España",
+		workout: {
 			videoID: "I8R5sQXjpKk",
 			thumbnail: "/img/boxers/workoutThumbnails/peldanyos-thumbnails.webp",
-    },
+		},
 		socials: {
 			twitch: "https://twitch.tv/peldanyos",
 			instagram: "https://instagram.com/peldanyos",
@@ -227,6 +235,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 80, // No encontrado
 		height: 1.79,
 		country: "mx",
+		countryName: "México",
 		socials: {},
 		versus: "rey-de-la-pista",
 	},
@@ -238,6 +247,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 85, // No encontrado
 		height: 1.85, // No encontrado
 		country: "do",
+		countryName: "República Dominicana",
 		socials: {
 			instagram: "https://instagram.com/mrangelovaldes",
 			twitter: "https://twitter.com/MrAngeloValdes",
@@ -254,6 +264,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 87,
 		height: 1.77,
 		country: "es",
+		countryName: "España",
 		socials: {},
 		versus: "rey-de-la-pista",
 	},
@@ -265,6 +276,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 75, // No encontrado
 		height: 1.69, // No es seguro
 		country: "ar",
+		countryName: "Argentina",
 		socials: {
 			twitch: "https://twitch.tv/unicornio",
 			instagram: "https://www.instagram.com/germanusinger",
@@ -282,6 +294,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 85, // No es seguro
 		height: 1.91,
 		country: "co",
+		countryName: "Colombia",
 		socials: {
 			twitch: "https://www.twitch.tv/pelicanger",
 			instagram: "https://www.instagram.com/pelicanger__",
@@ -300,6 +313,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 85, // No encontrado
 		height: 1.69, // No es seguro
 		country: "mx",
+		countryName: "México",
 		socials: {},
 		versus: "rey-de-la-pista",
 	},
@@ -311,6 +325,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 83, // No encontrado
 		height: 1.83, // No encontrado
 		country: "es",
+		countryName: "España",
 		socials: {
 			twitch: "https://www.twitch.tv/skain",
 			instagram: "https://www.instagram.com/skain24",
@@ -332,6 +347,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 71,
 		height: 1.8,
 		country: "es",
+		countryName: "España",
 		socials: {
 			twitch: "https://www.twitch.tv/folagorlives",
 			instagram: "https://www.instagram.com/yoel__ramirez",
@@ -350,6 +366,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 70,
 		height: 1.97,
 		country: "es",
+		countryName: "España",
 		versus: "el-mariana",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -383,6 +400,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 55, // No es seguro
 		height: 1.64,
 		country: "es",
+		countryName: "España",
 		versus: ["alana", "ama-blitz"],
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -403,6 +421,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 85,
 		height: 1.88,
 		country: "es",
+		countryName: "España",
 		versus: "la-cobra",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -423,6 +442,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 105,
 		height: 1.83,
 		country: "ar",
+		countryName: "Argentina",
 		versus: "guanyar",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -442,6 +462,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 62, // No es seguro
 		height: 1.7,
 		country: "es",
+		countryName: "España",
 		versus: "carreraaa",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
@@ -461,6 +482,7 @@ export const BOXERS: Boxer[] = addGetters([
 		weight: 61,
 		height: 1.65,
 		country: "ar",
+		countryName: "Argentina",
 		versus: "agustin-51",
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -98,7 +98,12 @@ const preloadBoxerImage: Preload[] = [
 				<div
 					class="relative order-1 -mt-20 flex flex-col items-center justify-center md:order-2 md:w-1/2 lg:mx-4"
 				>
-					<BoxerBigImage id={id} name={boxer.name} country={boxer.country} />
+					<BoxerBigImage
+						id={id}
+						name={boxer.name}
+						country={boxer.country}
+						countryName={boxer.countryName}
+					/>
 				</div>
 
 				<div class="order-3 flex w-full flex-col md:w-auto md:gap-y-20 lg:w-1/4">


### PR DESCRIPTION
## Descripción

He agregado `countryName` a todos los luchadores para que se muestre bien el atributo `alt` en las banderas. Anteriormente se mostraba como `undefined`.

## Capturas de pantalla (si corresponde)

Antes

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/c9ea07c3-832d-476c-87dd-e81543aa3fe1)

Después

![image](https://github.com/midudev/la-velada-web-oficial/assets/133175356/d23bc6ca-7046-49d3-81ba-d44a8e9dba2d)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la accesibilidad para todos.