### PR TITLE
Corrección de la orientación de las fotos de los boxeadores en pronósticos

### DIFF
--- a/src/consts/combats.ts
+++ b/src/consts/combats.ts
@@ -5,7 +5,7 @@ export const COMBATS: Combat[] = [
 	{
 		id: "1-agustin-51-vs-carreraaa",
 		number: 1,
-		boxers: ["agustin-51", "carreraaa"],
+		boxers: ["carreraaa", "agustin-51"],
 		titleSize: [1920, 1012],
 	},
 	{
@@ -47,7 +47,7 @@ export const COMBATS: Combat[] = [
 	{
 		id: "6-el-mariana-vs-plex",
 		number: 6,
-		boxers: ["el-mariana", "plex"],
+		boxers: ["plex", "el-mariana"],
 		titleSize: [1920, 950],
 	},
 ]


### PR DESCRIPTION
## Descripción

He corregido la orientación de las fotos de los boxeadores en la página pronósticos. Antes en algunos combates se daban la espalda, tras los cambios esto ya no sucede.

## Problema solucionado

Issue #818.

## Cambios propuestos

He modificado el orden de los boxeadores en el campo ```boxers``` de la constante ```COMBATS```.

## Capturas de pantalla (si corresponde)

### Antes
![mejoras-pronosticos-2](https://github.com/midudev/la-velada-web-oficial/assets/98945796/060bbf56-50c2-4fee-baab-4e5ac0a0812e)

### Después
![mejoras-pronosticos3](https://github.com/midudev/la-velada-web-oficial/assets/98945796/5df7d613-4685-4fe9-86f7-c9337a23a7ae)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Tras revisar los archivos donde se usa la constante ```COMBATS```, no he identificado ningún conflicto con el nuevo de orden de los boxeadores.
