### PR TITLE
Agregar una "y" en combate 2vs2

### DIFF
--- a/src/sections/Combat.astro
+++ b/src/sections/Combat.astro
@@ -39,10 +39,16 @@ const { combatNumber, combatId, boxers } = Astro.props
 						boxers.map((boxer, index) => (
 							<span>
 								{boxer.name}
-								{index < boxers.length - 1 && (
+								{boxer.name === "Zeling" || boxer.name === "Amablitz" ? (
 									<Typography as="span" variant="atomic-title" color="primary">
-										vs
+										y
 									</Typography>
+								) : (
+									index < boxers.length - 1 && (
+										<Typography as="span" variant="atomic-title" color="primary">
+											vs
+										</Typography>
+									)
 								)}
 							</span>
 						))


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
La intención de este cambio es que en el combate 2vs2 que aparece "zeling vs alana vs amablitz vs nissaxter" cambie.
## Problema solucionado

<!-- Describa el problema o la tarea que aborda esta solicitud de extracción, si corresponde. Incluya el número de problema o enlace al problema si existe. -->

## Cambios propuestos

Agregar una "y"  entre medio de Zeling y Alana, y,  Amabiltz y Nissaxter

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/145802712/7183e3fe-8ba8-4b86-9489-11b1a6bc436f)
Ahora
![image](https://github.com/midudev/la-velada-web-oficial/assets/145802712/84d3c7a7-e027-4f58-bbaa-d806860fb7ae)

## Comprobación de cambios

- ✅He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- ✅ He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- ✅ He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- ✅He actualizado la documentación, si corresponde.