### PR TITLE
new bg rival

### DIFF
--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -32,24 +32,23 @@ const isVersus = value[0].versus.length === 2
 					<a
 						class:list={[
 							`${isVersus ? "mx-2  p-1" : ""}`,
-							`${isKingOfTheTrack ? "p-1" : "bg-slate-50/5 text-xl font-bold text-accent transition hover:scale-110 hover:saturate-[150%]"}`,
+							`${isKingOfTheTrack ? "p-1" : "boxer-link text-xl font-bold text-accent"}`,
 						]}
 						href={item.id}
 						title={`Visita la página del boxeador ${item.name}`}
 						id={id + (index + 1)}
 					>
+						{!isKingOfTheTrack && (
+							<div
+								class:list={`${isVersus ? "boxer-link-background w-32" : "boxer-link-background w-full"}`}
+							/>
+						)}
+
 						<img
 							src={`/img/boxers/${item.id}-small.webp`}
-							class:list={
-								isKingOfTheTrack
-									? ["h-14 object-contain"]
-									: ["mx-auto aspect-square h-32 object-contain"]
-							}
+							class:list={isKingOfTheTrack ? ["h-14 object-contain"] : ["boxer-image "]}
 							alt={`Foto en pequeño del rival ${item.name}`}
-							style="
-										filter: drop-shadow(0 0 5px rgba(0, 0, 0, .5));
-										mask-image: linear-gradient(to bottom, black 50%, transparent 100%);
-									"
+							style="mask-image: linear-gradient(to bottom, black 50%, transparent 100%);"
 						/>
 						<span
 							class:list={[
@@ -66,3 +65,36 @@ const isVersus = value[0].versus.length === 2
 		</div>
 	</div>
 </article>
+
+<style>
+	.boxer-link {
+		@apply relative mb-2 flex flex-col transition-opacity duration-300 ease-in-out md:size-28 xl:size-36;
+
+		&:hover {
+			@apply opacity-90;
+		}
+
+		& .boxer-image {
+			@apply z-20 transition-opacity duration-300 ease-in-out;
+			mask-image: linear-gradient(to bottom, black 85%, transparent 100%);
+			filter: grayscale(100%);
+			transition: filter 0.3s ease;
+		}
+	}
+
+	.boxer-link-background {
+		@apply absolute bottom-0 block h-3/5 opacity-25 transition-opacity duration-300 ease-in-out;
+		background: linear-gradient(
+			180deg,
+			rgba(255, 255, 255, 1) 0%,
+			rgba(255, 255, 255, 0.5) 30%,
+			rgba(0, 0, 0, 0) 95%
+		);
+	}
+
+	.boxer-link:hover .boxer-image,
+	.boxer-link.active .boxer-image {
+		scale: 1.05;
+		filter: grayscale(0%);
+	}
+</style>


### PR DESCRIPTION
## Descripción

nuevo fondo para los rivales en la pagina de los detalles del boxeador

## Problema solucionado
color los mismos estilos que en el seleccionar boxeador de la pagina del home

## Cambios propuestos
cambiar el fondo del rival para el 1 vs 1 y 2 vs 2

## Capturas de pantalla (si corresponde)

Ahora 
1 vs 1
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/9d42a7ed-9acb-4ba3-9414-623690322b36)

2 vs 2 
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/bf5f1b6c-c2fd-4f83-894b-b15dfb50e2f1)


Antes 
1 vs 1
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/c1c384ed-0308-4e7f-82bb-5de289b4acb6)

2 vs 2
![image](https://github.com/midudev/la-velada-web-oficial/assets/32785129/7228a6ff-35dc-4559-955d-9af631a2dbe8)


<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [ x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ x] He actualizado la documentación, si corresponde.

## Impacto potencial
unificar la selección de los boxeadores 

