### PR TITLE
Aplicar lowercase a la fuente Atomic en el componente Typography

### DIFF
--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -12,8 +12,8 @@ const { as: Tag, class: className, variant, color, ...props } = Astro.props
 const variantClasses: { [key: string]: string } = {
 	"h2": "text-lg font-medium uppercase lg:text-2xl",
 	"h3": "text-2xl font-semibold uppercase",
-	"atomic-title": "text-5xl font-atomic",
-	"boxer-title": "text-6xl md:text-8xl font-atomic",
+	"atomic-title": "text-5xl font-atomic lowercase",
+	"boxer-title": "text-6xl md:text-8xl font-atomic lowercase",
 	"body": "text-xl",
 	"medium": "text-md",
 	"big": "text-6xl uppercase",


### PR DESCRIPTION
## Descripción

Se implementa el estilo de texto en minúsculas automáticamente para la familia tipográfica Atomic en el componente Typography.

## Problema solucionado

La familia tipográfica Atomic no cuenta con caracteres en mayúsculas, por lo que cuando se utilizaba esta fuente en el componente Typography, era necesario escribir los textos en minúsculas o aplicar la función `toLowerCase()` para que se visualizaran correctamente.

## Cambios propuestos

Se agrega la clase de Tailwind `lowercase` en el objeto `variantClasses` cuando se utiliza la fuente Atomic en las variantes `"atomic-title"` o `"boxer-title"` del componente Typography. De esta manera, independientemente de si el texto se proporciona en mayúsculas, minúsculas o una combinación de ambas, se aplicará automáticamente el estilo de minúsculas para asegurar una representación correcta de la fuente Atomic.

## Capturas de pantalla (si corresponde)

- El aspecto visual permanece igual, pero se simplifica el uso del componente Typography con la fuente Atomic.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

- Mejora en la experiencia de desarrollo al no ser necesario preocuparse por la capitalización del texto cuando se utiliza el componente Typography con la familia tipográfica Atomic, simplificando su uso y reduciendo la posibilidad de errores.
- Mantiene la consistencia visual al asegurar que la fuente Atomic se represente correctamente en todos los casos.
