### PR TITLE
 Fix: Meta Tags Rendered in the Body Instead of the Head (Combatates/[id].astro)

### DIFF
--- a/src/components/Combates/BackgroundVideo.astro
+++ b/src/components/Combates/BackgroundVideo.astro
@@ -1,0 +1,22 @@
+---
+interface Props {
+	id: string
+}
+
+const { id } = Astro.props
+---
+<div class="absolute left-0 top-0 -z-10 aspect-video h-[100vh] w-screen">
+	<video
+		autoplay
+		muted
+		loop
+		class="aspect-video size-full overflow-hidden object-cover opacity-0 transition-opacity duration-500"
+		style="mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, transparent);"
+		oncanplay="this.classList.add('opacity-70')"
+	>
+		<source
+			type="video/mp4"
+			src={`https://pub-b708fa93d7064977b256b094eb906703.r2.dev/${id}-corto.mp4`}
+		/>
+	</video>
+</div>

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -4,6 +4,7 @@ import { Image } from "astro:assets"
 import { COMBATS } from "@/consts/combats"
 import Layout from "@/layouts/Layout.astro"
 import CombatFeatures from "@/sections/CombatFeatures.astro"
+import BackgroundVideo from "@/components/Combates/BackgroundVideo.astro"
 
 const getCombatById = (id: string) => {
 	return COMBATS.find((combat) => combat.id === id)
@@ -39,28 +40,12 @@ const formatter = new Intl.ListFormat("es", {
 const formattedBoxerNames = formatter.format(boxerNames)
 const [imageWidth, imageHeight] = combatData.titleSize
 ---
-
-<div class="absolute left-0 top-0 z-0 aspect-video h-[100vh] w-screen">
-	<video
-		autoplay
-		muted
-		loop
-		class="aspect-video size-full overflow-hidden object-cover opacity-0 transition-opacity duration-500"
-		style="mask-image: linear-gradient(to bottom, rgba(0,0,0,1) 70%, transparent);"
-		oncanplay="this.classList.add('opacity-70')"
-	>
-		<source
-			type="video/mp4"
-			src={`https://pub-b708fa93d7064977b256b094eb906703.r2.dev/${id}-corto.mp4`}
-		/>
-	</video>
-</div>
-
 <Layout
 	title={`Combate número ${combatData.number} de La Velada IV`}
 	description={`Combate entre ${formattedBoxerNames}`}
 	image={`/img/matches/og-${id}-min.jpg`}
 >
+	<BackgroundVideo id={id} />
 	<main class="pointer-events-none md:-mt-12">
 		<div class="relative flex h-[60vh] w-full items-center justify-center md:h-[76vh]">
 			<Image


### PR DESCRIPTION
## Descripción

Se movio el video de fondo a un componente y se agrego dentro del la etiqueta layout `combates/[id].astro`, ya que al estar por fuera, estaba renderizando los meta tags en el body.

## Problema solucionado

- Ahora se renderizan los tags en el head.
- Soluciona problemas de semantica y Seo.

## Cambios propuestos

- Se creo un componente backgroundVideo.astro
- Se movio dentro del layout en la pagina `combates/[id].astro` el video.

## Capturas de pantalla (si corresponde)

**Antes.**
![image](https://github.com/midudev/la-velada-web-oficial/assets/22538431/f0976246-de8a-4938-a01f-f685e7f2c418)

**Ahora**
![image](https://github.com/midudev/la-velada-web-oficial/assets/22538431/4851f30e-a0cb-4f63-934f-1869a56f8a07)

![image](https://github.com/midudev/la-velada-web-oficial/assets/22538431/746f4fbb-8418-42ea-92f6-58f7c63680c1)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [ ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.


