### PR TITLE
fix: change div tag to span inside hamburguer button

### DIFF
--- a/src/components/HamburgerButton.astro
+++ b/src/components/HamburgerButton.astro
@@ -15,17 +15,17 @@ const genericHamburgerLine = `h-[2px] ${width} bg-gray-300 transition ease trans
 	]}
 	aria-label="Abrir menú de navegación"
 >
-	<div class:list={["group-[.open]:translate-y-2 group-[.open]:rotate-45", genericHamburgerLine]}>
-	</div>
-	<div class:list={["group-[.open]:opacity-0", genericHamburgerLine]}></div>
-	<div class:list={["group-[.open]:opacity-0", genericHamburgerLine]}></div>
-	<div
+	<span class:list={["group-[.open]:translate-y-2 group-[.open]:rotate-45", genericHamburgerLine]}>
+	</span>
+	<span class:list={["group-[.open]:opacity-0", genericHamburgerLine]}></span>
+	<span class:list={["group-[.open]:opacity-0", genericHamburgerLine]}></span>
+	<span
 		class:list={[
 			"group-[.open]:-translate-y-[0.6rem] group-[.open]:-rotate-45",
 			genericHamburgerLine,
 		]}
 	>
-	</div>
+	</span>
 </button>
 
 <script>


### PR DESCRIPTION
## Descripción

Para mejorar la semántica html sugiero el cambio de etiqueta div a span dentro del componente Hamburguer.

## Problema solucionado

<!-- Describa el problema o la tarea que aborda esta solicitud de extracción, si corresponde. Incluya el número de problema o enlace al problema si existe. -->

## Cambios propuestos

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [ ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles


