### PR TITLE
Add: Fix focus style for hero logo

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -106,8 +106,8 @@ const pages = [
 				style="background:linear-gradient(to right, transparent 3%, white 35%, white 100%)"
 			>
 			</div>
-			<div class="-ml-[8px] -mr-[4px]">
-				<a href="/">
+			<div class="focus-within-ring -ml-[8px] -mr-[4px]">
+				<a href="/" class="focus-visible:!ring-0">
 					<HeroLogo class:list={"h-auto w-full"} id="hero-logo-header" noEffect />
 				</a>
 			</div>
@@ -135,6 +135,10 @@ const pages = [
 	.nav-item:hover .background,
 	.nav-item:focus .background {
 		opacity: 1;
+	}
+
+	.focus-within-ring {
+		@apply focus-within:ring-1 focus-within:ring-white focus-within:ring-offset-1;
 	}
 
 	#menuMobileContent {


### PR DESCRIPTION
## Descripción

The focus indicator for link hero logo is not clear for the user


## Problema solucionado

The focus style for hero logo is now very clear for the user


## Cambios propuestos

Now the focus ring show on the parent container when the anchor element is selected using focus-whitin

## Capturas de pantalla (si corresponde)

Before:
<img width="1014" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/36999077/7c539318-adcb-4f57-84a0-149ac5456947">
After:
<img width="1110" alt="image" src="https://github.com/midudev/la-velada-web-oficial/assets/36999077/8796a5fe-2ed8-47aa-b178-368f1f42c3a0">

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
