### PR TITLE
Se agrega el sitemap de la pagina con las rutas de boxeadores y combates

### DIFF
--- a/src/pages/sitemap.xml.ts
+++ b/src/pages/sitemap.xml.ts
@@ -1,0 +1,32 @@
+import { BOXERS } from "@/consts/boxers";
+import { COMBATS } from "@/consts/combats";
+import { seoConfig } from "@/utils/seoConfig";
+import type { APIRoute } from 'astro';
+
+export const GET: APIRoute = async () => {
+
+	const BOXERS_URLS: string = BOXERS.map(boxer => {
+		return `
+		<url>
+			<loc>${seoConfig.baseURL}boxers/${boxer.id}</loc>
+		</url>`
+	}).join("\n");
+
+	const COMBATS_URLS: string = COMBATS.map(combat => {
+		return `
+		<url>
+			<loc>${seoConfig.baseURL}combates/${combat.id}</loc>
+		</url>`
+	}).join("\n");
+
+	return new Response(
+		`<?xml version="1.0" encoding="UTF-8"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:news="http://www.google.com/schemas/sitemap-news/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1">
+            ${BOXERS_URLS}
+			${COMBATS_URLS}
+        </urlset>`, {
+		headers: {
+			'Content-Type': 'text/xml; charset=utf-8',
+		},
+	});
+};


### PR DESCRIPTION
## Descripción

Se agrega el sitemap de la pagina con las rutas de boxeadores y combates

## Problema solucionado

Para Google es mas facil indexar una pagina mediante el archivo sitemap, entonces se creo este archivo con las urls de los boxeadores y combates

## Cambios propuestos

- Se agrego el archivo sipemap.xml.ts dentro de las paginas.


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Sin impacto.


