### PR TITLE
Arreglo y mejoras en scrollIntoView de las votaciones

### DIFF
--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -68,7 +68,7 @@ votes.forEach((vote) => {
 
 				if (isKingOfTheHill) {
 					return (
-						<li class="relative flex w-full max-w-3xl flex-col justify-center md:justify-between">
+						<li class="not-completed relative flex w-full max-w-3xl flex-col justify-center md:justify-between">
 							<Image
 								width={combatData.titleSize[0]}
 								height={combatData.titleSize[1]}
@@ -83,7 +83,7 @@ votes.forEach((vote) => {
 								{combatData.boxers.map((boxer) => (
 									<button
 										class:list={[
-											"vote-team group relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100",
+											"vote-team king-team group relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100",
 											{ "is-voted": userVotes[combatData.id] === boxer },
 										]}
 										data-combat-id={combatData.id}
@@ -114,7 +114,7 @@ votes.forEach((vote) => {
 				]
 
 				return (
-					<li class="relative flex h-96 w-full max-w-3xl flex-row justify-center md:justify-between">
+					<li class="not-completed relative flex h-96 w-full max-w-3xl flex-row justify-center md:justify-between">
 						<button
 							class:list={[
 								"vote-team group relative max-w-60 saturate-0 transition hover:scale-110 hover:saturate-100",
@@ -188,17 +188,28 @@ votes.forEach((vote) => {
 
 		$voteTeam.forEach(($button) => {
 			const { combatId, voteId } = $button.dataset
+			const $parent = $button.parentElement as HTMLElement
 
+			// maneja evento onlick para cada botón
 			$button.onclick = () => {
-				const $parent = $button.parentElement as HTMLElement
 				let $previousVoted: HTMLElement | null
 
+				// controla que no haya dos boxeadores votados
 				if ($parent) {
 					$previousVoted = $parent.querySelector(".is-voted")
 					$previousVoted?.classList.remove("is-voted")
 				}
 
 				$button.classList.add("is-voted")
+
+				// marca el combate como completado
+				if ($parent && $button.className.includes("king-team")) {
+					$parent.parentElement?.classList.remove("not-completed")
+					$parent.parentElement?.classList.add("completed")
+				} else {
+					$parent.classList.remove("not-completed")
+					$parent.classList.add("completed")
+				}
 
 				const rollbackUI = () => {
 					$button.classList.remove("is-voted")
@@ -230,12 +241,30 @@ votes.forEach((vote) => {
 							icon: true,
 						})
 
-						const nextCombat = $button.parentElement?.nextElementSibling as HTMLElement
-						if (nextCombat) nextCombat.scrollIntoView({ behavior: "smooth" })
+						// hace scroll hasta el siguiente combate en el DOM si esta sin completar
+						if ($$(".not-completed").length > 0) {
+							const nextCombat = $button.className.includes("king-team")
+								? ($button.parentElement?.parentElement?.nextElementSibling as HTMLElement)
+								: ($button.parentElement?.nextElementSibling as HTMLElement)
+							if (nextCombat?.className.includes("not-completed"))
+								nextCombat.scrollIntoView({ behavior: "smooth" })
+						}
 					})
 					.catch(() => {
 						rollbackUI()
 					})
+			}
+
+			// marca el combate como completado si algun boxeador esta votado
+			if ($button.className.includes("is-voted")) {
+				// marca el combate como completado
+				if ($parent && $button.className.includes("king-team")) {
+					$parent.parentElement?.classList.remove("not-completed")
+					$parent.parentElement?.classList.add("completed")
+				} else {
+					$parent.classList.remove("not-completed")
+					$parent.classList.add("completed")
+				}
 			}
 		})
 	})


### PR DESCRIPTION
## Descripción

Arreglo del scrollIntoView, al votar en el combate de rey de la pista. También he añadido que no haga el scroll si el siguiente combate ya está votado, evitando scrolls que pueden ser no deseados para el usuario.

## Problema solucionado

Issue #823 y propuesta para evitar scrolls potencialmente inedecuados

## Cambios propuestos

He añadido la clase king-team a los boxeadores del rey de la pista, al hacer el scrollIntoView, para ellos se usa al abuelo en vez de al padre para conseguir el siguiente comabte. Además, he añadido las clases not-completed y completed a las etiquetas ```<li>``` que contienen los combates. De esta manera, se tiene un control sobre los combates votados y se evita hacer scroll hacia ellos.

## Capturas de pantalla (si corresponde)

### Antes
[votos-antes.webm](https://github.com/midudev/la-velada-web-oficial/assets/98945796/71acc5cb-1d0e-402b-b5fc-9bdeda05618d)

### Después
[votos-despues.webm](https://github.com/midudev/la-velada-web-oficial/assets/98945796/5bd59c9b-1167-46da-82b4-08f40dee5309)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
