### PR TITLE
DESING: Rediseño grande a la la preview del Boxeador

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -8,7 +8,7 @@ interface Props {
 const { title, value, id } = Astro.props
 ---
 
-<div class="flex justify-center text-white">
+<div class="m-5 flex justify-center text-white">
 	<div class="style flex flex-col items-start text-center">
 		<h4>{title}</h4>
 		<p class="text-xl font-bold" id={id}>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -3,9 +3,9 @@ import BoxerBigImage from "@/components/BoxerBigImage.astro"
 import BoxerWorkout from "@/components/BoxerWorkout.astro"
 import BoxerClips from "@/components/BoxerClips.astro"
 import BoxerDetailInfo from "@/components/BoxerDetailInfo.astro"
-import BoxerDetailInfoRival from "@/components/BoxerDetailInfoRival.astro"
 import BoxerSocialLink from "@/components/BoxerSocialLink.astro"
 import SectionTitle from "@/components/SectionTitle.astro"
+import Typography from "@/components/Typography.astro"
 
 import Instagram from "@/icons/instagram.astro"
 import Tiktok from "@/icons/tiktok.astro"
@@ -13,7 +13,6 @@ import Twitch from "@/icons/twitch.astro"
 import X from "@/icons/x.astro"
 import YouTube from "@/icons/youtube.astro"
 
-import { COUNTRIES } from "@/consts/countries"
 import { BOXERS } from "@/consts/boxers"
 import type { Boxer } from "@/types/Boxer"
 import { COMBATS } from "@/consts/combats"
@@ -88,76 +87,75 @@ const reachBoxer = boxer.reach === undefined ? "Desconocido" : boxer.reach
 	title={`${boxer.name} - Información del boxeador de La Velada IV`}
 	preload={preloadBoxerImage}
 >
-	<main>
-		<section class="flex flex-col items-center justify-center">
-			<div class="flex w-full flex-col items-center md:flex-row md:gap-10">
-				<div class="order-2 flex w-full flex-col md:order-1 md:w-1/4 md:gap-y-20">
-					<BoxerDetailInfo title="Alias" value={boxer.name} id="boxer-alias" />
-					<BoxerDetailInfo title="País" value={COUNTRIES[boxer.country].name} id="boxer-país" />
-					<BoxerDetailInfo title="Edad" value={boxer.age} id="boxer-edad" />
-					<div class="hidden md:block">
-						<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-desk" />
-					</div>
-				</div>
-
-				<div
-					class="relative order-1 -mt-20 flex flex-col items-center justify-center md:order-2 md:w-1/2 lg:mx-4"
-				>
-					<BoxerBigImage id={id} name={boxer.name} country={boxer.country} />
-				</div>
-
-				<div class="order-3 flex w-full flex-col md:w-auto md:gap-y-20 lg:w-1/4">
-					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} id="boxer-peso" />
-					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} id="boxer-altura" />
-					<BoxerDetailInfo title="Guardia" value={guardBoxer} id="boxer-guardia" />
-					<BoxerDetailInfo title="Alcance" value={reachBoxer} id="boxer-alcance" />
-
-					<div class="block md:hidden">
-						<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-mobile" />
-					</div>
-				</div>
+<main class="m-auto w-full">
+	<section class="">
+		<section class="flex w-full flex-wrap items-center justify-center">
+			<div
+				class="relative bottom-20 flex flex-col items-center justify-center md:order-2 md:w-1/2 lg:mx-4"
+			>
+				<BoxerBigImage id={id} name={boxer.name} country={boxer.country} />
 			</div>
-
-			<div class="mt-24 flex max-w-xl flex-wrap justify-center gap-8 md:mt-56 md:max-w-full">
-				<BoxerSocialLink href={boxer.socials.twitch}>
-					<Twitch />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.instagram}>
-					<Instagram />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.twitter}>
-					<X />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.youtube}>
-					<YouTube />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.tiktok}>
-					<Tiktok />
-				</BoxerSocialLink>
+			<div class="max-w-96">
+				{
+					boxer.clips && boxer.clips.length > 0 && (
+						<section class="">
+							<BoxerClips clips={boxer.clips} />
+						</section>
+					)
+				}
 			</div>
 		</section>
