### PR TITLE
fix: prevent scrollbar on medium-size screens in boxers list

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -276,7 +276,7 @@ const boxerColumns = [
 
 <style>
 	.boxers-lists {
-		@apply relative w-screen overflow-x-scroll;
+		@apply relative w-screen overflow-x-scroll md:overflow-hidden;
 		scrollbar-width: none;
 	}
 


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
1. Debido a que el scroll de en las listas de boxeadores no es necesaria, se oculta

## Problema solucionado

<!-- Describa el problema o la tarea que aborda esta solicitud de extracción, si corresponde. Incluya el número de problema o enlace al problema si existe. -->
En Chrome se muestra una barra de scroll innecesaria en la sección `Elige tu luchador` en pantallas medianas

Pasos para reproducir:
1. Usar un width de pantalla comprendida entre el breakpoint de Tailwind `md` (momento en que se deja de mostrar el carousel) y la media query `width >= 1280` (momento en que se incrementa el tamaño de las imágenes de los boxeadores dispuestas en cada una de las 4 columnas). Por ejemplo, seleccionar el breakpoint `Tablet` de las Chrome Dev Tools
2. Scrollear hasta la sección `Elige tu luchador`
3. Hacer `hover` sobre cualquier boxeador de la última columna (Plex, Viruzz, Alana, Amablitz, Agustin y Guanyar)

## Cambios propuestos

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->
1. Se oculta el scroll de la sección de boxeadores en pantallas mayores al breakpoint de Tailwind `md`

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->
| Antes | Después |
| -- | -- |
| ![image](https://github.com/midudev/la-velada-web-oficial/assets/70046023/afb49674-ddf3-4b01-84b4-94506e56f6ad) | ![image](https://github.com/midudev/la-velada-web-oficial/assets/70046023/b8d4563c-d265-4430-9e21-d8535ceb0f40) |

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->
Husky me estuvo dando problemas para pushear los cambios ya que hay varios archivos que no están debidamente formateados. En mi local los formatee con `pnpm format` para poder subir este cambio. No subí los archivos formateados porque están fuera del scope de esta PR

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
