### PR TITLE
Hacer el mensaje de Ganador al hover (y ahora focus) accesible 

### DIFF
--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -32,13 +32,16 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 
 				return (
 					<li class="relative flex w-full max-w-2xl flex-row justify-between">
-						<button class="vote-team relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100">
+						<button class="vote-team group relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100">
 							<img
 								class="h-auto w-full"
 								src="/img/boxers/vote-6-plex.webp"
 								alt="Fotografía de "
 								style="mask-image: linear-gradient(black 80%, transparent)"
 							/>
+							<span class="opacity-0 group-hover:animate-fade-in group-focus:animate-fade-in">
+								ganador
+							</span>
 						</button>
 						<Image
 							width={combatData.titleSize[0]}
@@ -49,13 +52,16 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 							src={`/img/matches/title-${combat.id}.webp`}
 							alt={`Fotografía del combate entre ${boxerNames.join(", ")}`}
 						/>
-						<button class="vote-team relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100">
+						<button class="vote-team group relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100">
 							<img
 								class="h-auto w-full"
 								src="/img/boxers/vote-6-el-mariana.webp"
 								alt="Fotografía de "
 								style="mask-image: linear-gradient(black 80%, transparent)"
 							/>
+							<span class="opacity-0 group-hover:animate-fade-in group-focus:animate-fade-in">
+								ganador
+							</span>
 						</button>
 					</li>
 				)
@@ -74,11 +80,8 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 </script>
 
 <style>
-	.vote-team:hover {
-		&::after {
-			content: "ganador";
-			@apply pointer-events-none absolute bottom-0 left-0 right-0 z-50 mx-auto animate-fade-in font-atomic text-5xl text-green-500;
-			text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
-		}
+	.vote-team span {
+		@apply pointer-events-none absolute bottom-0 left-0 right-0 z-50 mx-auto font-atomic text-5xl text-green-500;
+		text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
 	}
 </style>


### PR DESCRIPTION
## Descripción

Antes teníamos el mensaje de Ganador con un pseudoelemento, y eso suele dar problemas con los lectores de pantalla. 

## Problema solucionado

El hover lo hemos hecho ahora de una forma distinta y además es accesible con el teclado.

## Cambios propuestos

Ahora tenemos un span en lugar del pseudoelemento y jugamos un poco con las propiedades group y group-hover y group-focus de TailwindCSS.

## Capturas de pantalla (si corresponde)

No afectan, es igual que antes.

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

No debería haberlos.

## Contexto adicional


## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
