### PR TITLE
Add: Clips embebidos con pequeña animación

### DIFF
--- a/src/components/BoxerClips.astro
+++ b/src/components/BoxerClips.astro
@@ -17,34 +17,50 @@ const hasClips = clips.length > 0
 		<section class="mt-2 overflow-hidden md:mt-10">
 			<div class="carousel flex select-none flex-row flex-nowrap transition duration-700  lg:max-w-none lg:!translate-x-0 lg:flex-wrap lg:place-content-center lg:gap-4">
 				{clips.map(({ text, url }) => (
-					<a
-						href={url}
-						target="_blank"
-						rel="noopener noreferrer"
-						class="group flex min-w-full max-w-[450px] flex-col justify-between bg-gradient-to-b px-12 pt-8 hover:from-zinc-600/25 lg:min-w-0"
-					>
-						<Typography
-							as="h3"
-							variant="atomic-title"
-							color="primary"
-							class:list={
-								"flex flex-1 -skew-y-2 items-center justify-center text-center transition group-hover:scale-110"
-							}
-						>
-							"{text.toLowerCase()}"
-						</Typography>
-
-						<footer class="mt-2 flex items-end justify-center p-5 text-center">
-							<Typography
-								as="p"
-								variant="body"
-								color="neutral"
-								class:list={"text-center group-hover:text-accent"}
+					<div class="card">
+						<div id="cardfront" class="cardfront">
+							<div
+								class="group flex min-w-full max-w-[450px] min-h-[300px] flex-col justify-between bg-gradient-to-b px-12 pt-8 hover:from-zinc-600/25 lg:min-w-0"
 							>
-								Ver clip
-							</Typography>
-						</footer>
-					</a>
+								<Typography
+									as="h3"
+									variant="atomic-title"
+									color="primary"
+									class:list={
+										"flex flex-1 -skew-y-2 items-center justify-center text-center transition group-hover:scale-110"
+									}
+								>
+									"{text.toLowerCase()}"
+								</Typography>
+
+								<footer id="verClip" class="verClip flex items-end justify-center p-5 text-center">
+									<Typography
+										as="p"
+										variant="body"
+										color="neutral"
+										class:list={"text-center group-hover:text-accent"}
+									>
+										Ver clip
+									</Typography>
+								</footer>
+							</div>
+						</div>
+						<div id="cardback" class="cardback">
+							<div class="group flex min-w-full max-w-[450px] flex-col justify-between bg-gradient-to-b hover:from-zinc-600/25 lg:min-w-0">
+								<iframe max-width="450" height="232" src={url} title={text} frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+								<footer id="volver" class="volver flex items-end justify-center p-5 text-center">
+									<Typography
+										as="p"
+										variant="body"
+										color="neutral"
+										class:list={"text-center group-hover:text-accent"}
+									>
+										Volver
+									</Typography>
+								</footer>
+							</div>
+						</div>
+					</div>
 				))}
 			</div>
 			<div class="mx-16 flex items-center justify-between lg:hidden">
@@ -61,6 +77,63 @@ const hasClips = clips.length > 0
 		</section>
 	)
 }
