### PR TITLE
Se arregla el responsive para Z-Fold

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -7,12 +7,12 @@ import SocialButtons from "@/components/SocialButtons.astro"
 	class="relative mt-20 flex w-full flex-col place-items-center pb-20 pt-14 md:flex-row md:justify-between md:pt-16"
 >
 	<hr
-		class="absolute top-0 h-[2px] w-full min-w-[20rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent bg-center md:my-9"
+		class="absolute top-0 h-[2px] w-full min-w-[18rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent bg-center md:my-9"
 	/>
 	<FooterContent />
 	<hr
 		aria-hidden="true"
-		class="my-12 h-[2px] w-full min-w-[20rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent bg-center md:hidden"
+		class="my-12 h-[2px] w-full min-w-[18rem] border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent bg-center md:hidden"
 	/>
 	<SocialButtons />
 </footer>

--- a/src/sections/Info.astro
+++ b/src/sections/Info.astro
@@ -8,7 +8,7 @@ import Typography from "@/components/Typography.astro"
 	aria-label="descripción del evento"
 >
 	<hr
-		class="h-[2px] min-w-[20rem] max-w-lg border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent sm:w-full"
+		class="h-[2px] min-w-[18rem] max-w-lg border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent sm:w-full"
 	/>
 
 	<a
@@ -44,6 +44,6 @@ import Typography from "@/components/Typography.astro"
 	</a>
 
 	<hr
-		class="my-7 h-[2px] w-full min-w-[20rem] max-w-lg border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent md:my-9"
+		class="my-7 h-[2px] w-full min-w-[18rem] max-w-lg border-t-0 bg-transparent bg-gradient-to-r from-transparent via-white to-transparent md:my-9"
 	/>
 </section>

--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -63,7 +63,7 @@ const boxerColumns = [
 		</div>
 
 		<div class="-mt-20 flex flex-col items-center justify-center md:mt-32 md:hidden">
-			<div class="carousel mt-8 w-full overflow-y-hidden overflow-x-scroll">
+			<div class="carousel mt-8 w-full max-w-[100vw] overflow-y-hidden overflow-x-scroll">
 				<div class="carousel-inner flex snap-x overflow-y-hidden overflow-x-scroll">
 					{
 						listOfBoxers.map((boxer, index) => (


### PR DESCRIPTION
## Descripción

Se arregla el responsive para Z-Fold

## Problema solucionado

Desborde de pantalla en mobile Z-Fold

## Cambios propuestos

Se agrega un max-w-[100vw] para que que el carrousel no desborde la pantalla, y se cambia el min width de los hr para que quede acorde.

## Capturas de pantalla

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/50113708/b85cea34-ea3a-43e0-9dd7-74d2a3d74f80)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/50113708/05c91c18-5e8d-4ec4-b8bd-e6262e085783)

## Impacto potencial

Mejora la compatibilidad de usuarios con mobiles con un width menor.

