### PR TITLE
Cambio altura de iconos para buena visualización en dispositivo móvil

### DIFF
--- a/src/icons/tiktok.astro
+++ b/src/icons/tiktok.astro
@@ -1,6 +1,6 @@
 <svg
 	width="40"
-	height="40"
+	height="48px"
 	viewBox="0 0 512 512"
 	fill="currentColor"
 	class:list={Astro.props.class}

--- a/src/icons/twitch.astro
+++ b/src/icons/twitch.astro
@@ -1,6 +1,6 @@
 <svg
 	width="36"
-	height="36"
+	height="48"
 	viewBox="0 0 24 24"
 	fill="currentColor"
 	class:list={Astro.props.class}

--- a/src/icons/x.astro
+++ b/src/icons/x.astro
@@ -1,6 +1,6 @@
 <svg
 	width="35px"
-	height="32px"
+	height="48px"
 	viewBox="0 0 35 32"
 	class:list={Astro.props.class}
 	role="img"

--- a/src/icons/youtube.astro
+++ b/src/icons/youtube.astro
@@ -1,6 +1,6 @@
 <svg
 	width="46"
-	height="46"
+	height="48"
 	viewBox="0 0 32 32"
 	fill="currentColor"
 	class:list={Astro.props.class}


### PR DESCRIPTION
## Descripción

En los dispositivos móviles, no se visualizan los iconos de las RRSS de los participantes de la velada con la misma altura.

## Problema solucionado

Problema solucionado cambiando la altura del svg hasta la máxima que estos tenían (48px)

## Cambios propuestos

Problema solucionado cambiando la altura del svg hasta la máxima que estos tenían (48px)

## Capturas de pantalla (si corresponde)

Antes:
![Captura de pantalla 2024-03-27 a las 18 08 28](https://github.com/midudev/la-velada-web-oficial/assets/121667390/59e3742c-fefd-4b9e-b103-7bafb1291ea0)
Después:
![Captura de pantalla 2024-03-27 a las 18 27 07](https://github.com/midudev/la-velada-web-oficial/assets/121667390/54c24542-92f9-42c2-b8a7-50f6d676cdcb)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

N/A

## Contexto adicional

N/A

## Enlaces útiles

N/A