+<style>
+	.cardback {
+		backface-visibility: hidden;
+		margin-top: -300px;
+		transform: rotateY(180deg);
+		pointer-events: none;
+	}
+	.rotate--cardback--on {
+		animation: rotateBackOn 0.5s ease-in-out forwards;
+	}
+	@keyframes rotateBackOn {
+		0% {
+			transform: rotateY(180deg);
+		}
+		100% {
+			transform: rotateY(360deg);
+			pointer-events: auto;
+		}
+	}
+	.rotate--cardback--off {
+		animation: rotateBackOff 0.5s ease-in-out forwards;
+	}
+	@keyframes rotateBackOff {
+		0% {
+			transform: rotateY(360deg);
+		}
+		100% {
+			transform: rotateY(180deg);
+		}
+	}
+	.cardfront {
+		backface-visibility: hidden;
+		overflow: hidden;
+	}
+	.rotate--cardfront--off {
+		animation: rotateFrontOff 0.5s ease-in-out forwards;
+	}
+	@keyframes rotateFrontOff {
+		0% {
+			transform: rotateY(0deg);
+		}
+		100% {
+			transform: rotateY(180deg);
+		}
+	}
+	.rotate--cardfront--on {
+		animation: rotateFrontOn 0.5s ease-in-out forwards;
+	}
+	@keyframes rotateFrontOn {
+		0% {
+			transform: rotateY(180deg);
+		}
+		100% {
+			transform: rotateY(0deg);
+		}
+	}
+</style>
 <script>
 	document.addEventListener("astro:page-load", () => {
 		const $carousel = document.querySelector(".carousel")
@@ -68,6 +141,31 @@ const hasClips = clips.length > 0
 		const $next = document.querySelector("[data-btn-next]")
 		const $clipIndex = document.querySelector("[data-clip-index]")
 
+		const $verClips = document.querySelectorAll(".verClip")
+		const $volvers = document.querySelectorAll(".volver")
+		const $cardfronts = document.querySelectorAll(".cardfront")
+		const $cardbacks = document.querySelectorAll(".cardback")
+		const $iframes = document.querySelectorAll("iframe")
+
+		$verClips.forEach((clip, index) => {
+			clip.addEventListener("click", () => {
+				$cardfronts[index].classList.add("rotate--cardfront--off")
+				$cardbacks[index].classList.add("rotate--cardback--on")
+			})
+		})
+		$volvers.forEach((volver, index) => {
+			volver.addEventListener("click", () => {
+				$cardfronts[index].classList.add("rotate--cardfront--on")
+				$cardbacks[index].classList.add("rotate--cardback--off")
+				const source = $iframes[index].src
+				$iframes[index].src = ""
+				$iframes[index].src = source
+				setTimeout(() => {
+					$cardfronts[index].classList = "cardfront"
+					$cardbacks[index].classList = "cardback"
+				}, "500")
+			})
+		})
 		let position = 0
 
 		const updatePosition = () => {

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -418,15 +418,15 @@ export const BOXERS: Boxer[] = addGetters([
 		clips: [
 			{
 				text: "No hay chance de que pierda. Soy un psicópata",
-				url: "https://youtube.com/clip/UgkxwyKEwj17kL8yJ2XVPNMI4dMuq-FdjYuG?si=LTAScm2qp6d7Bi4L",
+				url: "https://www.youtube.com/embed/ct0Hr6zYZGU?si=Y6wUewxg1UwqLvoj&amp;controls=0&amp;clip=UgkxwyKEwj17kL8yJ2XVPNMI4dMuq-FdjYuG&amp;clipt=EOP3-QUY--z6BQ",
 			},
 			{
 				text: "¿Se supone que tiene que picar?",
-				url: "https://youtube.com/clip/UgkxCVitcQsAn1I5wO4GlZY_kMcwLKaOI7HI?si=oyHb0fJkIWWQ8wTz",
+				url: "https://www.youtube.com/embed/ct0Hr6zYZGU?si=jucHSELaUPIteA_k&amp;clip=UgkxCVitcQsAn1I5wO4GlZY_kMcwLKaOI7HI&amp;clipt=EMmf7wUY4ZTwBQ",
 			},
 			{
 				text: "Hablaré en el ring. No tengo nada que decir.",
-				url: "https://youtube.com/clip/UgkxSCdNOmvFVB74IC_D56vglujXVWtVI60Q?si=Eqhsbja42efTdCaz",
+				url: "https://www.youtube.com/embed/ct0Hr6zYZGU?si=lc3jB0Vtt-cS6uhq&amp;controls=0&amp;clip=UgkxSCdNOmvFVB74IC_D56vglujXVWtVI60Q&amp;clipt=ELL72QUYvevaBQ",
 			},
 		],
 	},


### PR DESCRIPTION
## Descripción

Se han embebido los clips en la propia página con una pequeña animación y algunos controles en las acciones (ver clip, volver a la frase, etc.)

## Cambios propuestos

Se ha modificado la url del vídeo para que coincida con el iframe del clip.
Se ha insertado el iframe dentro de un bloque oculto que se activa al clicar en "Ver clip" simulando una card con un flip. Al darle a "Volver" se vuelve a la frase y se para el vídeo si se estaba reproduciendo.

## Capturas de pantalla (si corresponde)

![imagen](https://github.com/midudev/la-velada-web-oficial/assets/83401208/a173fb89-d2df-43f2-848a-441b6a1b5843)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Al cargar los clips como iframes dependemos de más peticiones a YouTube.
