### PR TITLE
Convert colors to HSL and fix bg color like design

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -59,16 +59,16 @@ const { title, description, preload, canonical, image } = Astro.props
 		<ButtonUp />
 		<style is:global>
 			:root {
-				--color-primary: #ddd;
-				--color-secondary: #333;
-				--color-accent: #b4cd02;
+				--color-primary: hsl(0, 0%, 86%);
+				--color-secondary: hsl(0, 0%, 20%);
+				--color-accent: hsl(72, 100%, 43%);
 				--color-accent-rgb: 213, 255, 0;
 
-				--background-color: #141800;
+				--background-color: hsl(0, 0%, 10%);
 				--background-twitch: var(--color-twitch-ice);
 
-				--color-twitch: #9146ff;
-				--color-twitch-ice: #f0f0ff;
+				--color-twitch: hsl(262, 100%, 60%);
+				--color-twitch-ice: hsl(240, 100%, 98%);
 			}
 
 			@font-face {

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -64,7 +64,7 @@ const { title, description, preload, canonical, image } = Astro.props
 				--color-accent: hsl(72, 100%, 43%);
 				--color-accent-rgb: 213, 255, 0;
 
-				--background-color: hsl(0, 0%, 10%);
+				--background-color: hsl(0, 0%, 12%);
 				--background-twitch: var(--color-twitch-ice);
 
 				--color-twitch: hsl(262, 100%, 60%);


### PR DESCRIPTION
## Descripción

En el diseño el color del fondo es mas oscuro no verdoso como estaba ahora.
También he convertido los colores a HSL para mejor lectura e implementación

## Problema solucionado

El fondo de la web no se correspondia al diseño

Diseño:
![CleanShot 2024-03-19 at 19 38 33@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/f23458f1-606e-4f7c-8997-0944ff9c58e2)


## Capturas de pantalla (si corresponde)

Antes:
![CleanShot 2024-03-19 at 19 40 59@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/472822f2-5adc-46b0-ac92-f8dd76cf2864)

Ahora:
![CleanShot 2024-03-19 at 21 07 00@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/65665d3b-7680-448a-94ee-a7ec0b1ddda0)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.


## Enlaces útiles

- [Referencia sobre HSL](https://okbinteractive.studio/insights/por-que-es-mejor-usar-hsl-para-trabajar-con-colores)
- [Más info sobre HSL](https://www.uifrommars.com/que-es-hsl/)
