### PR TITLE
feat: :sparkles: Optimización 🐜 (hormiga) +

### DIFF
--- a/src/function/miduCode.ts
+++ b/src/function/miduCode.ts
@@ -4,8 +4,39 @@ interface Contributor {
 }
 
 export async function showContributors($miduContainer: HTMLDivElement) {
-	const contributors = await getContributors()
+	async function loadContributors() {
+		const contributorsLocalStorage = localStorage.getItem("contributors")
+		const contributors: Contributor[] = contributorsLocalStorage
+			? JSON.parse(contributorsLocalStorage)
+			: await getContributors()
 
+		// maps for the contributors for save types Contributors
+		const contributorsMap = contributors.map((contributor: Contributor) => {
+			return {
+				avatar_url: contributor.avatar_url,
+				login: contributor.login,
+				/* add more data here */
+			}
+		})
+		contributorsLocalStorage ||
+			localStorage.setItem("contributors", JSON.stringify(contributorsMap))
+		return await contributors
+	}
+	function convertImgUrlToBase64(name: string, url: string) {
+		const img = new Image()
+		img.src = url
+		img.crossOrigin = "Anonymous"
+		img.onload = function () {
+			const canvas = document.createElement("canvas")
+			const ctx = canvas.getContext("2d")
+			canvas.width = img.width
+			canvas.height = img.height
+			ctx?.drawImage(img, 0, 0)
+			const dataURL = canvas.toDataURL("image/png")
+			localStorage.setItem(name, dataURL)
+		}
+	}
+	const contributors = await loadContributors()
 	for (let i = 0; i < contributors.length; i++) {
 		setTimeout(() => {
 			const { avatar_url, login } = contributors[i]
@@ -14,13 +45,22 @@ export async function showContributors($miduContainer: HTMLDivElement) {
 			img.title = login
 			img.classList.add("bubbles")
 			if (login === "midudev") {
+				const localStorageItem = localStorage.getItem(login)
 				img.setAttribute("id", "midu")
-				img.src = `${avatar_url}&size=150`
+				img.src = localStorageItem
+					? localStorageItem || `${avatar_url}&size=150`
+					: `${avatar_url}&size=60`
+				// convert img url to base64 and save in localstorage
+				convertImgUrlToBase64(login, img.src)
 			} else {
-				img.src = `${avatar_url}&size=60`
+				const localStorageItem = localStorage.getItem(login)
+				img.src = localStorageItem
+					? localStorageItem || `${avatar_url}&size=60`
+					: `${avatar_url}&size=60`
 				img.style.left = `${generateRandomNumber()}vw`
 				const startRotation = Math.floor(Math.random() * (90 - -90 + 1)) + -45
 				img.style.transform = `rotate(${startRotation}deg)`
+				convertImgUrlToBase64(login, img.src)
 			}
 			img.addEventListener("animationend", () => {
 				$miduContainer.removeChild(img)


### PR DESCRIPTION
## Descripción

Se realizo una optimización Hormiga para el konami code midu, ahora solo la primera ves usamos consumo de datos para obtener contribuidores y cargar estos en la web, posteriormente se cargaran desde LocalStorage

## Problema solucionado

No resuelve problema, SUMA optimización 1% 🚀 

## Cambios propuestos

Optimización de konami code midu al cargar los contribuidores

## Capturas de pantalla (si corresponde)

Primera carga KONAMI CODE midu:
<img width="1266" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/31475869/b9325c40-19bc-4485-8cd6-963ca3723725">
Posteriores cargas KONAMI CODE midu
<img width="1248" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/31475869/4330b983-9c9d-4a2d-8dc0-809ef0b53bea">

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
