### PR TITLE
Se arregla desborde de pantalla

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -18,7 +18,7 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 	<main class="flex min-h-screen flex-col items-center text-[#b4cd02]">
 		<div class="mx-auto w-full max-w-4xl p-8">
 			<Typography
-				class="mb-12 -skew-y-6 text-wrap text-center text-6xl"
+				class="title mb-12 -skew-y-6 text-wrap text-center text-6xl"
 				color="primary"
 				as="h1"
 				variant="atomic-title"
@@ -87,5 +87,10 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 			rgba(255, 255, 255, 0.5) 30%,
 			rgba(0, 0, 0, 0) 95%
 		);
+	}
+	@media (width <= 320px) {
+		.title {
+			font-size: 2.75rem;
+		}
 	}
 </style>


### PR DESCRIPTION
## Descripción

Se arregla responsive para width <= 320px

## Problema solucionado

Desborde del título en pantallas con un width <= 320px

## Cambios propuestos

Se agrega un query que modifica el font-size del título

## Capturas de pantalla (si corresponde)

Antes:
<img width="279" alt="before" src="https://github.com/midudev/la-velada-web-oficial/assets/50113708/a8a99952-2f0a-4f66-a7b3-af6ed5726a52">
<img width="279" alt="Captura de pantalla 2024-03-23 a la(s) 12 32 29" src="https://github.com/midudev/la-velada-web-oficial/assets/50113708/2ddaec0e-07ab-46cd-9c5a-b9b2692137bf">


Después:
<img width="280" alt="Captura de pantalla 2024-03-23 a la(s) 12 33 27" src="https://github.com/midudev/la-velada-web-oficial/assets/50113708/bd6d26e5-3232-4c2f-80e1-b259aaa1f564">
<img width="290" alt="Captura de pantalla 2024-03-23 a la(s) 12 33 46" src="https://github.com/midudev/la-velada-web-oficial/assets/50113708/b87423e7-e8f6-4307-a2e2-87a26c463fbe">



## Comprobación de cambios

- [✔️] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [✔️] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [✔️] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [✔️] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora la accesibilidad de usuarios con un width menor.
