### PR TITLE
Added global.d.ts with ToastOptions and Window interfaces

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,0 +1,13 @@
+interface ToastOptions {
+	title?: string
+	message?: string
+	type?: string
+	location?: string
+	icon?: boolean
+	theme?: string
+	dismissible?: boolean
+}
+
+interface Window {
+	toast: (options: ToastOptions) => void
+}


### PR DESCRIPTION
## Descripción
He agregado el archivo global.d.ts con las opciones del Toast y agregado al objeto global Window.

## Problema solucionado
- Arregla el error de TypeScript "La propiedad toast no existe en el tipo Window & typeof globalThis ."