### PR TITLE
feat: add user id in session

### DIFF
--- a/auth.config.js
+++ b/auth.config.js
@@ -6,6 +6,31 @@ export default defineConfig({
 		Twitch({
 			clientId: import.meta.env.TWITCH_CLIENT_ID,
 			clientSecret: import.meta.env.TWITCH_CLIENT_SECRET,
+			profile(profile) {
+				return {
+					id: profile.sub,
+					name: profile.preferred_username,
+					email: profile.email,
+					image: profile.picture,
+				}
+			},
+
 		}),
 	],
+	callbacks: {
+		async session({ token, session }) {
+			if (token) {
+				session.user.id = token.id
+			}
+			return session
+		},
+		async jwt({ token, user }) {
+			if (user) {
+				token.id = user.id
+				delete token.sub
+			}
+			return token
+		}
+	}
+
 })


### PR DESCRIPTION
## Descripción

Se agrega el ID del usuario de Twitch en la `session` obtenida atravez de `Astro-auth`

## Problema solucionado
Actualmente no se puede obtener el ID del usuario logueado, ya que se requiere para los pronosticos de los combates

## Cambios propuestos

se configura el provider de Twitch, para que al momento de loguear, nos de el campo de `sub` el cual es el ID del usuario.
Asi tambien como este campo agregarlo en el JWT y en la session.
Pues se necesita el ID para identificar a los usuario que votan y prevenir que voten varias veces.

## Enlaces útiles
Documentación usada para realizar el cambio 
[Modificar el Provider](https://authjs.dev/guides/providers/custom-provider#override-default-options)
[agregar callbacks al momento de authenticarte](https://next-auth.js.org/configuration/callbacks)
