### PR TITLE
Fix format rivals

### DIFF
--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -15,7 +15,7 @@ const { title, value, id } = Astro.props
 		class="flex w-full items-start justify-between pl-2.5 pr-2.5 pt-2 text-center md:flex-col md:items-center"
 	>
 		<h4>{title}</h4>
-		<div>
+		<div class="w-2/3 text-right md:w-full md:text-center">
 			{
 				value.map((item, index) => (
 					<>
@@ -27,9 +27,7 @@ const { title, value, id } = Astro.props
 						>
 							{item.name}
 						</a>
-						{index !== value.length - 1 && index % 2 === 0 && (
-							<span class="text-xl font-bold text-accent"> / </span>
-						)}
+						{index !== value.length - 1 && <span class="text-xl font-bold text-accent"> / </span>}
 					</>
 				))
 			}

--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -15,7 +15,7 @@ const { title, value, id } = Astro.props
 		class="flex w-full items-start justify-between pl-2.5 pr-2.5 pt-2 text-center md:flex-col md:items-center"
 	>
 		<h4>{title}</h4>
-		<div class="w-2/3 text-right md:w-full md:text-center">
+		<div class="w-4/5 text-right md:w-full md:text-center">
 			{
 				value.map((item, index) => (
 					<>

--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -27,7 +27,9 @@ const { title, value, id } = Astro.props
 						>
 							{item.name}
 						</a>
-						{index !== value.length - 1 && <span class="text-xl font-bold text-accent"> / </span>}
+						{index !== value.length - 1 && index % 2 === 0 && (
+							<span class="text-xl font-bold text-accent"> / </span>
+						)}
 					</>
 				))
 			}


### PR DESCRIPTION
## Descripción

Se acomodó el alineado de rivales para la parte responsive

## Problema solucionado

Se alineó a la derecha los rivales, ya que quedaban alineados al centro

## Cambios propuestos

## Capturas de pantalla

**Antes:**
![image](https://github.com/midudev/la-velada-web-oficial/assets/63821577/9029dbdb-605f-4968-9184-db8e627ae694)

**Ahora:**
![image](https://github.com/midudev/la-velada-web-oficial/assets/63821577/ca5a80c2-dd2f-4d1b-8229-57ee3c0ffcc2)

## Comprobación de cambios

- [ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

## Contexto adicional

## Enlaces útiles
