### PR TITLE
Add: estilizar el vs de los combates

### DIFF
--- a/src/sections/Combat.astro
+++ b/src/sections/Combat.astro
@@ -26,7 +26,7 @@ const { combatNumber, combatId, boxers } = Astro.props
 			variant="atomic-title"
 			color="primary"
 			tabindex={-1}
-			class:list={"absolute inset-0 -z-10 self-center text-center text-[20rem] opacity-80"}
+			class:list={"absolute inset-0 -z-10 self-center text-center text-[20rem] opacity-20"}
 			>{combatNumber}
 		</Typography>
 		<h2 class:list={["text-center text-4xl font-semibold uppercase text-white  lg:text-6xl"]}>
@@ -34,9 +34,20 @@ const { combatNumber, combatId, boxers } = Astro.props
 				<span>
 					{ordinals[combatNumber]} combate
 				</span>
-				<span>
-					{boxers.map((boxer) => boxer.name).join(" vs ")}
-				</span>
+				<div>
+					{
+						boxers.map((boxer, index) => (
+							<span>
+								{boxer.name}
+								{index < boxers.length - 1 && (
+									<Typography as="span" variant="atomic-title" color="primary">
+										vs
+									</Typography>
+								)}
+							</span>
+						))
+					}
+				</div>
 			</span>
 		</h2>
 	</div>


### PR DESCRIPTION
## Descripción

Se estilizo el "vs" en los combates de la página de cada boxeador, para poder resaltar quienes se enfrentan y se bajo la opacidad del número de combate.

## Problema solucionado

No se distinguía los nombres de los boxeadores.

## Cambios propuestos

Se utilizó el componente Typography para estilizar el texto.

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/12983015/b71d9f1d-692c-4dff-8b23-7d7b90338de7)
![image](https://github.com/midudev/la-velada-web-oficial/assets/12983015/96d1e214-6ee5-4061-bcb9-b435c1e297a5)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

