### PR TITLE
remove types from Sponsors file

### DIFF
--- a/src/consts/sponsors.ts
+++ b/src/consts/sponsors.ts
@@ -1,35 +1,4 @@
-type SponsorId =
-	| "vicio"
-	| "revolut"
-	| "prime"
-	| "alsa"
-	| "spotify"
-	| "cerave"
-	| "grefusa"
-	| "el-pozo"
-	| "maxibon"
-	| "infojobs"
-type SponsorName =
-	| "Vicio"
-	| "Revolut"
-	| "Prime"
-	| "Alsa"
-	| "Spotify"
-	| "Cerave"
-	| "Grefusa"
-	| "ElPozo"
-	| "Maxibon"
-	| "InfoJobs"
-
-interface Sponsors {
-	id: SponsorId
-	name: SponsorName
-	url: string
-	image: {
-		width: number
-		height: number
-	}
-}
+import type { Sponsors } from "@/types/Sponsors"
 
 export const SPONSORS: Array<Sponsors> = [
 	{


### PR DESCRIPTION
## Descripción

Se removió tipos innecesarios en el archivo "sponsors.ts"

Ya que alguien había agregado los tipos en "types/Sponsors.ts",  así que importe esos tipos en "sponsors.ts".

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.