+		<section class="mt-20 flex flex-wrap items-center justify-center">
+			<section>
+				<div class="m-5">
+					<Typography as="h1" variant="atomic-title" color="primary">Datos básicos</Typography>
+				</div>
+				<div class="m-auto flex max-w-md flex-wrap items-center justify-center">
+					<BoxerDetailInfo title="Edad" value={boxer.age} id="boxer-edad" />
+					<BoxerDetailInfo title="Peso" value={`${boxer.weight} kg.`} id="boxer-peso" />
+					<BoxerDetailInfo title="Altura" value={`${boxer.height} m.`} id="boxer-altura" />
+				</div>
+			</section>
+			<section>
+				<div class="m-auto flex max-w-md flex-col items-center justify-center">
+					<div class="m-5">
+						<Typography as="h1" variant="atomic-title" color="primary">Redes</Typography>
+					</div>
+					<div class="flex w-96 flex-wrap justify-center gap-2 md:max-w-full">
+						<BoxerSocialLink href={boxer.socials.twitch}>
+							<Twitch />
+						</BoxerSocialLink>
+						<BoxerSocialLink href={boxer.socials.instagram}>
+							<Instagram />
+						</BoxerSocialLink>
+						<BoxerSocialLink href={boxer.socials.twitter}>
+							<X />
+						</BoxerSocialLink>
+						<BoxerSocialLink href={boxer.socials.youtube}>
+							<YouTube />
+						</BoxerSocialLink>
+						<BoxerSocialLink href={boxer.socials.tiktok}>
+							<Tiktok />
+						</BoxerSocialLink>
+					</div>
+				</div>
+			</section>
+		</section>
+	</section>
 
-		{
-			boxer.workout && (
-				<section class="my-44">
-					<SectionTitle title="Entrenamiento" description="Preparación para el combate" />
+	{
+		boxer.workout && (
+			<section class="my-44">
+				<SectionTitle title="Entrenamiento" description="Preparación para el combate" />
 
-					<BoxerWorkout workout={boxer.workout} />
-				</section>
-			)
-		}
-		{
-			boxer.clips && boxer.clips.length > 0 && (
-				<section class="my-44">
-					<SectionTitle title="Declaraciones" description="Citas previas del combate" />
+				<BoxerWorkout workout={boxer.workout} />
+			</section>
+		)
+	}
 
-					<BoxerClips clips={boxer.clips} />
-				</section>
-			)
-		}
-		{forecast && <Forecasts count={forecastCount} boxers={boxersWithForecast} />}
-		<CombatSection combatId={combat.id} combatNumber={combat.number} boxers={boxers} />
-	</main>
+	{forecast && <Forecasts count={forecastCount} boxers={boxersWithForecast} />}
+	<CombatSection combatId={combat.id} combatNumber={combat.number} boxers={boxers} />
+</main>
 </Layout>
 
 <script></script>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -87,7 +87,7 @@ const reachBoxer = boxer.reach === undefined ? "Desconocido" : boxer.reach
 	title={`${boxer.name} - Información del boxeador de La Velada IV`}
 	preload={preloadBoxerImage}
 >
-<main class="m-auto w-full">
+  <main class="m-auto w-full">
 	<section class="">
 		<section class="flex w-full flex-wrap items-center justify-center">
 			<div
@@ -155,7 +155,7 @@ const reachBoxer = boxer.reach === undefined ? "Desconocido" : boxer.reach
 
 	{forecast && <Forecasts count={forecastCount} boxers={boxersWithForecast} />}
 	<CombatSection combatId={combat.id} combatNumber={combat.number} boxers={boxers} />
-</main>
+  </main>
 </Layout>
 
 <script></script>

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -99,7 +99,7 @@ const reachBoxer = boxer.reach === undefined ? "Desconocido" : boxer.reach
 				{
 					boxer.clips && boxer.clips.length > 0 && (
 						<section class="">
-							<BoxerClips clips={boxer.clips} />
+							<BoxerClips clips={boxer.clips.slice(0, 2)} />
 						</section>
 					)
 				}


### PR DESCRIPTION
## Descripción

Se crea un diseño totalmente nuevo para la preview de un boxeador

## Problema solucionado

**Hoy Midu mencionó que le gustaría tener las frases del boxeador al lado de su imagen porque actualmente estaban muy abajo
https://www.twitch.tv/videos/2096342432?t=0h22m26s**

## Cambios propuestos

1) Las frases se movieron al lado del boxeador 
2) Las redes y la información se mueve hacia la parte de abajo
3) Se quita el país y el combate porque es información que ya está incluida en la sección de combate y es un poco redundante
4) En BoxerDetailInfo.astro añadí un margin para que los datos personales no se vean pegados
5) Es totalmente responsive


## Capturas de pantalla (si corresponde)

Diseño actual:

![vista vieja](https://github.com/midudev/la-velada-web-oficial/assets/96151177/c6294583-8c83-4d4b-a1d6-7ae0054cd61a)

Diseño propuesto:

![vista nueva](https://github.com/midudev/la-velada-web-oficial/assets/96151177/3a57b33a-8bbb-48bf-9e4c-2737f3c7b345)


<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [SÍ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [Sí ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [Sí ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [Sí ] He actualizado la documentación, si corresponde.

## Impacto potencial

En mi opinión personal se ve un poco mejor el diseño, se quita información redundante y se le da importancia a las frases