### PR TITLE
Fix carousel observe when resize to mobile

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -197,9 +197,9 @@ const boxerColumns = [
 		// detect if it changes
 		mobileMediaQuery.addEventListener("change", (event) => {
 			if (event.matches) {
-				carouselItems.forEach((item) => carouselObserver.unobserve(item))
-			} else {
 				carouselItems.forEach((item) => carouselObserver.observe(item))
+			} else {
+				carouselItems.forEach((item) => carouselObserver.unobserve(item))
 			}
 		})
 	})


### PR DESCRIPTION
## Descripción
Cuando se hace resize del navegador y pasa a tamaño mobile el carousel de boxeadores no funciona como corresponde (no se activa el boxeador del medio)
Solo funciona de forma adecuada cuando el navegador parte con el tamaño mobile

## Cambios propuestos
Estaba al revés el observe el el eventListener change 

## Capturas de pantalla (si corresponde)

Antes:

https://github.com/midudev/la-velada-web-oficial/assets/6934077/233316ec-88e1-461e-94ba-8ad5d6fd0348

Ahora:

https://github.com/midudev/la-velada-web-oficial/assets/6934077/4a1718ff-a04b-4e69-87a9-9e780222de97


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

