### PR TITLE
fix(#829): Boxer with 4 social link not centered

### DIFF
--- a/src/components/BoxerSocials.astro
+++ b/src/components/BoxerSocials.astro
@@ -1,0 +1,54 @@
+---
+import BoxerSocialLink from "@/components/BoxerSocialLink.astro"
+import Instagram from "@/icons/instagram.astro"
+import Tiktok from "@/icons/tiktok.astro"
+import Twitch from "@/icons/twitch.astro"
+import X from "@/icons/x.astro"
+import Youtube from "@/icons/youtube.astro"
+import type { Boxer } from "@/types/Boxer"
+
+interface Props {
+	socials: Boxer["socials"]
+}
+
+const { socials } = Astro.props
+---
+
+{
+	Object.keys(socials).map((social) => {
+		switch (social) {
+			case "twitter":
+				return (
+					<BoxerSocialLink href={socials[social]}>
+						<X />
+					</BoxerSocialLink>
+				)
+			case "twitch":
+				return (
+					<BoxerSocialLink href={socials[social]}>
+						<Twitch />
+					</BoxerSocialLink>
+				)
+			case "youtube":
+				return (
+					<BoxerSocialLink href={socials[social]}>
+						<Youtube />
+					</BoxerSocialLink>
+				)
+			case "tiktok":
+				return (
+					<BoxerSocialLink href={socials[social]}>
+						<Tiktok />
+					</BoxerSocialLink>
+				)
+			case "instagram":
+				return (
+					<BoxerSocialLink href={socials[social]}>
+						<Instagram />
+					</BoxerSocialLink>
+				)
+			default:
+				return null
+		}
+	})
+}

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -3,16 +3,10 @@ import BoxerBigImage from "@/components/BoxerBigImage.astro"
 import BoxerClips from "@/components/BoxerClips.astro"
 import BoxerDetailInfo from "@/components/BoxerDetailInfo.astro"
 import BoxerDetailInfoRival from "@/components/BoxerDetailInfoRival.astro"
-import BoxerSocialLink from "@/components/BoxerSocialLink.astro"
+import BoxerSocials from "@/components/BoxerSocials.astro"
 import BoxerWorkout from "@/components/BoxerWorkout.astro"
 import BoxerGallery from "@/components/Boxers/Gallery.astro"
 import Typography from "@/components/Typography.astro"
-
-import Instagram from "@/icons/instagram.astro"
-import Tiktok from "@/icons/tiktok.astro"
-import Twitch from "@/icons/twitch.astro"
-import X from "@/icons/x.astro"
-import YouTube from "@/icons/youtube.astro"
 
 import { BOXERS } from "@/consts/boxers"
 import { COMBATS } from "@/consts/combats"
@@ -137,23 +131,17 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 			<Typography as="h3" variant="h3" color="white" class:list={"mb-12 text-center"}>
 				REDES SOCIALES
 			</Typography>
-			<div class="m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full md:grid-cols-5">
-				<BoxerSocialLink href={boxer.socials.twitch}>
-					<Twitch />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.instagram}>
-					<Instagram />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.twitter}>
-					<X />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.youtube}>
-					<YouTube />
-				</BoxerSocialLink>
-				<BoxerSocialLink href={boxer.socials.tiktok}>
-					<Tiktok />
-				</BoxerSocialLink>
-			</div>
+			{
+				Object.keys(boxer.socials).length < 5 ? (
+					<div class="m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full md:grid-cols-4">
+						<BoxerSocials socials={boxer.socials} />
+					</div>
+				) : (
+					<div class="m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full md:grid-cols-5">
+						<BoxerSocials socials={boxer.socials} />
+					</div>
+				)
+			}
 		</section>
 
 		{boxer.workout && <BoxerWorkout workout={boxer.workout} />}

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -80,6 +80,8 @@ const preloadBoxerImage: Preload[] = [
 const rivalOrRivals = rivals.length > 1 ? "Rivales" : "Rival"
 const guardBoxer = boxer.guard === undefined ? "Desconocida" : boxer.guard
 const flagAlt = countryName === undefined ? "un país" : countryName.name
+
+const socialLinks = Object.keys(boxer.socials)
 ---
 
 <Layout
@@ -131,17 +133,17 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 			<Typography as="h3" variant="h3" color="white" class:list={"mb-12 text-center"}>
 				REDES SOCIALES
 			</Typography>
-			{
-				Object.keys(boxer.socials).length < 5 ? (
-					<div class="m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full md:grid-cols-4">
-						<BoxerSocials socials={boxer.socials} />
-					</div>
-				) : (
-					<div class="m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full md:grid-cols-5">
-						<BoxerSocials socials={boxer.socials} />
-					</div>
-				)
-			}
+			<div
+				class:list={[
+					"m-auto grid w-10/12 grid-cols-2 gap-4 md:w-full",
+					{
+						"md:grid-cols-4": socialLinks.length === 4,
+						"md:grid-cols-5": socialLinks.length === 5,
+					},
+				]}
+			>
+				<BoxerSocials socials={boxer.socials} />
+			</div>
 		</section>
 
 		{boxer.workout && <BoxerWorkout workout={boxer.workout} />}


### PR DESCRIPTION
## Descripción

Se hace que solo cree 4 columnas de grid si tiene 4 links

## Problema solucionado

Issue #829 

## Cambios propuestos

1. Sacar los links a un componente nuevo
2. Según tengan 5 o menos usar una clase u otra.

## Capturas de pantalla (si corresponde)

Antes:
<img width="1772" alt="Screenshot 2024-04-02 at 01 41 55" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/67a0c320-27ae-4a32-ad28-ca7094953747">

Después:
<img width="1772" alt="Screenshot 2024-04-02 at 01 41 45" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/e6bc9b9f-1904-4d2f-bcda-b161313ec630">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora del centrado de los links de los boxeadores

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
