### PR TITLE
show random contributors

### DIFF
--- a/src/function/miduCode.ts
+++ b/src/function/miduCode.ts
@@ -33,7 +33,17 @@ export async function showContributors($miduContainer: HTMLDivElement) {
 export async function getContributors() {
 	const url = "https://api.github.com/repos/midudev/la-velada-web-oficial/contributors"
 	const response = await fetch(url)
-	const contributors = (await response.json()) as Contributor[]
+
+	const linkHeader = response.headers.get("link")
+	const pageCount = linkHeader
+		? parseInt(linkHeader.match(/page=(\d+)>; rel="last"/)?.[1] || "1")
+		: 1
+	const randomPage = Math.floor(Math.random() * pageCount) + 1
+	const randomPageUrl = `${url}?page=${randomPage}`
+	const randomPageResponse = await fetch(randomPageUrl)
+
+	const contributors = (await randomPageResponse.json()) as Contributor[]
+
 	return contributors
 }
 


### PR DESCRIPTION
## Descripción

Mostrar de forma aleatoria los contribuidores en el KonamiCode, Todos queremos ser robots !!! 🎊 
(Esto refleja a no mostrar siempre los mismo que están en el TOP con mas contribuciones)

## Problema solucionado

Hacemos una petición a la API para obtener el número de paginas existentes de los contribuidores para luego hacer un random contribuidores por pagina.
  
