### PR TITLE
Update active thumbnail position in boxer carousel

### DIFF
--- a/src/sections/SelectYourBoxer.astro
+++ b/src/sections/SelectYourBoxer.astro
@@ -266,7 +266,21 @@ const boxerColumns = [
 			})
 		}
 
+		function updateActiveThumbnailPosition() {
+			const boxer = new URLSearchParams(window.location.search).get("boxer")
+			const boxerActiveElement = $(`.carousel .boxer-link[data-id=${boxer}]`)
+			if (boxerActiveElement) {
+				const carouselWidth = carouselInner.clientWidth
+				const thumbnailWidth = boxerActiveElement.offsetWidth
+				const currentPosition = boxerActiveElement.offsetLeft - (carouselWidth - thumbnailWidth) / 2
+
+				carouselInner.scrollTo(currentPosition, 0)
+			}
+		}
+
 		if (mobileMediaQuery.matches) {
+			updateActiveThumbnailPosition()
+
 			carouselInner.addEventListener("scroll", () => {
 				highlightActiveBoxer()
 			})


### PR DESCRIPTION
## Descripción

Se creó una función para actualizar la posición del thumbnail activo dentro del carousel de boxeadores en dispositivo móvil.

## Problema solucionado

Al cargar la página, ingresando con una url que tenga el parámetro "boxer" (ejemplo: https://lavelada.es/?boxer=peldanyos) el thumbnail activo dentro del carousel no se estaba visualizando y no generaba una buena apreciación visual

## Cambios propuestos

1. Crear un función updateActiveThumbnailPosition para obtener la posición del thumbnail activo y actualizarla en el carousel para que pueda ser vista por el usuario.
2. Invocar la función solo en dispositivo móvil, ya que el carousel solo se visualiza en dicho escenario.

## Capturas de pantalla (si corresponde)

Before
![image](https://github.com/midudev/la-velada-web-oficial/assets/164126437/008f789d-3c63-468a-81a8-d227960e252d)

After
![image](https://github.com/midudev/la-velada-web-oficial/assets/164126437/e0933ddb-d652-4af9-a918-56a6be010eb4)

## Comprobación de cambios

- [ ✅] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ ✅] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ✅] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ✅] He actualizado la documentación, si corresponde.

## Impacto potencial

Ninguna
