### PR TITLE
Filter de rivales de Rey de la Pista

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -55,7 +55,7 @@ if (typeof boxer.versus === "object") {
 		rivals = rivals.concat(BOXERS.filter((rival: Boxer) => rival.id === vs))
 	}
 } else {
-	rivals = BOXERS.filter((rival: Boxer) => rival.id === boxer.versus)
+	rivals = boxers.filter((rival: Boxer) => rival.id !== boxer.id)
 }
 
 if (forecast) {


### PR DESCRIPTION
## Descripción

Se hizo un filter de para poder mostrar los rivales de los boxeadores que participarán en El Rey de la Pista

## Problema solucionado

No se mostraban los rivales de los boxeadores que participarán en El Rey de la Pista

## Cambios propuestos

Se hizo el filter sobre la constante boxers ( en minúsculas) y se comparo el id de boxeador

## Capturas de pantalla (si corresponde)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

## Enlaces útiles
