### PR TITLE
Fix: view versus on initial page load

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -94,7 +94,18 @@ const boxerColumns = [
 		const boxerTitle = $(".boxer-title") as HTMLImageElement
 		const boxerPhoto = $(".boxer-photo") as HTMLPictureElement
 		const boxerCountry = $(".boxer-flag") as HTMLImageElement
+		const queryString = window.location.search
+		const urlParams = new URLSearchParams(queryString)
+		const initialBoxer = urlParams.get("boxer") ?? "el-mariana"
+		const initialBoxerElement = $(`a.boxer-link[data-id=${initialBoxer}]`)
+		let isInitialBoxer = true
 
+		const initialBoxerLink =
+			Array.from(boxerLinks).find(
+				(boxerLink) => boxerLink.getAttribute("data-id") === initialBoxer
+			) ?? boxerLinks[0]
+
+		activateBoxer(initialBoxerElement, initialBoxerLink, boxerNav, false)
 		function activateBoxer(
 			element: HTMLElement,
 			link: HTMLElement,
@@ -102,7 +113,8 @@ const boxerColumns = [
 			replaceUrl: boolean = false,
 			showAlliesAndOpponents: boolean = true
 		) {
-			if (element.classList.contains("active")) return
+			if (element.classList.contains("active") && !isInitialBoxer) return
+			isInitialBoxer = false
 
 			const { id, name, country, countryName, opponents = "", allies = "" } = element?.dataset
 


### PR DESCRIPTION
## Descripción
Corrección en la funcionalidad para mostrar correctamente el "versus" o "aliada" del boxeador o boxeadora enfocada al cargar la página.

## Problema solucionado
Al entrar a la página (sin importar que haya o no params) no se muestra el "versus" o "aliada" del boxeador o boxeadora  enfocada como se muestra en el video

## Cambios propuestos
Se ha añadido una comprobación del boxeador enfocado al cargar el js en la página, permitiendo así que se muestre correctamente el "versus" o "aliada" al cargar la página donde simplemente se recuperan los valores necesarios para reutilizar la función activateBoxer()

## Capturas de pantalla (si corresponde)
[demo-versus.webm](https://github.com/midudev/la-velada-web-oficial/assets/42650947/28c646e5-7ac4-429d-baf0-87d8551b5eea)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.

## Impacto potencial

Funcionamiento esperado de la sección