### PR TITLE
feat(types): added view transition types

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@astrojs/tailwind": "5.1.0",
     "@astrojs/vercel": "7.4.0",
     "@midudev/tailwind-animations": "0.0.7",
+    "@types/dom-view-transitions": "1.0.4",
     "@typescript-eslint/parser": "7.4.0",
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",


### PR DESCRIPTION
## Descripción

Añadidos tipos para la `View Transition API`

## Problema solucionado

Error de tipado cuando se usaba `View Transition API`

## Cambios propuestos

1. Añadida dependencia de desarrollo `@types/dom-view-transitions`

## Capturas de pantalla (si corresponde)

Antes:
<img width="1342" alt="Screenshot 2024-03-31 at 15 03 28" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/28d193cd-33de-4eb2-a69c-a1017b234097">

> [!important]
> ERROR: Property 'startViewTransition' does not exist on type 'Document'

Después:
<img width="1509" alt="Screenshot 2024-03-31 at 15 04 02" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/d3dfab32-8f22-426d-b5b9-c004d84738e2">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejoras para los desarrolladores.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
