### PR TITLE
Desing section info boxer

### DIFF
--- a/src/components/BoxerBigImage.astro
+++ b/src/components/BoxerBigImage.astro
@@ -41,7 +41,7 @@ const { name, country, countryName, id, loading } = Astro.props
 </picture>
 
 <div
-	class="absolute bottom-10 z-10 flex max-w-md flex-col items-center justify-center text-wrap md:-bottom-32"
+	class="absolute top-44 z-10 flex max-w-md flex-col items-center justify-center text-wrap md:-bottom-32"
 	transition:name="boxer-name"
 >
 	<BoxerTitleName name={name} />

--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -8,10 +8,12 @@ interface Props {
 const { title, value, id } = Astro.props
 ---
 
-<div class="flex justify-center text-white">
+<div
+	class="group relative items-center justify-center overflow-hidden px-10 py-2 text-white mix-blend-screen transition"
+>
 	<div class="style flex flex-col items-start text-center">
-		<h4>{title}</h4>
-		<p class="text-xl font-bold" id={id}>
+		<h4 class="font-atomic lowercase text-accent">{title}</h4>
+		<p class="text-4xl font-bold" id={id}>
 			{value}
 		</p>
 	</div>

--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -10,27 +10,34 @@ interface Props {
 const { title, value, id } = Astro.props
 ---
 
-<div class="flex justify-center text-white">
-	<div
-		class="flex w-full items-start justify-between pl-2.5 pr-2.5 pt-2 text-center md:flex-col md:items-center"
-	>
-		<h4>{title}</h4>
-		<div class="w-4/5 text-right md:w-full md:text-center">
+<div class="flex justify-center text-white mix-blend-screen">
+	<div class="flex w-full items-start justify-between text-center md:flex-col md:items-center">
+		<div class="text-right md:w-full md:text-center">
 			{
 				value.map((item, index) => (
 					<>
 						<a
-							class:list={"text-xl font-bold text-accent hover:underline"}
+							class="-skew-x-6 transition hover:scale-110 hover:underline"
 							href={item.id}
 							title={`Visita la página del boxeador ${item.name}`}
 							id={id + (index + 1)}
 						>
-							{item.name}
+							<img
+								src={`/img/boxers/${item.id}-small.webp`}
+								class="mx-auto aspect-square h-32 object-contain"
+								alt={`Foto en pequeño del rival ${item.name}`}
+								style="
+									filter: drop-shadow(0 0 5px rgba(0, 0, 0, .5));
+									mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
+								"
+							/>
+							<span class:list={"text-xl font-bold text-accent "}>{item.name}</span>
 						</a>
 						{index !== value.length - 1 && <span class="text-xl font-bold text-accent"> / </span>}
 					</>
 				))
 			}
 		</div>
+		<h4>{title}</h4>
 	</div>
 </div>

--- a/src/components/BoxerSocialLink.astro
+++ b/src/components/BoxerSocialLink.astro
@@ -12,7 +12,7 @@ const { href } = Astro.props
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			class="group relative inline-flex w-32 items-center justify-center overflow-hidden bg-gradient-to-b from-white/20 to-transparent px-10 py-2 text-white mix-blend-screen transition"
+			class="group relative inline-flex w-full items-center justify-center overflow-hidden bg-gradient-to-b from-white/20 to-transparent px-10 py-2 text-white mix-blend-screen transition"
 		>
 			<slot />
 			<span class="absolute inset-0 h-1/2 bg-gradient-to-b from-white to-transparent opacity-0 transition-opacity duration-200 ease-in-out group-hover:h-[90%] group-hover:opacity-20 group-focus:h-[90%] group-focus:opacity-20" />

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -15,6 +15,7 @@ import X from "@/icons/x.astro"
 import YouTube from "@/icons/youtube.astro"
 
 import type { Preload } from "@/components/SEO.astro"
+import Typography from "@/components/Typography.astro"
 import { BOXERS } from "@/consts/boxers"
 import { COMBATS } from "@/consts/combats"
 import { COUNTRIES } from "@/consts/countries"
@@ -96,16 +97,14 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 	<main>
 		<section class="relative flex flex-col items-center justify-center">
 			<div class="flex w-full flex-col md:flex-row md:gap-10">
-				<div
-					class="left-10 order-2 flex w-full flex-col md:absolute md:order-1 md:w-[300px] md:gap-y-20"
-				>
-					<BoxerClips clips={boxer.clips} />
-					<div class="hidden md:block">
-						<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-desk" />
+				<div class="flex w-full flex-col md:w-1/4 md:gap-y-20">
+					<div class="order-2 flex w-full flex-col md:order-1">
+						<BoxerClips clips={boxer.clips} />
+						<div class="hidden md:block">
+							<BoxerDetailInfoRival title={rivalOrRivals} value={rivals} id="boxer-rival-desk" />
+						</div>
 					</div>
 				</div>
-
-				<div class="flex w-full flex-col md:w-1/4 md:gap-y-20"></div>
 
 				<div
 					class="relative order-1 -mt-20 flex flex-col items-center justify-center md:order-2 md:w-1/2 lg:mx-4"
@@ -127,23 +126,28 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 				</div>
 			</div>
 
-			<div class="mt-24 flex max-w-xl flex-wrap justify-center gap-8 md:mt-56 md:max-w-full">
-				<BoxerSocialLink href={boxer.socials.twitch}>
-					<Twitch />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.instagram}>
-					<Instagram />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.twitter}>
-					<X />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.youtube}>
-					<YouTube />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.tiktok}>
-					<Tiktok />
-				</BoxerSocialLink>
-			</div>
+			<section class="mt-52">
+				<Typography as="h3" variant="h3" color="white" class:list={"mb-12 text-center"}>
+					REDES SOCIALES
+				</Typography>
+				<div class="flex w-full flex-col md:flex-row md:gap-10">
+					<BoxerSocialLink href={boxer.socials.twitch}>
+						<Twitch />
+					</BoxerSocialLink>
+					<BoxerSocialLink href={boxer.socials.instagram}>
+						<Instagram />
+					</BoxerSocialLink>
+					<BoxerSocialLink href={boxer.socials.twitter}>
+						<X />
+					</BoxerSocialLink>
+					<BoxerSocialLink href={boxer.socials.youtube}>
+						<YouTube />
+					</BoxerSocialLink>
+					<BoxerSocialLink href={boxer.socials.tiktok}>
+						<Tiktok />
+					</BoxerSocialLink>
+				</div>
+			</section>
 		</section>
 
 		{


### PR DESCRIPTION
## Descripción

Nuevo diseño para la sección de los boxeadores 

## Problema solucionado

Muestra la foto del rival y se ve mejor la información del boxeador 

## Cambios propuestos

Ahora 
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/5d394f2f-38b2-40a8-9bfe-7ae0878994c7)

Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/53d587c8-3cc9-41bf-9823-21ddda07354c)


## Comprobación de cambios

- [ x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ x] He actualizado la documentación, si corresponde.

## Impacto potencial
Nueva forma de consultar la información de los peleadores

