### PR TITLE
fix:konamiCode contributors request

### DIFF
--- a/src/function/miduCode.ts
+++ b/src/function/miduCode.ts
@@ -26,7 +26,7 @@ export async function showContributors($miduContainer: HTMLDivElement) {
 				$miduContainer.removeChild(img)
 			})
 			$miduContainer.appendChild(img)
-		}, i * 300)
+		}, i * 435)
 	}
 }
 
@@ -34,7 +34,7 @@ export async function getContributors() {
 	const url = "https://api.github.com/repos/midudev/la-velada-web-oficial/contributors"
 	const response = await fetch(url)
 
-	const linkHeader = response.headers.get("link")
+	const linkHeader = await response.headers.get("link")
 	const pageCount = linkHeader ? Number(linkHeader.match(/page=(\d+)>; rel="last"/)?.[1] || "1") : 1
 	const randomPage = Math.floor(Math.random() * pageCount) + 1
 	const randomPageUrl = `${url}?page=${randomPage}`


### PR DESCRIPTION
## Descripción

-  Hay un problema con la solicitud de contribuciones al ejecutar el comando midu. El problema radica en que la solicitud no se está ejecutando de manera asíncrona como se espera.

- Mostrar al mismo tiempo la animación de los contribuidores con el audio de ibai

## Problema solucionado

- Agregamos await en la respuesta del calculo de paginas que hace en la petición en la API de Github

- Se ha calculado el número total de contribuyentes por página en la solicitud, que asciende a 30. Este valor se divide por la duración del audio, que es de 1300 milisegundos (ms). El resultado de esta operación es de aproximadamente 433 ms. Para garantizar un ritmo adecuado, hemos redondeado este valor a 435 ms.
  
