### PR TITLE
fix: Evento Cerrar Dialog del Clip

### DIFF
--- a/src/components/ClipsModal.astro
+++ b/src/components/ClipsModal.astro
@@ -43,9 +43,9 @@
 		const $closeButton = document.querySelector(".close-dialog")
 		const $ytFrame = document.querySelector(".yt-iframe")
 
-		$clipDialog.onclose = () => {
+		$clipDialog.addEventListener("close", (event) => {
 			$ytFrame?.setAttribute("src", "")
-		}
+		})
 
 		$closeButton?.addEventListener("click", () => $clipDialog.close())
 


### PR DESCRIPTION
## Descripción

Se cambia evento de cerrar del dialog para los clips

## Problema solucionado

El problema es que en la funcion .onclose no existe dentro del elemento dialog y generaba un error en el navegador


## Capturas de pantalla (si corresponde)

Antes:
![image](https://github.com/midudev/la-velada-web-oficial/assets/69535361/1616db73-045a-4583-9f7d-f968f55b12c1)

Despues:
![image](https://github.com/midudev/la-velada-web-oficial/assets/69535361/2d7d04cc-eeee-4008-b1af-4ef374b20a9f)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

