### PR TITLE
Declaración Boxeadores

### DIFF
--- a/src/components/BoxerClips.astro
+++ b/src/components/BoxerClips.astro
@@ -15,13 +15,13 @@ const hasClips = clips.length > 0
 {
 	hasClips && (
 		<section class="mt-2 overflow-hidden md:mt-10">
-			<div class="carousel flex select-none flex-row flex-nowrap transition duration-700  lg:max-w-none lg:!translate-x-0 lg:flex-wrap lg:place-content-center lg:gap-4">
+			<div class="carousel flex select-none flex-row flex-nowrap transition duration-700 lg:max-w-none lg:!translate-x-0 lg:flex-wrap lg:place-content-center lg:gap-8">
 				{clips.map(({ text, url }) => (
 					<a
 						href={url}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="group flex min-w-full max-w-[450px] flex-col justify-between bg-gradient-to-b px-12 pt-8 hover:from-zinc-600/25 lg:min-w-0"
+						class="group flex min-w-full max-w-[450px] flex-col justify-between bg-gradient-to-b px-12 pt-8 hover:from-zinc-600/25 lg:min-w-[300px] lg:max-w-[600px]"
 					>
 						<Typography
 							as="h3"
@@ -71,7 +71,6 @@ const hasClips = clips.length > 0
 		let position = 0
 
 		const updatePosition = () => {
-			// Midu diría que esto es un poquito regulinchis :)
 			$carousel?.setAttribute("style", `transform: translateX(-${100 * position}%)`)
 
 			if ($clipIndex) $clipIndex.innerHTML = `Cita ${position + 1}/${$carousel?.children.length}`


### PR DESCRIPTION
## Descripción

He hecho que las declaraciones de los boxeadores se vean más anchas para desktop.

## Problema solucionado

Se veían las declaraciones demasiado estrechas.

## Cambios propuestos

He hecho que las declaraciones de los boxeadores se vean más anchas para desktop.

## Capturas de pantalla (si corresponde)

![image](https://github.com/midudev/la-velada-web-oficial/assets/159711246/0682f411-ed83-4c8e-a330-5a9d39bbfb34)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
