### PR TITLE
fix: social networks in fighters on a mobile screen

### DIFF
--- a/src/components/BoxerSocialLink.astro
+++ b/src/components/BoxerSocialLink.astro
@@ -12,7 +12,7 @@ const { href } = Astro.props
 			href={href}
 			target="_blank"
 			rel="noopener noreferrer"
-			class="group relative inline-flex w-full items-center justify-center overflow-hidden bg-gradient-to-b from-white/20 to-transparent px-10 py-2 text-white mix-blend-screen transition"
+			class="group relative inline-flex w-full items-center justify-center overflow-hidden bg-gradient-to-b from-white/20 to-transparent px-10 py-2 text-white mix-blend-screen transition odd:last:ml-[50%] md:odd:last:ml-0"
 		>
 			<slot />
 			<span class="absolute inset-0 h-1/2 bg-gradient-to-b from-white to-transparent opacity-0 transition-opacity duration-200 ease-in-out group-hover:h-[90%] group-hover:opacity-20 group-focus:h-[90%] group-focus:opacity-20" />

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -137,7 +137,7 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 			<Typography as="h3" variant="h3" color="white" class:list={"mb-12 text-center"}>
 				REDES SOCIALES
 			</Typography>
-			<div class="flex w-full flex-col md:flex-row md:gap-10">
+			<div class="m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full md:grid-cols-5">
 				<BoxerSocialLink href={boxer.socials.twitch}>
 					<Twitch />
 				</BoxerSocialLink>


### PR DESCRIPTION
## Descripción

He corregido la manera en la que se visualizan las redes sociales en la página de cada boxeador en móvil. Debido que al estar estiradas al ancho de la pantalla de móvil no se visualizaba correctamente, ahora se logran visualizar de una mejor manera con una grilla.

## Problema solucionado

Visualización de las redes sociales en la página de cada boxeador en móvil.

## Cambios propuestos

He cambiado los estilos del div que contiene los enlaces de cada red social para que se muestre en una grilla en móvil, sin perder las características en otras pantallas. Y a su vez un centrado a la ultima red social.

## Capturas de pantalla (si corresponde)

Antes:
![imagen](https://github.com/midudev/la-velada-web-oficial/assets/129574887/03d70cd8-023c-4b6c-ae97-601efa31df36)

Después:
![imagen](https://github.com/midudev/la-velada-web-oficial/assets/129574887/ada8e3a8-8a12-4945-9b94-211828451fe8)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Una vez revisado los archivos, se ha detectado que no presenta cambios de rendimiento ni afecta a ningún otro código.