### PR TITLE
Section details boxer

### DIFF
--- a/src/components/BoxerDetailInfo.astro
+++ b/src/components/BoxerDetailInfo.astro
@@ -10,8 +10,8 @@ const { title, value, id } = Astro.props
 
 <div class="flex justify-center text-white">
 	<div class="style flex flex-col items-start text-center">
-		<h4>{title}</h4>
-		<p class="text-xl font-bold" id={id}>
+		<h4 class="font-atomic text-lg lowercase text-accent md:text-xl">{title}</h4>
+		<p class="text-xl font-bold md:text-4xl" id={id}>
 			{value}
 		</p>
 	</div>

--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -8,31 +8,64 @@ interface Props {
 }
 
 const { title, value, id } = Astro.props
+
+const isKingOfTheTrack = value[0].versus === "rey-de-la-pista"
+const isVersus = value[0].versus.length === 2
 ---
 
-<div class="flex justify-center text-white">
+<div class="flex justify-center text-white mix-blend-screen">
 	<div
-		class="flex w-full items-start justify-between pl-2.5 pr-2.5 pt-2 text-center md:flex-col md:items-center"
+		class:list=`flex w-full text-center flex-col items-center ${isKingOfTheTrack ? "md:-mt-10 p-5" : "pl-2.5 pr-2.5 pt-2"}`
 	>
-		<h4>{title}</h4>
 		<div
-			class="flex w-full flex-row flex-wrap justify-end gap-x-2 md:justify-center md:text-center"
+			class:list={isKingOfTheTrack
+				? ["grid grid-cols-5"]
+				: [
+						isVersus
+							? "grid grid-cols-2"
+							: "flex w-full flex-row flex-wrap justify-center gap-x-2  md:justify-center md:text-center",
+					]}
 		>
 			{
 				value.map((item, index) => (
 					<>
 						<a
-							class:list={"text-xl font-bold text-accent hover:underline"}
+							class:list={
+								isKingOfTheTrack
+									? ""
+									: `bg-slate-50/5 text-xl font-bold text-accent transition hover:scale-110 hover:underline ${isVersus ? "mx-2  p-1" : ""}`
+							}
 							href={item.id}
 							title={`Visita la página del boxeador ${item.name}`}
 							id={id + (index + 1)}
 						>
-							{item.name}
+							<img
+								src={`/img/boxers/${item.id}-small.webp`}
+								class:list={
+									isKingOfTheTrack
+										? ["h-14 object-contain"]
+										: ["mx-auto aspect-square h-32 object-contain"]
+								}
+								alt={`Foto en pequeño del rival ${item.name}`}
+								style="
+										filter: drop-shadow(0 0 5px rgba(0, 0, 0, .5));
+										mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
+									"
+							/>
+							<span
+								class:list={
+									isKingOfTheTrack
+										? ["text-[10px] font-bold text-accent"]
+										: ["text-xl font-bold text-accent"]
+								}
+							>
+								{item.name}
+							</span>
 						</a>
-						{index !== value.length - 1 && <span class="text-xl font-bold text-accent"> / </span>}
 					</>
 				))
 			}
 		</div>
+		<h4>{title}</h4>
 	</div>
 </div>

--- a/src/components/BoxerSocialLink.astro
+++ b/src/components/BoxerSocialLink.astro
@@ -12,7 +12,7 @@ const { href } = Astro.props
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			class="group relative inline-flex w-32 items-center justify-center overflow-hidden bg-gradient-to-b from-white/20 to-transparent px-10 py-2 text-white mix-blend-screen transition"
+			class="group relative inline-flex w-full items-center justify-center overflow-hidden bg-gradient-to-b from-white/20 to-transparent px-10 py-2 text-white mix-blend-screen transition"
 		>
 			<slot />
 			<span class="absolute inset-0 h-1/2 bg-gradient-to-b from-white to-transparent opacity-0 transition-opacity duration-200 ease-in-out group-hover:h-[90%] group-hover:opacity-20 group-focus:h-[90%] group-focus:opacity-20" />

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -6,6 +6,7 @@ import BoxerDetailInfoRival from "@/components/BoxerDetailInfoRival.astro"
 import BoxerSocialLink from "@/components/BoxerSocialLink.astro"
 import BoxerWorkout from "@/components/BoxerWorkout.astro"
 import BoxerGallery from "@/components/Boxers/Gallery.astro"
+import Typography from "@/components/Typography.astro"
 
 import Instagram from "@/icons/instagram.astro"
 import Tiktok from "@/icons/tiktok.astro"
@@ -109,7 +110,13 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 				<div
 					class="relative order-1 -mt-20 flex flex-col items-center justify-center md:order-2 md:w-1/2 lg:mx-4"
 				>
-					<BoxerBigImage id={id} name={boxer.name} country={boxer.country} countryName={flagAlt} loading='eager' />
+					<BoxerBigImage
+						id={id}
+						name={boxer.name}
+						country={boxer.country}
+						countryName={flagAlt}
+						loading="eager"
+					/>
 				</div>
 
 				<div
@@ -125,8 +132,12 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 					</div>
 				</div>
 			</div>
-
-			<div class="mt-24 flex max-w-xl flex-wrap justify-center gap-8 md:mt-56 md:max-w-full">
+		</section>
+		<section class="mt-64">
+			<Typography as="h3" variant="h3" color="white" class:list={"mb-12 text-center"}>
+				REDES SOCIALES
+			</Typography>
+			<div class="flex w-full flex-col md:flex-row md:gap-10">
 				<BoxerSocialLink href={boxer.socials.twitch}>
 					<Twitch />
 				</BoxerSocialLink>


### PR DESCRIPTION
## Descripción

Nuevo diseño para la sección de los boxeadores arregle la vista para cuando es 2 contra 2 y cuando es el rey de la pista
y hice el ajustes tomando en cuenta los comentarios de la pull request #739 

## Problema solucionado

* Muestra la foto del rival y se ve mejor la información del boxeador 
* Se arreglo la vista para el 2 vs 2 y el rey de la pista 

 
## Cambios propuestos
Nueva forma de visualizar a los rivales 
Ahora
* 1 vs 1
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/22cbf02e-e258-4989-acda-37033cc36e77)

* 2 vs 2
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/e21926cb-618b-4906-9fcf-86cb11e2c22a)

* rey de la pista 
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/97e90be8-ec91-44b1-9edf-1bca4c16e5d4)


Antes 
* 1 vs 1
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/2f230fbe-7702-4ad5-a548-95bd4e15fe46)

* 2 vs 2
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/bf4b23ec-41cf-4c37-839c-a3020fe548d5)

* rey de la pista
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/81d088fc-571b-453a-9d93-758c8d659ca1)





## Comprobación de cambios

- [x ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [ x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x ] He actualizado la documentación, si corresponde.

## Contexto adicional
ajustes según los comentarios de la pull request #739 

## Enlaces útiles
Pull Request - #739 
