### PR TITLE
\#801 Arreglo de retardo  de la imagen al abrir el lightbox de la galería de los boxeadores

### DIFF
--- a/src/components/Boxers/Gallery.astro
+++ b/src/components/Boxers/Gallery.astro
@@ -132,19 +132,21 @@ const { id, name } = Astro.props
 				$gallery.querySelector("a[data-current=true]")?.removeAttribute("data-current")
 				// set current data atribute
 				link.setAttribute("data-current", "true")
-				// add lightbox
-				if (!$lightbox.open) {
-					$lightbox.showModal()
-				}
 
+				// update de image before show lightbox
 				if ($lightbox.open && document.startViewTransition) {
 					document.startViewTransition(() => {
 						updateImg(link)
 					})
 					return
+				} else {
+					updateImg(link)
 				}
 
-				updateImg(link)
+				// add lightbox
+				if (!$lightbox.open) {
+					$lightbox.showModal()
+				}
 			})
 		)
 	})


### PR DESCRIPTION

## Descripción

Dentro del componente Boxers/Gallery, he modificado el manejador de evento click para los links. 

## Problema solucionado

Solución del issue #801. 

## Cambios propuestos

Antes se mostraba primero el lightbox y luego se actualizaba la imagen, provocando un ligero retardo. Ahora se actualiza la imagen antes de mostar el lightbox, de esta manera se elimina el problema.

## Capturas de pantalla (si corresponde)
### Antes
[Grabación de pantalla desde 30-03-24 18:11:42.webm](https://github.com/midudev/la-velada-web-oficial/assets/98945796/3934b606-ab6c-4f24-9a2e-93183c05b04c)
### Después
[Grabación de pantalla desde 30-03-24 18:13:12.webm](https://github.com/midudev/la-velada-web-oficial/assets/98945796/49d474fb-9e79-40f1-aa94-2f12acf3bdc0)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
