### PR TITLE
Habilitar pre-renderizacion de las rutas dynamicas

### DIFF
--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -29,6 +29,8 @@ export function getStaticPaths() {
 	})
 }
 
+export const prerender = true
+
 const { id } = Astro.params
 
 const [boxer] = BOXERS.filter((boxer) => boxer.id === id)

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -18,6 +18,8 @@ export const getStaticPaths = () => {
 	}))
 }
 
+export const prerender = true
+
 const { id } = Astro.params
 const combatData = COMBATS.find((combat) => combat.id === id)
 const boxerNames = combatData ? getBoxerNames(combatData.boxers) : []


### PR DESCRIPTION
## Descripción

Se prerenderizan las rutas dynamicas en tiempo de build

## Problema solucionado

Al usar `output: "server"` Astro no renderiza en build time las rutas dynamicas aunque se use el `getStaticPages()` si no que lo hace bajo demanda.

## Cambios propuestos

Se exporta una constante `export prerender = true` que habilita la prerenderizacion de las rutas dynamicas cuando usamos el `output: "server"`

## Capturas de pantalla (si corresponde)

- Alerta de Astro avisando que ignora el `getStaticPaths()` sin la solucion implementada
![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/d103b89c-04b5-4cd6-b667-99af45478e85)

- La prerenderizacion de las rutas al habilitar la prerenderizacion
![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/a71cfa26-be31-4ddd-bf23-0e3e8f0d1180)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Esta solución mejora el rendimiento y la experiencia de usuario al prerrenderizar las rutas dinámicas en tiempo de build, evitando la renderización bajo demanda en el servidor.

## Enlaces útiles

https://docs.astro.build/en/basics/rendering-modes/#server-output-modes
