### PR TITLE
Se agrega la imagen de titulo de combate como fondo detras de los peleadores

### DIFF
--- a/src/sections/Combat.astro
+++ b/src/sections/Combat.astro
@@ -1,6 +1,8 @@
 ---
 import Typography from "@/components/Typography.astro"
+import { COMBATS } from "@/consts/combats"
 import type { Boxer } from "@/types/Boxer"
+import Image from "astro/components/Image.astro"
 
 interface Props {
 	combatId: string
@@ -45,18 +47,38 @@ const createCombatDisplay = (boxers: Boxer[]) => {
 }
 
 const combatDisplay = createCombatDisplay(boxers)
+
+const combatData = COMBATS.find((combat) => combat.id === combatId)
+const boxerNames = combatData?.boxers ?? []
 ---
 
 <section class="mt-40 flex flex-col items-center gap-5 md:gap-10 lg:gap-0">
 	<div class:list={["relative flex w-full flex-col items-center justify-center py-20"]}>
-		<Typography
-			as="div"
-			variant="atomic-title"
-			color="primary"
-			tabindex={-1}
-			class:list={"absolute inset-0 -z-10 self-center text-center text-[20rem] opacity-20"}
-			>{combatNumber}
-		</Typography>
+		<div class='absolute inset-0 -z-10 opacity-20 grid place-items-center'>
+			{
+				combatData ? (
+					<Image
+						width={combatData.titleSize[0]}
+						height={combatData.titleSize[1]}
+						transition:name={`title-image-${combatId}`}
+						loading={"eager"}
+						class="inset-0 h-auto max-h-96 w-full max-w-80 scale-100 object-contain sm:scale-110 lg:max-w-3xl"
+						src={`/img/matches/title-${combatId}.webp`}
+						alt={`Fotografía del combate entre ${boxerNames.join(", ")}`}
+					/>
+				) : (
+					<Typography
+						as="div"
+						variant="atomic-title"
+						color="primary"
+						tabindex={-1}
+						class:list={"text-center text-[20rem]"}
+					>
+						{combatNumber}
+					</Typography>
+				)
+			}
+		</div>
 		<h2 class:list={["text-center text-4xl font-semibold uppercase text-white lg:text-6xl"]}>
 			{ordinals[combatNumber]} combate
 		</h2>


### PR DESCRIPTION
## Descripción

Se agrega la imagen del titulo de combate de la pagina `/combates/[id].astro` como fondo detras de los peleadores (`zeling x nissaxter vs alana x amablitz`). Anteriormente se tenia el numero del combate.

## Problema solucionado

Detras del texto de los peleadores (`el mariana vs yosoyplex` o `el rey de la pista`) teniamos el numero de combate en grande con la fuente Atomic, lo que se veia bien pero ya era algo que teniamos en el titulo superior y era algo simple.


## Cambios propuestos

Se agrega la imagen de titulo de combate que esta en la pagina `/combates/[id].astro` en el fondo de los peleadores junto con el transition:name para que se haga una transition al navegar y se deja como fallback el numero de combate que estaba anteriormente.

## Capturas de pantalla (si corresponde)
- Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/dc2610f5-3228-4638-a32c-42b603477e68)

- Despues
![image](https://github.com/midudev/la-velada-web-oficial/assets/93395794/cfb39749-f699-4768-a9ff-90bba8feb479)
[demo](https://github.com/midudev/la-velada-web-oficial/assets/93395794/39667382-8ed8-4e1e-b01f-ca6d9170eba4)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

- Brindara una mejor experiencia al usuario y mejora un poco el diseño de esa seccion.

## Contexto adicional

- No fui capaz de animar el cambio de opacidad en la view transition.
