### PR TITLE
Remove mouseenter event when clicking a boxer

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -160,11 +160,20 @@ const boxerColumns = [
 			boxerCountry.alt = `Bandera de ${countryName}`
 		}
 
+		function handleMouseEnter(event: MouseEvent) {
+			const currentTarget = event.currentTarget as HTMLElement
+			const link = currentTarget
+			if (currentTarget.classList.contains("active")) return
+			activateBoxer(currentTarget, link, boxerNav, true)
+		}
+
 		boxerLinks.forEach((link) => {
-			link.addEventListener("mouseenter", (event) => {
-				const currentTarget = event.currentTarget as HTMLElement
-				if (currentTarget.classList.contains("active")) return
-				activateBoxer(currentTarget, link, boxerNav, true)
+			link.addEventListener("mouseenter", handleMouseEnter)
+		})
+
+		document.addEventListener("astro:before-preparation", () => {
+			boxerLinks.forEach((link) => {
+				link.removeEventListener("mouseenter", handleMouseEnter)
 			})
 		})
 


### PR DESCRIPTION
## Descripción

El issue #679 se origina debido a que no se esta removiendo el evento mouseenter después de hacer click en un boxeador.
Se creó una función controladora para poder reutilizarla en el addEventListener y removeEventListener del evento mouseenter y se agregó el evento astro:before-preparation para remover el mouseenter después de que el usuario haya cliqueado en un boxeador.

## Problema solucionado

Issue #679

## Cambios propuestos

1. Crear una función controladora llamada handleMouseEnter
2. Añadir la función controladora en el addEventListener y removeEventListener del evento mouseenter
3. Agregar el evento astro:before-preparation
4. Ejecutar el removeEventListener del evento mouseenter dentro de astro:before-preparation

## Capturas de pantalla (si corresponde)

Antes:
[issue-boxer-selection.webm](https://github.com/midudev/la-velada-web-oficial/assets/164126437/2f703015-4c5b-4489-aca2-a7f9f3efbd5a)

Después: 
[fix-boxer-selection.webm](https://github.com/midudev/la-velada-web-oficial/assets/164126437/dfac6c96-07ca-41a9-8208-1cd35a7557a6)

## Comprobación de cambios

- [ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

## Impacto potencial

Ninguna
