### PR TITLE
Error en Boxer Clips

### DIFF
--- a/src/components/BoxerClips.astro
+++ b/src/components/BoxerClips.astro
@@ -16,12 +16,13 @@ const hasClips = clips.length > 0
 	hasClips && (
 		<section class="z-10 mt-2 md:mt-0">
 			<div class="carousel flex select-none flex-row flex-nowrap transition duration-700 md:max-w-none md:!translate-x-0 md:flex-wrap md:place-content-center md:gap-4">
-				{clips.map(({ text, url }) => (
+				{clips.map(({ text, url }, index) => (
 					<a
 						href={url}
 						target="_blank"
 						rel="noopener noreferrer"
-						class="group flex min-w-full max-w-[450px] flex-col justify-between  hover:saturate-150 md:min-w-0"
+						class:list={`group flex min-w-full max-w-[450px] flex-col justify-between  hover:saturate-150 md:min-w-0 ${index === 0 ? "block" : "hidden"} md:block`}
+						data-clip-item
 					>
 						<Typography
 							as="h3"
@@ -69,12 +70,22 @@ const hasClips = clips.length > 0
 		const $prev = document.querySelector("[data-btn-prev]")
 		const $next = document.querySelector("[data-btn-next]")
 		const $clipIndex = document.querySelector("[data-clip-index]")
+		const $clipItems = document.querySelectorAll("[data-clip-item]")
 
 		let position = 0
 
 		const updatePosition = () => {
-			// Midu diría que esto es un poquito regulinchis :)
-			$carousel?.setAttribute("style", `transform: translateX(-${100 * position}%)`)
+			if (window.innerWidth < 768) {
+				$clipItems.forEach(($item, index) => {
+					$item.classList.toggle("hidden", index !== position)
+					$item.classList.toggle("block", index === position)
+				})
+			} else {
+				$clipItems.forEach(($item) => {
+					$item.classList.remove("hidden")
+					$item.classList.add("block")
+				})
+			}
 
 			if ($clipIndex) $clipIndex.innerHTML = `Cita ${position + 1}/${$carousel?.children.length}`
 		}
@@ -94,5 +105,8 @@ const hasClips = clips.length > 0
 			}
 			updatePosition()
 		})
+
+		window.addEventListener("resize", updatePosition)
+		updatePosition()
 	})
 </script>


### PR DESCRIPTION
## Descripción

En el carrusel se muestran todas las frases al mismo tiempo, independientemente del tamaño de la pantalla, cuando lo deseado es mostrar solo una frase a la vez en pantallas pequeñas y permitir la navegación entre ellas usando las flechas.

## Problema solucionado

El carrusel muestra todas las frases simultáneamente, en lugar de una sola a la vez en pantallas pequeñas con navegación por flechas.

## Cambios propuestos

Los cambios realizados permiten mostrar solo una frase a la vez en el carrusel en pantallas pequeñas, mientras que en pantallas más grandes se muestran todas las frases. La función updatePosition se encarga de actualizar la visibilidad de las frases según la posición actual y el tamaño de la pantalla.

## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/159711246/fb4e5cb5-c43c-4a1e-9c81-eee012e5c938)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/159711246/79863f89-a09a-4c16-b061-a0f2132e5704)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
