### PR TITLE
Se elimina logica innecesaria al seleccionar el boxeador actual

### DIFF
--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -4,10 +4,31 @@ import type { Boxer } from "@/types/Boxer"
 interface Props {
 	boxers: Boxer[]
 	class?: string
-	selectedBoxerId: string
+	selectedBoxer: Boxer
 }
 
-const { boxers, class: className = "", selectedBoxerId } = Astro.props
+const { boxers, class: className = "", selectedBoxer } = Astro.props
+
+const isAlly = (id: Boxer["id"]) => selectedBoxer.allies?.includes(id)
+
+const hasSameOpponents = (selectedBoxerOpponents: string[], opponents: string[]) => {
+	return selectedBoxerOpponents.every((sBoxerOpponent) =>
+		opponents.some((opponent) => opponent === sBoxerOpponent)
+	)
+}
+
+const isOpponent = (id: Boxer["id"], versus: Boxer["versus"]) => {
+	const selectedBoxerOpponents = Array.isArray(selectedBoxer.versus)
+		? selectedBoxer.versus
+		: [selectedBoxer.versus]
+
+	const opponents = Array.isArray(versus) ? versus : [versus]
+
+	return (
+		selectedBoxerOpponents.includes(id) ||
+		(hasSameOpponents(selectedBoxerOpponents, opponents) && id !== selectedBoxer.id && !isAlly(id))
+	)
+}
 ---
 
 <div class:list={`flex flex-col ${className}`}>
@@ -15,7 +36,14 @@ const { boxers, class: className = "", selectedBoxerId } = Astro.props
 		boxers.map(({ id, name, country, countryName, weight, rotate, versus, allies }) => (
 			<a
 				href={`/boxers/${id}`}
-				class:list={["boxer-link", { active: selectedBoxerId === id }]}
+				class:list={[
+					"boxer-link",
+					{
+						active: selectedBoxer.id === id,
+						ally: isAlly(id),
+						opponent: isOpponent(id, versus),
+					},
+				]}
 				title={`Visita la página del boxeador ${name}`}
 				data-id={id}
 				data-name={name}

--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -53,13 +53,13 @@ const boxerColumns = [
 
 		<div class="boxers-nav hidden w-full justify-between md:flex">
 			<nav class="boxers-lists flex h-full justify-start gap-4 py-4">
-				<ColumnBoxers boxers={boxerColumns[0]} selectedBoxerId={selectedBoxerId} />
-				<ColumnBoxers boxers={boxerColumns[1]} selectedBoxerId={selectedBoxerId} class="mt-12" />
+				<ColumnBoxers boxers={boxerColumns[0]} selectedBoxer={selectedBoxer} />
+				<ColumnBoxers boxers={boxerColumns[1]} selectedBoxer={selectedBoxer} class="mt-12" />
 			</nav>
 
 			<nav class="boxers-lists flex h-full justify-end gap-2 py-4">
-				<ColumnBoxers boxers={boxerColumns[2]} selectedBoxerId={selectedBoxerId} class="mt-12" />
-				<ColumnBoxers boxers={boxerColumns[3]} selectedBoxerId={selectedBoxerId} />
+				<ColumnBoxers boxers={boxerColumns[2]} selectedBoxer={selectedBoxer} class="mt-12" />
+				<ColumnBoxers boxers={boxerColumns[3]} selectedBoxer={selectedBoxer} />
 			</nav>
 		</div>
 
@@ -75,7 +75,7 @@ const boxerColumns = [
 									${index === listOfBoxers.length - 1 ? "mr-[30%]" : ""}
 								`}
 							>
-								<ColumnBoxers boxers={[boxer]} selectedBoxerId={selectedBoxerId} />
+								<ColumnBoxers boxers={[boxer]} selectedBoxer={selectedBoxer} />
 							</div>
 						))
 					}
@@ -94,20 +94,6 @@ const boxerColumns = [
 		const boxerTitle = $(".boxer-title") as HTMLImageElement
 		const boxerPhoto = $(".boxer-photo") as HTMLPictureElement
 		const boxerCountry = $(".boxer-flag") as HTMLImageElement
-		const queryString = window.location.search
-		const urlParams = new URLSearchParams(queryString)
-		const initialBoxer = urlParams.get("boxer") ?? "el-mariana"
-		const initialBoxerElement = $(`a.boxer-link[data-id=${initialBoxer}]`)
-		let isInitialBoxer = true
-
-		if (initialBoxerElement) {
-			const initialBoxerLink =
-				Array.from(boxerLinks).find(
-					(boxerLink) => boxerLink.getAttribute("data-id") === initialBoxer
-				) ?? boxerLinks[0]
-
-			activateBoxer(initialBoxerElement, initialBoxerLink, boxerNav, false)
-		}
 
 		function activateBoxer(
 			element: HTMLElement,
@@ -116,8 +102,7 @@ const boxerColumns = [
 			replaceUrl: boolean = false,
 			showAlliesAndOpponents: boolean = true
 		) {
-			if (element?.classList.contains("active") && !isInitialBoxer) return
-			isInitialBoxer = false
+			if (element?.classList.contains("active")) return
 
 			const { id, name, country, countryName, opponents = "", allies = "" } = element?.dataset
 


### PR DESCRIPTION
## Descripción

Se elimina la lógica redundante utilizada para reseleccionar el boxeador actual (`?boxer=example` 🥊) al navegar de vuelta a la home 🏡.

## Problema solucionado

Anteriormente, se estaba reseleccionando el boxeador actual cada vez que se regresaba a la home 🏡. Sin embargo, esto ya no es necesario, ya que la página se re-renderiza en el servidor con el boxeador seleccionado, evitando la necesidad de volver a hacerlo con JavaScript.

## Cambios propuestos

Se elimina el código innecesario para evitar reseleccionar el boxeador y prevenir posibles parpadeos de la informacion del  boxeador seleccionado entre navegaciones, tambien se agrega la logica al componente `ColumnBoxer.astro` para marcar los boxeadores como aliados y oponentes.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

- Mejora la eficiencia al eliminar lógica redundante.
- Previene posibles parpadeos del boxeador actual entre navegaciones.
- Puede mejorar ligeramente el rendimiento en dispositivos de gama baja al no tener que ejecutar JavaScript innecesario durante la navegación.

## Adicional

Anteriormente habia creado una PR para solucionar esto pero esta no cubria la logica de la seleccion de aliados y oponentes.