### PR TITLE
Eliminar lógica redundante para reselección de boxer

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -94,20 +94,6 @@ const boxerColumns = [
 		const boxerTitle = $(".boxer-title") as HTMLImageElement
 		const boxerPhoto = $(".boxer-photo") as HTMLPictureElement
 		const boxerCountry = $(".boxer-flag") as HTMLImageElement
-		const queryString = window.location.search
-		const urlParams = new URLSearchParams(queryString)
-		const initialBoxer = urlParams.get("boxer") ?? "el-mariana"
-		const initialBoxerElement = $(`a.boxer-link[data-id=${initialBoxer}]`)
-		let isInitialBoxer = true
-
-		if (initialBoxerElement) {
-			const initialBoxerLink =
-				Array.from(boxerLinks).find(
-					(boxerLink) => boxerLink.getAttribute("data-id") === initialBoxer
-				) ?? boxerLinks[0]
-
-			activateBoxer(initialBoxerElement, initialBoxerLink, boxerNav, false)
-		}
 
 		function activateBoxer(
 			element: HTMLElement,
@@ -116,8 +102,7 @@ const boxerColumns = [
 			replaceUrl: boolean = false,
 			showAlliesAndOpponents: boolean = true
 		) {
-			if (element?.classList.contains("active") && !isInitialBoxer) return
-			isInitialBoxer = false
+			if (element?.classList.contains("active")) return
 
 			const { id, name, country, countryName, opponents = "", allies = "" } = element?.dataset
 


### PR DESCRIPTION
## Descripción

Se elimina la lógica redundante utilizada para reseleccionar el boxeador actual (`?boxer=example`) al navegar de vuelta a `index.astro`.

## Problema solucionado

Anteriormente, se estaba reseleccionando el boxeador actual cada vez que se regresaba a `index.astro` (`/`). Sin embargo, esto ya no es necesario, ya que la página se re-renderiza en el servidor con el boxeador seleccionado, evitando la necesidad de volver a hacerlo con JavaScript.

![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/e134e1f6-d29e-4c36-ad07-07e257a6f762)


## Cambios propuestos

Se elimina el código innecesario para evitar reseleccionar el boxeador y prevenir posibles parpadeos del boxeador actual entre navegaciones.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

- Mejora la eficiencia al eliminar lógica redundante.
- Previene posibles parpadeos del boxeador actual entre navegaciones.
- Puede mejorar ligeramente el rendimiento en dispositivos de gama baja al no tener que ejecutar JavaScript innecesario durante la navegación.

