### PR TITLE
If not exist 'guard ' or 'reach' in Boxer, add default

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -79,6 +79,8 @@ const preloadBoxerImage: Preload[] = [
 ]
 
 const rivalOrRivals = rivals.length > 1 ? "Rivales" : "Rival"
+const guardBoxer = boxer.guard !== null ? "Desconocida" : boxer.guard
+const reachBoxer = boxer.reach !== null ? "Desconocido" : boxer.reach
 ---
 
 <Layout
@@ -107,8 +109,8 @@ const rivalOrRivals = rivals.length > 1 ? "Rivales" : "Rival"
 				<div class="order-3 flex w-full flex-col md:w-auto md:gap-y-20 lg:w-1/4">
 					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} id="boxer-peso" />
 					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} id="boxer-altura" />
-					<BoxerDetailInfo title="Guardia" value={boxer.guard} id="boxer-guardia" />
-					<BoxerDetailInfo title="Alcance" value={boxer.reach} id="boxer-alcance" />
+					<BoxerDetailInfo title="Guardia" value={guardBoxer} id="boxer-guardia" />
+					<BoxerDetailInfo title="Alcance" value={reachBoxer} id="boxer-alcance" />
 
 					<div class="block md:hidden">
 						<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-mobile" />

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -79,8 +79,8 @@ const preloadBoxerImage: Preload[] = [
 ]
 
 const rivalOrRivals = rivals.length > 1 ? "Rivales" : "Rival"
-const guardBoxer = boxer.guard !== null ? "Desconocida" : boxer.guard
-const reachBoxer = boxer.reach !== null ? "Desconocido" : boxer.reach
+const guardBoxer = boxer.guard === undefined ? "Desconocida" : boxer.guard
+const reachBoxer = boxer.reach === undefined ? "Desconocido" : boxer.reach
 ---
 
 <Layout


### PR DESCRIPTION
## Descripción
<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
Si la **guardia** o el **alcance** del boxeador no existe, no se muestra. Se ha puesto un texto por defecto en esos casos
## Cambios propuestos
- Al ser **guard** y **reach** opcionales. 
```javascript
export interface Boxer {
	guard?: string
	reach?: number
        // more code
``` 
- Podemos añadir un texto por defecto si no existen
```javascript
const guardBoxer = boxer.guard === undefined ? "Desconocida" : boxer.guard
const reachBoxer = boxer.reach === undefined ? "Desconocido" : boxer.reach
``` 

## Capturas de pantalla (si corresponde)
## Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/44408822/928b224d-8f8c-43e8-b8dd-3b8818e3e6e9)
## Después
![image](https://github.com/midudev/la-velada-web-oficial/assets/44408822/6b766498-36bc-4dc2-a195-c095a9fbc85c)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
