### PR TITLE
Added animation to `scale` property of the boxer when hovering

### DIFF
--- a/src/components/ColumnBoxers.astro
+++ b/src/components/ColumnBoxers.astro
@@ -95,12 +95,14 @@ const isOpponent = (id: Boxer["id"], versus: Boxer["versus"]) => {
 
 	.boxer-link:hover .boxer-image,
 	.boxer-link.active .boxer-image {
+		transition: scale 0.3s ease-in-out;
 		scale: 1.05;
 		filter: grayscale(0%);
 	}
 
 	.boxer-link.ally {
 		& .boxer-image {
+			transition: scale 0.3s ease-in-out;
 			scale: 1.05;
 		}
 
@@ -113,6 +115,7 @@ const isOpponent = (id: Boxer["id"], versus: Boxer["versus"]) => {
 
 	.boxer-link.opponent {
 		& .boxer-image {
+			transition: scale 0.3s ease-in-out;
 			scale: 1.05;
 		}
 


### PR DESCRIPTION
## Descripción

Añadida una animación a la propiedad `scale` para que cuando se haga hover en los elementos del `nav` se anime al igual que el resto de properties.

## Cambios propuestos

* Añadida la propiedad CSS `transition` en todos los lugares donde se hacía un escalado de imagen en un `boxer-link`.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

* El único problema que he encontrado es que como la clase `active`, `.oponent` y `.ally` se eliminan usando JS, la animación sólo se produce en entrada y no en salida. Estoy intentando ver cómo arreglarlo sin duplicar mucho código (he probado con `.addEventListener("transitionend", callback)` en el JS pero no funciona 🤔 .
