### PR TITLE
Optimizando carga de imagenes dependiendo si se entra directamente a la home o se vuelve a ella

### DIFF
--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -1,13 +1,15 @@
 ---
 import type { Boxer } from "@/types/Boxer"
+import type { HTMLAttributes } from "astro/types"
 
 interface Props {
 	boxers: Boxer[]
 	class?: string
 	selectedBoxer: Boxer
+	imgLoading?: HTMLAttributes<"img">["loading"]
 }
 
-const { boxers, class: className = "", selectedBoxer } = Astro.props
+const { boxers, class: className = "", selectedBoxer, imgLoading } = Astro.props
 
 const isAlly = (id: Boxer["id"]) => selectedBoxer.allies?.includes(id)
 
@@ -57,7 +59,7 @@ const isOpponent = (id: Boxer["id"], versus: Boxer["versus"]) => {
 					src={`/img/boxers/${id}-small.webp`}
 					alt={`Foto en pequeño del boxeador ${name}`}
 					class:list={`boxer-image aspect-square h-full w-full object-contain ${rotate ? "rotate-y-180" : ""}`}
-					loading="lazy"
+					loading={imgLoading}
 				/>
 			</a>
 		))

--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -11,7 +11,7 @@ const listOfBoxers = BOXERS.map((boxer) => {
 	return { ...boxer, countryName }
 })
 
-const selectedBoxerId = Astro.url.searchParams.get("boxer") ?? "el-mariana"
+const selectedBoxerId = Astro.url.searchParams.get("boxer")
 const selectedBoxer = listOfBoxers.find(({ id }) => id === selectedBoxerId) || listOfBoxers[0]
 
 // split in 4 columns
@@ -47,19 +47,37 @@ const boxerColumns = [
 				name={selectedBoxer.name}
 				country={selectedBoxer.country}
 				countryName={selectedBoxer.countryName}
-				loading="lazy"
+				loading={selectedBoxerId ? "eager" : "lazy"}
 			/>
 		</article>
 
 		<div class="boxers-nav hidden w-full justify-between md:flex">
 			<nav class="boxers-lists flex h-full justify-start gap-4 py-4">
-				<ColumnBoxers boxers={boxerColumns[0]} selectedBoxer={selectedBoxer} />
-				<ColumnBoxers boxers={boxerColumns[1]} selectedBoxer={selectedBoxer} class="mt-12" />
+				<ColumnBoxers
+					boxers={boxerColumns[0]}
+					selectedBoxer={selectedBoxer}
+					imgLoading={!selectedBoxerId ? "lazy" : undefined}
+				/>
+				<ColumnBoxers
+					boxers={boxerColumns[1]}
+					selectedBoxer={selectedBoxer}
+					class="mt-12"
+					imgLoading={!selectedBoxerId ? "lazy" : undefined}
+				/>
 			</nav>
 
 			<nav class="boxers-lists flex h-full justify-end gap-2 py-4">
-				<ColumnBoxers boxers={boxerColumns[2]} selectedBoxer={selectedBoxer} class="mt-12" />
-				<ColumnBoxers boxers={boxerColumns[3]} selectedBoxer={selectedBoxer} />
+				<ColumnBoxers
+					boxers={boxerColumns[2]}
+					selectedBoxer={selectedBoxer}
+					class="mt-12"
+					imgLoading={!selectedBoxerId ? "lazy" : undefined}
+				/>
+				<ColumnBoxers
+					boxers={boxerColumns[3]}
+					selectedBoxer={selectedBoxer}
+					imgLoading={!selectedBoxerId ? "lazy" : undefined}
+				/>
 			</nav>
 		</div>
 


### PR DESCRIPTION
## Descripción

Se optimiza la carga de imágenes de los boxeadores en la página de inicio (home 🏡) dependiendo de si se accede directamente a ella o si se navega desde la página de un boxeador específico.

## Problema solucionado

Cuando se navegaba desde la página de un boxeador hacia la página de inicio, las imágenes experimentaban un parpadeo debido al uso de lazy loading. Esto ocurría porque el DOM retrasaba la carga de las imágenes hasta determinar si estaban dentro del viewport, lo cual causaba un alto valor de Largest Contentful Paint (LCP).

## Cambios propuestos

Se agrega una condición para utilizar `loading=lazy` únicamente cuando se accede directamente a la página de inicio desde el navegador. Cuando se regresa a la página de inicio después de navegar hacia la página de un boxeador, se utiliza `loading=eager` para cargar las imágenes de manera más rápida y evitar el parpadeo.

## Capturas de pantalla (si corresponde)
- Sin el cambio propuesto
https://github.com/midudev/la-velada-web-oficial/assets/93395794/f1afd1c8-dc32-4f6c-956a-5fb00dfef60e

- Con el cambio propuesto
https://github.com/midudev/la-velada-web-oficial/assets/93395794/802623f5-2537-49af-9a38-bad63a38f0a2

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

- Mejora la experiencia de usuario en dispositivos con recursos limitados, evitando parpadeos al navegar de vuelta a la página de inicio.

## Enlaces útiles

- Articulo de Google donde se habla de esto: https://web.dev/articles/lazy-loading-images?hl=es-419#effects_on_largest_contentful_paint_lcp
