### PR TITLE
Fixed and shortened boxer's social media links

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -341,7 +341,7 @@ export const BOXERS: Boxer[] = addGetters([
 		country: "es",
 		socials: {
 			twitch: "https://twitch.tv/sezarbluelive",
-			instagram: "https://instagram.com/sezarblue/",
+			instagram: "https://instagram.com/sezarblue",
 			twitter: "https://twitter.com/soysezarblue",
 			youtube: "https://youtube.com/sezarblue",
 			tiktok: "https://tiktok.com/@sezar_blue_",

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -36,7 +36,7 @@ export const BOXERS: Boxer[] = addGetters([
 			twitch: "https://twitch.tv/elmariana",
 			instagram: "https://instagram.com/elmarianaa",
 			twitter: "https://twitter.com/elmarianaa",
-			youtube: "https://youtube.com/c/elmariana",
+			youtube: "https://youtube.com/elmariana",
 			tiktok: "https://tiktok.com/@elmarianaa",
 		},
 		clips: [
@@ -64,7 +64,7 @@ export const BOXERS: Boxer[] = addGetters([
 		socials: {
 			twitch: "https://twitch.tv/shelao",
 			instagram: "https://instagram.com/crissalva40",
-			youtube: "https://youtube.com/c/shelao",
+			youtube: "https://youtube.com/shelao",
 			tiktok: "https://tiktok.com/@shelao",
 		},
 		clips: [
@@ -102,8 +102,8 @@ export const BOXERS: Boxer[] = addGetters([
 		socials: {
 			twitch: "https://twitch.tv/zeling",
 			instagram: "https://instagram.com/zeiing",
-			twitter: "https://twitter.com/zeling",
-			youtube: "https://www.youtube.com/channel/UCTfejVE5het7QO8WCY7yIQA",
+			twitter: "https://twitter.com/zeiing",
+			youtube: "https://youtube.com/@zeling_",
 			tiktok: "https://tiktok.com/@zeliing",
 		},
 		clips: [
@@ -137,7 +137,7 @@ export const BOXERS: Boxer[] = addGetters([
 			twitch: "https://twitch.tv/nissaxter",
 			instagram: "https://instagram.com/nissaxter",
 			twitter: "https://twitter.com/nissaxter",
-			youtube: "https://www.youtube.com/channel/UCjUjTl1MiPdAwRxklFLNklg",
+			youtube: "https://youtube.com/nissaxter_",
 			tiktok: "https://tiktok.com/@nissaxter_",
 		},
 		clips: [
@@ -168,10 +168,10 @@ export const BOXERS: Boxer[] = addGetters([
 		reach: 168, // No encontrado
 		socials: {
 			twitch: "https://twitch.tv/carreraaa",
-			instagram: "https://www.instagram.com/rodricarreraaa/",
+			instagram: "https://instagram.com/rodricarreraaa",
 			twitter: "http://twitter.com/rodricarreraaa",
 			youtube: "http://youtube.com/carreraaa",
-			tiktok: "https://www.tiktok.com/@carreproroblox74",
+			tiktok: "https://tiktok.com/@carreproroblox74",
 		},
 		clips: [
 			{
@@ -201,11 +201,11 @@ export const BOXERS: Boxer[] = addGetters([
 		guard: "Izquierda", // encontrado
 		reach: 168, // No encontrado
 		socials: {
-			twitch: "https://www.twitch.tv/lacobraaa",
-			instagram: "https://www.instagram.com/lautarodelcampo/",
+			twitch: "https://twitch.tv/lacobraaa",
+			instagram: "https://instagram.com/lautarodelcampo",
 			twitter: "https://twitter.com/lautarodeIcampo",
-			youtube: "https://www.youtube.com/channel/UCCfPkh8osJPC2pPq283kKXg",
-			tiktok: "https://www.tiktok.com/@lacobraaa.9",
+			youtube: "https://youtube.com/@lacobraaa",
+			tiktok: "https://tiktok.com/@lacobraaa.9",
 		},
 		clips: [
 			{
@@ -228,10 +228,10 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.84,
 		country: "es",
 		socials: {
-			twitch: "https://www.twitch.tv/karchez",
-			instagram: "https://www.instagram.com/karchezz/",
+			twitch: "https://twitch.tv/karchez",
+			instagram: "https://instagram.com/karchezz",
 			twitter: "https://twitter.com/Karchezzz",
-			youtube: "https://www.youtube.com/Karchez",
+			youtube: "https://youtube.com/Karchez",
 			tiktok: "https://tiktok.com/@karchez",
 		},
 		clips: [
@@ -287,11 +287,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.79,
 		country: "mx",
 		socials: {
-			twitch: "https://www.twitch.tv/aldo_geo/about",
-			instagram: "https://www.instagram.com/_aldogeo_/",
+			twitch: "https://twitch.tv/aldo_geo",
+			instagram: "https://instagram.com/_aldogeo_",
 			twitter: "https://twitter.com/aldogeotv",
-			youtube: "https://www.youtube.com/user/aldogeo100",
-			tiktok: "https://www.tiktok.com/@aldo_geo?lang=es",
+			youtube: "https://youtube.com/aldogeo100",
+			tiktok: "https://tiktok.com/@aldo_geo",
 		},
 		clips: [
 			{
@@ -340,11 +340,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.77,
 		country: "es",
 		socials: {
-			twitch: "https://www.twitch.tv/sezarbluelive",
-			instagram: "https://www.instagram.com/sezarblue/",
+			twitch: "https://twitch.tv/sezarbluelive",
+			instagram: "https://instagram.com/sezarblue/",
 			twitter: "https://twitter.com/soysezarblue",
-			youtube: "https://www.youtube.com/sezarblue",
-			tiktok: "https://www.tiktok.com/@sezar_blue_",
+			youtube: "https://youtube.com/sezarblue",
+			tiktok: "https://tiktok.com/@sezar_blue_",
 		},
 		clips: [
 			{
@@ -372,10 +372,10 @@ export const BOXERS: Boxer[] = addGetters([
 		country: "ar",
 		socials: {
 			twitch: "https://twitch.tv/unicornio",
-			instagram: "https://www.instagram.com/germanusinger",
+			instagram: "https://instagram.com/germanusinger",
 			twitter: "https://twitter.com/GermanUsinger",
-			youtube: "https://youtube.com/c/unicornioperro",
-			tiktok: "https://www.tiktok.com/@german.usinger",
+			youtube: "https://youtube.com/unicornioperro",
+			tiktok: "https://tiktok.com/@german.usinger",
 		},
 		clips: [
 			{
@@ -398,11 +398,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.91,
 		country: "co",
 		socials: {
-			twitch: "https://www.twitch.tv/pelicanger",
-			instagram: "https://www.instagram.com/pelicanger__",
+			twitch: "https://twitch.tv/pelicanger",
+			instagram: "https://instagram.com/pelicanger__",
 			twitter: "https://twitter.com/offpeli",
-			youtube: "https://www.youtube.com/c/Pelicanger",
-			tiktok: "https://www.tiktok.com/@pelicanger.oficial",
+			youtube: "https://youtube.com/Pelicanger",
+			tiktok: "https://tiktok.com/@pelicanger.oficial",
 		},
 		clips: [
 			{
@@ -425,11 +425,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.69, // No es seguro
 		country: "mx",
 		socials: {
-			twitch: "https://m.twitch.tv/robertocein/home",
-			instagram: "https://www.instagram.com/robertocein/",
+			twitch: "https://twitch.tv/robertocein",
+			instagram: "https://instagram.com/robertocein",
 			twitter: "https://twitter.com/Roberto_Cein",
-			youtube: "https://www.youtube.com/channel/UCt8RJDArdFmULfqNENimQvw",
-			tiktok: "https://www.tiktok.com/@roberto_cein?lang=es",
+			youtube: "https://youtube.com/c/robertocein1",
+			tiktok: "https://tiktok.com/@roberto_cein",
 		},
 		clips: [
 			{
@@ -452,11 +452,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.83, // No encontrado
 		country: "es",
 		socials: {
-			twitch: "https://www.twitch.tv/skain",
-			instagram: "https://www.instagram.com/skain24",
+			twitch: "https://twitch.tv/skain",
+			instagram: "https://instagram.com/skain24",
 			twitter: "https://twitter.com/skain24",
-			youtube: "https://www.youtube.com/@skain24",
-			tiktok: "https://www.tiktok.com/@skain24",
+			youtube: "https://youtube.com/@skain24",
+			tiktok: "https://tiktok.com/@skain24",
 		},
 		workout: {
 			videoID: "PUNBQ1_rbuo",
@@ -483,11 +483,11 @@ export const BOXERS: Boxer[] = addGetters([
 		height: 1.8,
 		country: "es",
 		socials: {
-			twitch: "https://www.twitch.tv/folagorlives",
-			instagram: "https://www.instagram.com/yoel__ramirez",
+			twitch: "https://twitch.tv/folagorlives",
+			instagram: "https://instagram.com/yoel__ramirez",
 			twitter: "https://twitter.com/FolagoR",
-			tiktok: "https://www.tiktok.com/@folagor_official",
-			youtube: "https://www.youtube.com/Folagor03",
+			tiktok: "https://tiktok.com/@folagor_official",
+			youtube: "https://youtube.com/Folagor03",
 		},
 		clips: [
 			{
@@ -535,7 +535,7 @@ export const BOXERS: Boxer[] = addGetters([
 		socials: {
 			instagram: "https://instagram.com/yosoyplex",
 			twitter: "https://twitter.com/yosoyplex",
-			youtube: "https://youtube.com/c/YoSoyPlex",
+			youtube: "https://youtube.com/YoSoyPlex",
 			tiktok: "https://tiktok.com/@yosoyplexx",
 		},
 		workout: {
@@ -572,7 +572,7 @@ export const BOXERS: Boxer[] = addGetters([
 			twitch: "https://twitch.tv/byviruzz",
 			instagram: "https://instagram.com/victormelida",
 			twitter: "https://twitter.com/byViruZz",
-			youtube: "https://youtube.com/c/byViruZz",
+			youtube: "https://youtube.com/byViruZz",
 			tiktok: "https://tiktok.com/@victormelida",
 		},
 		clips: [
@@ -606,7 +606,7 @@ export const BOXERS: Boxer[] = addGetters([
 			twitch: "https://twitch.tv/alanalarana",
 			instagram: "https://instagram.com/alanafloresf",
 			twitter: "https://twitter.com/alanafloresf",
-			youtube: "https://youtube.com/c/alanalarana",
+			youtube: "https://youtube.com/alanalarana",
 			tiktok: "https://tiktok.com/@alanatwitch",
 		},
 		workout: {
@@ -645,7 +645,7 @@ export const BOXERS: Boxer[] = addGetters([
 			twitch: "https://twitch.tv/amablitz",
 			instagram: "https://instagram.com/amablitz",
 			twitter: "https://twitter.com/amablitz",
-			youtube: "https://youtube.com/c/amablitz",
+			youtube: "https://youtube.com/amablitz",
 			tiktok: "https://tiktok.com/@amablitz",
 		},
 		clips: [
@@ -673,10 +673,10 @@ export const BOXERS: Boxer[] = addGetters([
 		reach: 168, // No encontrado
 		socials: {
 			twitch: "https://twitch.tv/agustin51",
-			instagram: "https://www.instagram.com/IMAGUS51",
+			instagram: "https://instagram.com/imagus51",
 			twitter: "https://twitter.com/ImAgus51",
-			youtube: "https://www.youtube.com/channel/UC1Bb0DVSgXLKuLbenbpkb8g",
-			tiktok: "https://www.tiktok.com/@agustin51",
+			youtube: "https://youtube.com/Agustin5111",
+			tiktok: "https://tiktok.com/@agustin51",
 		},
 		clips: [
 			{
@@ -708,7 +708,7 @@ export const BOXERS: Boxer[] = addGetters([
 			twitch: "https://twitch.tv/guanyar",
 			instagram: "https://instagram.com/guanyarr",
 			twitter: "https://twitter.com/guanyarr",
-			youtube: "https://www.youtube.com/channel/UCEy75s5IJw-ISYDu1d7HzlA?view_as=subscriber",
+			youtube: "https://youtube.com/GUANYAR",
 			tiktok: "https://tiktok.com/@guanyar",
 		},
 		clips: [


### PR DESCRIPTION
## Descripción

Se han acortado y arreglado los links de las redes sociales de los boxeadores.

## Problema solucionado

-El link al Twitter de Zeling redireccionaba a una cuenta incorrecta.
-Se han acortado los links de las redes sociales.

## Cambios propuestos

-El link al Twitter de Zeling ha sido sustituido por el real.
-Se han eliminado los subdominios (m/www), los parametros (lang/view_as) y los paths innecesarios.
-Los IDs de Youtube han sido cambiados por el nombre de usuario para ser más legibles y cortos.

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.
