### PR TITLE
fix: :lipstick: mobile boxers scroll animation

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -65,7 +65,7 @@ const boxerColumns = [
 
 		<div class="-mt-20 flex flex-col items-center justify-center md:mt-32 md:hidden">
 			<div class="carousel mt-8 w-full max-w-[100vw] overflow-y-hidden overflow-x-scroll">
-				<div class="carousel-inner flex snap-x overflow-y-hidden overflow-x-scroll">
+				<div class="carousel-inner flex snap-x snap-mandatory overflow-y-hidden overflow-x-scroll">
 					{
 						listOfBoxers.map((boxer, index) => (
 							<div
@@ -209,38 +209,34 @@ const boxerColumns = [
 		})
 
 		const carouselInner = $(".carousel-inner") as HTMLElement
-		const carouselItems = $$(".carousel-item") as globalThis.NodeListOf<HTMLElement>
-
-		// detect centered carousel item with intersection observer
-		const carouselObserver = new IntersectionObserver(
-			(entries) => {
-				entries.forEach((entry) => {
-					if (entry.isIntersecting) {
-						const link = entry.target.querySelector(".boxer-link") as HTMLAnchorElement
-						activateBoxer(link, link, carouselInner, false, false)
-					}
-				})
-			},
-			{
-				root: carouselInner,
-				threshold: 0.95,
-			}
-		)
 
 		// detect match media change for mobile
-		const isMobileMediaQuery = window.matchMedia("(max-width: 768px)")
-		// detect first time
-		if (isMobileMediaQuery.matches) {
-			carouselItems.forEach((item) => carouselObserver.observe(item))
-		}
-		// detect if it changes
-		isMobileMediaQuery.addEventListener("change", (event) => {
-			if (event.matches) {
-				carouselItems.forEach((item) => carouselObserver.observe(item))
-			} else {
-				carouselItems.forEach((item) => carouselObserver.unobserve(item))
+		const mobileMediaQuery = window.matchMedia("(max-width: 768px)")
+
+		function highlightBoxer(link: HTMLAnchorElement) {
+			if (
+				link.getBoundingClientRect().left >
+					carouselInner.getBoundingClientRect().width / 2 -
+						link.getBoundingClientRect().width * 0.75 &&
+				link.getBoundingClientRect().left <
+					carouselInner.getBoundingClientRect().width / 2 +
+						link.getBoundingClientRect().width * 0.25
+			) {
+				activateBoxer(link, link, carouselInner, false, false)
 			}
-		})
+		}
+
+		function highlightActiveBoxer() {
+			boxerLinks.forEach((link) => {
+				highlightBoxer(link)
+			})
+		}
+
+		if (mobileMediaQuery.matches) {
+			carouselInner.addEventListener("scroll", () => {
+				highlightActiveBoxer()
+			})
+		}
 	})
 </script>
 


### PR DESCRIPTION
fixes #698

## Descripción

La animación de scroll horizontal en [SelectYourBoxer.astro](https://github.com/midudev/la-velada-web-oficial/blob/main/src/sections/SelectYourBoxer.astro) tenía algunas inconsistencias en la version móvil. Agregué un snap-mandatory y un event listener 'scroll' en el carouselInner para activarlos segun su posición en x.

## Problema solucionado

Soluciona el issue [#698 Problema con el scroll de luchadores en la versión móvil](https://github.com/midudev/la-velada-web-oficial/issues/698)

## Cambios propuestos

* snap-mandatory para solucionar que la terminacion de la animacion de scroll termine en un elemento. Antes de esto la animacion hacia un salto al hacer un scroll largo.
* se agregó un scroll listener al carouselInner para comprobar la posicion en x de los elementos en el carousel. (Se aceptan futuras recomendaciones si existe otra mejor manera de hacer esta implementación que solucione el problema)

## Capturas de pantalla (si corresponde)

https://github.com/midudev/la-velada-web-oficial/assets/46976866/91212312-3f92-4cd9-ae3e-0ccea1bfc575

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

No se que tanto cambio de rendimiento pueda causar el scroll listener que agregué, se colocó dentro de un if para sólo agregarlo a la versión móvil.

## contexto adicional

El cambio de lugar del import de BoxerBigImage se hizo por Prettier. No pude subir cambios sin acomodar ese import.
