### PR TITLE
Mejoras pronosticos

### DIFF
--- a/src/components/Pronosticos/Intro.astro
+++ b/src/components/Pronosticos/Intro.astro
@@ -23,7 +23,7 @@ import Typography from "@/components/Typography.astro"
 		>
 			¡Inicia sesión para participar!
 		</Action>
-		<small class="mt-2">Para participar, necesitas una cuenta de Twitch</small>
+		<small class="mt-2 lg:text-base">Para participar, necesitas una cuenta de Twitch</small>
 	</div>
 	<aside class="absolute -z-10 opacity-20 lg:relative lg:opacity-100">
 		<img

--- a/src/consts/combats.ts
+++ b/src/consts/combats.ts
@@ -5,7 +5,7 @@ export const COMBATS: Combat[] = [
 	{
 		id: "1-agustin-51-vs-carreraaa",
 		number: 1,
-		boxers: ["agustin-51", "carreraaa"],
+		boxers: ["carreraaa", "agustin-51"],
 		titleSize: [1920, 1012],
 	},
 	{
@@ -47,7 +47,7 @@ export const COMBATS: Combat[] = [
 	{
 		id: "6-el-mariana-vs-plex",
 		number: 6,
-		boxers: ["el-mariana", "plex"],
+		boxers: ["plex", "el-mariana"],
 		titleSize: [1920, 950],
 	},
 ]


### PR DESCRIPTION
## Descripción

He modificado en const/combats, el orden los boxeadores en el campo boxers. Aparte, he aumentado el tamaño de texto debajo de iniciar sesión, no se veía bien en desktop.

## Problema solucionado

Issue #818. Este cambio ha corregido la orientación de las fotos en la sección de pronósticos. Ahora los boxeadores se sitúan cara a cara en todos los combates. 

## Cambios propuestos

Orden correcto de los boxeadores en COMBATS.boxers y he añadido la clase text-base a la etiqueta small debajo del botón de iniciar sesión. 

## Capturas de pantalla (si corresponde)

### Antes
![mejoras-pronosticos-2](https://github.com/midudev/la-velada-web-oficial/assets/98945796/9e62f946-a908-4c21-9537-9d10a54011f0)
![Captura desde 2024-03-31 20-08-54](https://github.com/midudev/la-velada-web-oficial/assets/98945796/28a9f26d-2738-4ade-a12f-a5c974f1359d)

### Después
![mejoras-pronosticos3](https://github.com/midudev/la-velada-web-oficial/assets/98945796/03abe63e-bed8-46cc-bb65-626af396e471)
![Captura desde 2024-03-31 20-09-41](https://github.com/midudev/la-velada-web-oficial/assets/98945796/6f44ac64-34c0-4af7-9a91-ef9946d616ac)



## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

He revisado las paginas donde se accede a la constante COMBATS y no he encontrado conflictos con el nuevo orden.
