### PR TITLE
Estilos de tabla de características de los combates

### DIFF
--- a/src/sections/CombatFeatures.astro
+++ b/src/sections/CombatFeatures.astro
@@ -60,7 +60,7 @@ const middleIndex = boxers.length / 2
 		<tbody>
 			{
 				relevantBoxerData.map(([key, { label, concat }]) => (
-					<tr class="mb-10 bg-gradient-to-b from-black via-transparent/40 to-transparent/40 p-4">
+					<tr class="mb-10 bg-gradient-to-b from-black/0 via-transparent/40 to-transparent/40 p-4">
 						{boxers.map((boxer, index) => {
 							if (boxer == null) return null
 

--- a/src/sections/CombatFeatures.astro
+++ b/src/sections/CombatFeatures.astro
@@ -60,7 +60,7 @@ const middleIndex = boxers.length / 2
 		<tbody>
 			{
 				relevantBoxerData.map(([key, { label, concat }]) => (
-					<tr class="mb-10 bg-gradient-to-b from-white/20 via-transparent to-transparent p-4">
+					<tr class="mb-10 bg-gradient-to-b from-black via-transparent/40 to-transparent/40 p-4">
 						{boxers.map((boxer, index) => {
 							if (boxer == null) return null
 


### PR DESCRIPTION
## Descripción

Se ha cambiado un poco la tonalidad de color de la tabla en combates, un poco mas oscura para que al leer no moleste tanto el video de fondo.
## Problema solucionado
Ahora es un poco mas cómoda la lectura de la tabla, las luces y colores del video no afectan


## Capturas de pantalla (si corresponde)
Antes
![image](https://github.com/midudev/la-velada-web-oficial/assets/113316257/889f6770-a4ff-4960-8307-d15b9df2ad66)
Ahora
![image](https://github.com/midudev/la-velada-web-oficial/assets/113316257/2e69e8e3-9653-4415-9616-93fda017ca4a)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.


