### PR TITLE
show rival or rivals (prev rival/es) according to number

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -76,6 +76,8 @@ const preloadBoxerImage: Preload[] = [
 		rel: "preload",
 	},
 ]
+
+const rivalOrRivals = rivals.length > 1 ? "Rivales" : "Rival"
 ---
 
 <Layout
@@ -91,7 +93,7 @@ const preloadBoxerImage: Preload[] = [
 					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} id="boxer-país" />
 					<BoxerDetailInfo title="Edad" value={boxer.age} id="boxer-edad" />
 					<div class="hidden md:block">
-						<BoxerDetailInfoRival title="Rival/es" value={rivals} id="boxer-rival-desk" />
+						<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-desk" />
 					</div>
 				</div>
 
@@ -108,7 +110,7 @@ const preloadBoxerImage: Preload[] = [
 					<BoxerDetailInfo title="Alcance" value={boxer.reach} id="boxer-alcance" />
 
 					<div class="block md:hidden">
-						<BoxerDetailInfoRival title="Rival/es" value={rivals} id="boxer-rival-mobile" />
+						<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-mobile" />
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
## Descripción

En la página de boxer, mostrar directament "Rival" o "Rivales" según la cantidad de oponentes en lugar de siempre mostrar "Rival/es".

## Capturas de pantalla (si corresponde)

![Rival](https://github.com/midudev/la-velada-web-oficial/assets/76450853/5e18faa0-e594-4271-af56-15445dcba453)

![Rivales en el 2vs2](https://github.com/midudev/la-velada-web-oficial/assets/76450853/8da6c19c-056d-4495-9a59-b2a3f04a6763)

![Rivales en el Rei de la pista](https://github.com/midudev/la-velada-web-oficial/assets/76450853/adc4498c-26ff-491e-8d02-1d0bede9fcc7)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
