### PR TITLE
[WIP] Add Calendar component closes #831, #483

### DIFF
--- a/src/components/CalendarComponent.astro
+++ b/src/components/CalendarComponent.astro
@@ -3,7 +3,7 @@ import Action from "@/components/Action.astro"
 ---
 
 <!-- This button is used to open the dialog -->
-<Action as="button" id="calendar-open" class:list={"bg-twitch"}>Añadir al calendario</Action>
+<Action as="button" id="calendar-open" class="bg-twitch">Añadir al calendario</Action>
 <!-- Overlay element -->
 <div
 	id="calendar-overlay"

--- a/src/components/CalendarComponent.astro
+++ b/src/components/CalendarComponent.astro
@@ -1,0 +1,218 @@
+---
+import Action from "@/components/Action.astro"
+---
+
+<!-- This button is used to open the dialog -->
+<Action as="button" id="calendar-open" class:list={"bg-twitch"}>Añadir al calendario</Action>
+<!-- Overlay element -->
+<div
+	id="calendar-overlay"
+	class="fixed inset-0 z-40 hidden h-screen w-screen bg-black bg-opacity-80 blur-md"
+>
+</div>
+<div id="calendar-close" class="radial fixed inset-0 top-0 -z-10 hidden"></div>
+
+<!-- The dialog -->
+<div
+	id="calendar-dialog"
+	class="fixed left-1/2 top-1/2 z-50 hidden w-96 -translate-x-1/2 -translate-y-1/2 gap-0 overflow-hidden rounded-lg bg-secondary drop-shadow-lg"
+>
+	<div class="flex h-full w-full flex-col" id="calendar-options">
+		<a
+			href="https://calendar.google.com/calendar/render?action=TEMPLATE"
+			id="google"
+			class="h-full w-full border-b border-b-black/35 bg-secondary py-5 text-center font-medium text-primary hover:bg-accent hover:text-secondary"
+			>Google Calendar</a
+		>
+		<a
+			href="/"
+			id="apple"
+			class="h-full w-full border-b border-b-black/35 bg-secondary py-5 text-center font-medium text-primary hover:bg-accent hover:text-secondary"
+			>Apple Calendar</a
+		>
+		<a
+			href="/"
+			id="ms365"
+			class="h-full w-full border-b border-b-black/35 bg-secondary py-5 text-center font-medium text-primary hover:bg-accent hover:text-secondary"
+			>Microsoft 365</a
+		>
+		<a
+			href="/"
+			id="msteams"
+			class="h-full w-full bg-secondary py-5 text-center font-medium text-primary hover:bg-accent hover:text-secondary"
+			>Microsoft Teams</a
+		>
+	</div>
+</div>
+<style>
+	.radial {
+		background-image: radial-gradient(
+			var(--color-accent) 0%,
+			rgba(0, 0, 0, 0.1) 30%,
+			transparent 100%
+		);
+	}
+</style>
+<script>
+	import { $, $$ } from "@/lib/dom-selector"
+
+	interface VeladaEvent {
+		name: string
+		details: string
+		startDate: string
+		endDate: string
+		startTime: string
+		endTime: string
+		timeZone: string
+		location: string
+		iCalFileName: string
+	}
+
+	interface VeladaDate {
+		start: Date
+		end: Date
+		c: boolean
+		event: VeladaEvent
+	}
+
+	type CalendarProviders = "google" | "apple" | "ms365" | "msteams"
+
+	// selectors
+	const $openButton = $("#calendar-open")
+	const $dialog = $("#calendar-dialog")
+	const $overlay = $("#calendar-overlay")
+	const $close = $("#calendar-close")
+	const $calendarOptions = $$("#calendar-options > a")
+
+	const eventData: VeladaEvent = {
+		name: "🥊 La Velada del Año 4 - El Evento del Año",
+		details:
+			"¡Arranca la Velada del Año!<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]",
+		startDate: "2024-07-13",
+		endDate: "2024-07-13",
+		startTime: "19:00",
+		endTime: "22:00",
+		timeZone: "Europe/Madrid",
+		location: "Spain",
+		iCalFileName: "Reminder-Event",
+	}
+
+	$calendarOptions?.forEach((link: any) => {
+		link.addEventListener("click", (ev: PointerEvent) => {
+			ev.preventDefault()
+			const element = ev.target as HTMLAnchorElement
+			const providerUrl = element.href
+			const provider = element.id as CalendarProviders
+			addToCalendar(providerUrl, provider, eventData)
+		})
+	})
+	// show the overlay and the dialog
+	$openButton.addEventListener("click", () => {
+		$dialog.classList.remove("hidden")
+		$overlay.classList.remove("hidden")
+		$close.classList.remove("hidden")
+	})
+
+	// closes modal when clicking out of it
+	$overlay.addEventListener("click", () => {
+		$dialog.classList.add("hidden")
+		$overlay.classList.add("hidden")
+		$close.classList.add("hidden")
+	})
+
+	function addToCalendar(providerUrl: string, provider: CalendarProviders, event: VeladaEvent) {
+		switch (provider) {
+			case "google":
+				addToGoogleCalendar(providerUrl, event)
+				break
+			default:
+				throw new Error("NOT YET IMPLEMENTED").stack
+		}
+	}
+
+	function encodeURL(url: string, urlParams: Record<string, string>, action = true) {
+		if (action) url += "&"
+		const newUrl = Object.keys(urlParams)
+			.map((key: string) => {
+				return `${encodeURIComponent(key)}=${encodeURIComponent(urlParams[key])}`
+			})
+			.join("&")
+		return url + newUrl
+	}
+
+	function addToGoogleCalendar(url: string, event: VeladaEvent): void {
+		const { startTime, endTime } = formatDate(generateDate(event))
+
+		event.details = sanitizeHtml(event.details)
+		const urlParams = {
+			dates: `${startTime}/${endTime}`,
+			text: event.name,
+			location: event.location,
+			details: event.details,
+		}
+
+		const encodedUrl = encodeURL(url, urlParams)
+		window.open(encodedUrl, "_blank")
+	}
+
+	function formatDate({ start, end, c, event }: VeladaDate) {
+		const newDate = new window.Date(
+			start.toLocaleString("en-US", {
+				timeZone: "UTC",
+			})
+		)
+		const newLocalDate = new window.Date(
+			new window.Date(newDate.toLocaleString("en-US", { timeZone: event.timeZone }))
+		)
+		const offset = newLocalDate.getTime() - newDate.getTime()
+		start.setTime(start.getTime() + offset)
+		end.setTime(end.getTime() + offset)
+		const cleanStart = start.toISOString().replace(".000", "").replace(/-/g, "").replace(/:/g, "")
+		const cleanEnd = end.toISOString().replace(".000", "").replace(/-/g, "").replace(/:/g, "")
+		return {
+			startTime: cleanStart,
+			endTime: cleanEnd,
+			recurrence: c,
+		}
+	}
+
+	function generateDate(event: VeladaEvent): VeladaDate {
+		const start = event.startDate.split("-")
+		const [sYear, sMonth, sDay] = start
+		const end = event.endDate.split("-")
+		const [eYear, eMonth, eDay] = end
+		const startDate = new Date(`${sYear}-${sMonth}-${sDay}T${event.startTime}:00.000+00:00`)
+		const endDate = new Date(`${eYear}-${eMonth}-${eDay}T${event.endTime}:00.000+00:00`)
+
+		return {
+			start: startDate,
+			end: endDate,
+			c: !0,
+			event,
+		}
+	}
+
+	function sanitizeHtml(details: string, t = !1): string {
+		const regex = {
+			newLines: /<br\s*\/?>/gi,
+			elementsWithLink: /\[(|\/)(url|br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]|((\|.*)\[\/url\])/gi,
+			elements: /\[(\/|)(br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]/gi,
+			links: /\[url\]([\w&$+.,:;=~!*'?@^%#|\s\-()/]*)\[\/url\]/gi,
+		}
+		details = details.replace(regex.newLines, "\n")
+		if (t) {
+			details = details.replace(regex.elementsWithLink, "")
+		} else {
+			details = details.replace(regex.elements, "<$1$2>").replace(regex.links, (_, matchedLink) => {
+				let a = `<a href="${(matchedLink = matchedLink.split("|"))[0]}" target="_blank" rel="noopener">`
+				if (matchedLink.length > 1 && matchedLink[1] !== "") {
+					a += matchedLink[1]
+				} else {
+					a += matchedLink[0]
+				}
+				return `${a}</a>`
+			})
+		}
+		return details
+	}
+</script>

--- a/src/components/CalendarComponent.astro
+++ b/src/components/CalendarComponent.astro
@@ -54,28 +54,10 @@ import Action from "@/components/Action.astro"
 	}
 </style>
 <script>
+	import { VELADAEVENT } from "@/consts/calendar"
+	import { addToCalendar } from "@/function/calendar"
 	import { $, $$ } from "@/lib/dom-selector"
-
-	interface VeladaEvent {
-		name: string
-		details: string
-		startDate: string
-		endDate: string
-		startTime: string
-		endTime: string
-		timeZone: string
-		location: string
-		iCalFileName: string
-	}
-
-	interface VeladaDate {
-		start: Date
-		end: Date
-		c: boolean
-		event: VeladaEvent
-	}
-
-	type CalendarProviders = "google" | "apple" | "ms365" | "msteams"
+	import type { CalendarProviders } from "@/types/Calendar"
 
 	// selectors
 	const $openButton = $("#calendar-open")
@@ -84,26 +66,13 @@ import Action from "@/components/Action.astro"
 	const $close = $("#calendar-close")
 	const $calendarOptions = $$("#calendar-options > a")
 
-	const eventData: VeladaEvent = {
-		name: "🥊 La Velada del Año 4 - El Evento del Año",
-		details:
-			"¡Arranca la Velada del Año!<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]",
-		startDate: "2024-07-13",
-		endDate: "2024-07-13",
-		startTime: "19:00",
-		endTime: "22:00",
-		timeZone: "Europe/Madrid",
-		location: "Spain",
-		iCalFileName: "Reminder-Event",
-	}
-
 	$calendarOptions?.forEach((link: any) => {
 		link.addEventListener("click", (ev: PointerEvent) => {
 			ev.preventDefault()
 			const element = ev.target as HTMLAnchorElement
 			const providerUrl = element.href
 			const provider = element.id as CalendarProviders
-			addToCalendar(providerUrl, provider, eventData)
+			addToCalendar(providerUrl, provider, VELADAEVENT)
 		})
 	})
 	// show the overlay and the dialog
@@ -119,100 +88,4 @@ import Action from "@/components/Action.astro"
 		$overlay.classList.add("hidden")
 		$close.classList.add("hidden")
 	})
-
-	function addToCalendar(providerUrl: string, provider: CalendarProviders, event: VeladaEvent) {
-		switch (provider) {
-			case "google":
-				addToGoogleCalendar(providerUrl, event)
-				break
-			default:
-				throw new Error("NOT YET IMPLEMENTED").stack
-		}
-	}
-
-	function encodeURL(url: string, urlParams: Record<string, string>, action = true) {
-		if (action) url += "&"
-		const newUrl = Object.keys(urlParams)
-			.map((key: string) => {
-				return `${encodeURIComponent(key)}=${encodeURIComponent(urlParams[key])}`
-			})
-			.join("&")
-		return url + newUrl
-	}
-
-	function addToGoogleCalendar(url: string, event: VeladaEvent): void {
-		const { startTime, endTime } = formatDate(generateDate(event))
-
-		event.details = sanitizeHtml(event.details)
-		const urlParams = {
-			dates: `${startTime}/${endTime}`,
-			text: event.name,
-			location: event.location,
-			details: event.details,
-		}
-
-		const encodedUrl = encodeURL(url, urlParams)
-		window.open(encodedUrl, "_blank")
-	}
-
-	function formatDate({ start, end, c, event }: VeladaDate) {
-		const newDate = new window.Date(
-			start.toLocaleString("en-US", {
-				timeZone: "UTC",
-			})
-		)
-		const newLocalDate = new window.Date(
-			new window.Date(newDate.toLocaleString("en-US", { timeZone: event.timeZone }))
-		)
-		const offset = newLocalDate.getTime() - newDate.getTime()
-		start.setTime(start.getTime() + offset)
-		end.setTime(end.getTime() + offset)
-		const cleanStart = start.toISOString().replace(".000", "").replace(/-/g, "").replace(/:/g, "")
-		const cleanEnd = end.toISOString().replace(".000", "").replace(/-/g, "").replace(/:/g, "")
-		return {
-			startTime: cleanStart,
-			endTime: cleanEnd,
-			recurrence: c,
-		}
-	}
-
-	function generateDate(event: VeladaEvent): VeladaDate {
-		const start = event.startDate.split("-")
-		const [sYear, sMonth, sDay] = start
-		const end = event.endDate.split("-")
-		const [eYear, eMonth, eDay] = end
-		const startDate = new Date(`${sYear}-${sMonth}-${sDay}T${event.startTime}:00.000+00:00`)
-		const endDate = new Date(`${eYear}-${eMonth}-${eDay}T${event.endTime}:00.000+00:00`)
-
-		return {
-			start: startDate,
-			end: endDate,
-			c: !0,
-			event,
-		}
-	}
-
-	function sanitizeHtml(details: string, t = !1): string {
-		const regex = {
-			newLines: /<br\s*\/?>/gi,
-			elementsWithLink: /\[(|\/)(url|br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]|((\|.*)\[\/url\])/gi,
-			elements: /\[(\/|)(br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]/gi,
-			links: /\[url\]([\w&$+.,:;=~!*'?@^%#|\s\-()/]*)\[\/url\]/gi,
-		}
-		details = details.replace(regex.newLines, "\n")
-		if (t) {
-			details = details.replace(regex.elementsWithLink, "")
-		} else {
-			details = details.replace(regex.elements, "<$1$2>").replace(regex.links, (_, matchedLink) => {
-				let a = `<a href="${(matchedLink = matchedLink.split("|"))[0]}" target="_blank" rel="noopener">`
-				if (matchedLink.length > 1 && matchedLink[1] !== "") {
-					a += matchedLink[1]
-				} else {
-					a += matchedLink[0]
-				}
-				return `${a}</a>`
-			})
-		}
-		return details
-	}
 </script>

--- a/src/components/CalendarComponent.astro
+++ b/src/components/CalendarComponent.astro
@@ -37,7 +37,7 @@ import Action from "@/components/Action.astro"
 			>Outlook Calendar</a
 		>
 		<a
-			href="/"
+			href="https://teams.live.com/_#/scheduling-form/?opener=1&navCtx=new-meeting-button&calendarType=User&webinarType=None"
 			id="msteams"
 			class="h-full w-full bg-secondary py-5 text-center font-medium text-primary hover:bg-accent hover:text-secondary"
 			>Microsoft Teams</a

--- a/src/components/CalendarComponent.astro
+++ b/src/components/CalendarComponent.astro
@@ -54,7 +54,7 @@ import Action from "@/components/Action.astro"
 	}
 </style>
 <script>
-	import { VELADAEVENT } from "@/consts/calendar"
+	import { VELADA_EVENT } from "@/consts/calendar"
 	import { addToCalendar } from "@/function/calendar"
 	import { $, $$ } from "@/lib/dom-selector"
 	import type { CalendarProviders } from "@/types/Calendar"
@@ -72,7 +72,7 @@ import Action from "@/components/Action.astro"
 			const element = ev.target as HTMLAnchorElement
 			const providerUrl = element.href
 			const provider = element.id as CalendarProviders
-			addToCalendar(providerUrl, provider, VELADAEVENT)
+			addToCalendar(providerUrl, provider, VELADA_EVENT)
 		})
 	})
 	// show the overlay and the dialog

--- a/src/components/CalendarComponent.astro
+++ b/src/components/CalendarComponent.astro
@@ -31,10 +31,10 @@ import Action from "@/components/Action.astro"
 			>Apple Calendar</a
 		>
 		<a
-			href="/"
-			id="ms365"
+			href="https://outlook.live.com/calendar/0/deeplink/compose?path=%2Fcalendar%2Faction%2Fcompose&rru=addevent"
+			id="outlook"
 			class="h-full w-full border-b border-b-black/35 bg-secondary py-5 text-center font-medium text-primary hover:bg-accent hover:text-secondary"
-			>Microsoft 365</a
+			>Outlook Calendar</a
 		>
 		<a
 			href="/"

--- a/src/consts/calendar.ts
+++ b/src/consts/calendar.ts
@@ -1,6 +1,6 @@
 import type { VeladaEvent } from "@/types/Calendar"
 
-export const VELADAEVENT: VeladaEvent = {
+export const VELADA_EVENT: VeladaEvent = {
 	name: "🥊 La Velada del Año 4 - El Evento del Año",
 	details:
 		"¡Arranca la Velada del Año!<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]",

--- a/src/consts/calendar.ts
+++ b/src/consts/calendar.ts
@@ -1,0 +1,14 @@
+import type { VeladaEvent } from "@/types/Calendar"
+
+export const VELADAEVENT: VeladaEvent = {
+	name: "🥊 La Velada del Año 4 - El Evento del Año",
+	details:
+		"¡Arranca la Velada del Año!<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]",
+	startDate: "2024-07-13",
+	endDate: "2024-07-13",
+	startTime: "19:00",
+	endTime: "22:00",
+	timeZone: "Europe/Madrid",
+	location: "Spain",
+	iCalFileName: "Reminder-Event",
+}

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -1,5 +1,8 @@
 import type { CalendarProviders, VeladaDate, VeladaEvent } from "@/types/Calendar"
 
+/**
+ * Adds the event to the Calendar dependig on the provider, see {@link CalendarProviders}.
+ */
 function addToCalendar(providerUrl: string, provider: CalendarProviders, event: VeladaEvent) {
 	switch (provider) {
 		case "google":
@@ -10,7 +13,16 @@ function addToCalendar(providerUrl: string, provider: CalendarProviders, event: 
 	}
 }
 
-function encodeURL(url: string, urlParams: Record<string, string>, action = true) {
+/**
+ * Encodes URL using {@link encodeURIComponent} for the `url` and the `searchParams`.
+ *
+ * @param url URL.
+ * @param urlParams Search parameters for the URL.
+ * @param [action] True if `action=...` is specified, false otherwise.
+ *
+ * @returns {string} encodedUrl Encoded URL joint by `&`.
+ */
+function encodeURL(url: string, urlParams: Record<string, string>, action: boolean = true): string {
 	if (action) url += "&"
 	const newUrl = Object.keys(urlParams)
 		.map((key: string) => {
@@ -20,6 +32,9 @@ function encodeURL(url: string, urlParams: Record<string, string>, action = true
 	return url + newUrl
 }
 
+/**
+ * Adds the event to Google Calendar, using its format.
+ */
 function addToGoogleCalendar(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event))
 
@@ -35,6 +50,14 @@ function addToGoogleCalendar(url: string, event: VeladaEvent): void {
 	window.open(encodedUrl, "_blank")
 }
 
+/**
+ * Formats date into a provider friendly way, see {@link CalendarProviders}.
+ *
+ * @param {VeladaDate} date
+ *
+ * @example
+ * const date = formatDate(generateDate(event))
+ */
 function formatDate({ start, end, c, event }: VeladaDate) {
 	const newDate = new window.Date(
 		start.toLocaleString("en-US", {
@@ -56,6 +79,13 @@ function formatDate({ start, end, c, event }: VeladaDate) {
 	}
 }
 
+/**
+ * Generates a valid Date to be formatted for the providers and returns and object, see {@link formatDate}.
+ *
+ * @param {VeladaEvent} event The event.
+ *
+ * @returns {VeladaDate} eventDate The date start and end times and day, c, and the event itself.
+ */
 function generateDate(event: VeladaEvent): VeladaDate {
 	const start = event.startDate.split("-")
 	const [sYear, sMonth, sDay] = start
@@ -72,7 +102,18 @@ function generateDate(event: VeladaEvent): VeladaDate {
 	}
 }
 
-function sanitizeHtml(details: string, tag = false): string {
+/**
+ * Sanitize details string into HTML valid characters.
+ *
+ * @example
+ * const details = "¡Arranca la Velada del Año!<br><br>Entra a Twitch y no te lo pierdas → [url]https://twitch.tv/ibai[/url]"
+ * const sanitized = sanitizeHtml(details)
+ * sanitized = '¡Arranca la Velada del Año!\n\nEntra a Twitch y no te lo pierdas → <a href="https://twitch.tv/ibai" target="_blank" rel="noopener">https://twitch.tv/ibai</a>'
+ *
+ * @param details Event details, the part that displays text information.
+ * @param tag True if the details are meant to be rendered with the current tags, false otherwise.
+ */
+function sanitizeHtml(details: string, tag: boolean = false): string {
 	const regex = {
 		newLines: /<br\s*\/?>/gi,
 		elementsWithLink: /\[(|\/)(url|br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]|((\|.*)\[\/url\])/gi,

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -1,10 +1,7 @@
 import type { CalendarProviders, VeladaDate, VeladaEvent } from "@/types/Calendar"
 
 function isIOS(): boolean {
-	if (
-		/iPad|iPhone|iPod/i.test(navigator.userAgent || navigator.vendor) ||
-		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
-	) {
+	if (/iPad|iPhone|iPod/i.test(navigator.userAgent)) {
 		return true
 	} else {
 		return false
@@ -12,7 +9,7 @@ function isIOS(): boolean {
 }
 
 function isAndroid(): boolean {
-	if (/android/i.test(navigator.userAgent || navigator.vendor)) {
+	if (/android/i.test(navigator.userAgent)) {
 		return true
 	} else {
 		return false

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -11,6 +11,9 @@ function addToCalendar(providerUrl: string, provider: CalendarProviders, event: 
 		case "outlook":
 			addToOutlookCalendar(providerUrl, event)
 			break
+		case "msteams":
+			addToMicrosoftTeams(providerUrl, event)
+			break
 		default:
 			throw new Error("NOT YET IMPLEMENTED")
 	}
@@ -52,6 +55,25 @@ function addToGoogleCalendar(url: string, event: VeladaEvent): void {
 		text: event.name,
 		location: event.location,
 		details: event.details,
+	}
+
+	const encodedUrl = encodeURL(url, urlParams)
+	openUrl(encodedUrl)
+}
+
+/**
+ * Adds the event to Microsoft Teams meeting, using its format.
+ */
+function addToMicrosoftTeams(url: string, event: VeladaEvent): void {
+	const { startTime, endTime } = formatDate(generateDate(event), "delimiters")
+
+	event.details = sanitizeHtml(event.details)
+	const urlParams = {
+		startTime,
+		endTime,
+		subject: event.name,
+		location: event.location,
+		content: event.details,
 	}
 
 	const encodedUrl = encodeURL(url, urlParams)

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -1,0 +1,100 @@
+import type { CalendarProviders, VeladaDate, VeladaEvent } from "@/types/Calendar"
+
+function addToCalendar(providerUrl: string, provider: CalendarProviders, event: VeladaEvent) {
+	switch (provider) {
+		case "google":
+			addToGoogleCalendar(providerUrl, event)
+			break
+		default:
+			throw new Error("NOT YET IMPLEMENTED")
+	}
+}
+
+function encodeURL(url: string, urlParams: Record<string, string>, action = true) {
+	if (action) url += "&"
+	const newUrl = Object.keys(urlParams)
+		.map((key: string) => {
+			return `${encodeURIComponent(key)}=${encodeURIComponent(urlParams[key])}`
+		})
+		.join("&")
+	return url + newUrl
+}
+
+function addToGoogleCalendar(url: string, event: VeladaEvent): void {
+	const { startTime, endTime } = formatDate(generateDate(event))
+
+	event.details = sanitizeHtml(event.details)
+	const urlParams = {
+		dates: `${startTime}/${endTime}`,
+		text: event.name,
+		location: event.location,
+		details: event.details,
+	}
+
+	const encodedUrl = encodeURL(url, urlParams)
+	window.open(encodedUrl, "_blank")
+}
+
+function formatDate({ start, end, c, event }: VeladaDate) {
+	const newDate = new window.Date(
+		start.toLocaleString("en-US", {
+			timeZone: "UTC",
+		})
+	)
+	const newLocalDate = new window.Date(
+		new window.Date(newDate.toLocaleString("en-US", { timeZone: event.timeZone }))
+	)
+	const offset = newLocalDate.getTime() - newDate.getTime()
+	start.setTime(start.getTime() + offset)
+	end.setTime(end.getTime() + offset)
+	const cleanStart = start.toISOString().replace(".000", "").replace(/-/g, "").replace(/:/g, "")
+	const cleanEnd = end.toISOString().replace(".000", "").replace(/-/g, "").replace(/:/g, "")
+	return {
+		startTime: cleanStart,
+		endTime: cleanEnd,
+		recurrence: c,
+	}
+}
+
+function generateDate(event: VeladaEvent): VeladaDate {
+	const start = event.startDate.split("-")
+	const [sYear, sMonth, sDay] = start
+	const end = event.endDate.split("-")
+	const [eYear, eMonth, eDay] = end
+	const startDate = new Date(`${sYear}-${sMonth}-${sDay}T${event.startTime}:00.000+00:00`)
+	const endDate = new Date(`${eYear}-${eMonth}-${eDay}T${event.endTime}:00.000+00:00`)
+
+	return {
+		start: startDate,
+		end: endDate,
+		c: true,
+		event,
+	}
+}
+
+function sanitizeHtml(details: string, tag = false): string {
+	const regex = {
+		newLines: /<br\s*\/?>/gi,
+		elementsWithLink: /\[(|\/)(url|br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]|((\|.*)\[\/url\])/gi,
+		elements: /\[(\/|)(br|hr|p|b|strong|u|i|em|li|ul|ol|h\d)\]/gi,
+		links: /\[url\]([\w&$+.,:;=~!*'?@^%#|\s\-()/]*)\[\/url\]/gi,
+	} as const
+	details = details.replace(regex.newLines, "\n")
+	if (tag) {
+		details = details.replace(regex.elementsWithLink, "")
+	} else {
+		details = details.replace(regex.elements, "<$1$2>").replace(regex.links, (_, url: string) => {
+			const matchedUrl: readonly string[] = url.split("|")
+			let a = `<a href="${matchedUrl[0]}" target="_blank" rel="noopener">`
+			if (matchedUrl.length > 1 && matchedUrl[1] !== "") {
+				a += matchedUrl[1]
+			} else {
+				a += matchedUrl[0]
+			}
+			return `${a}</a>`
+		})
+	}
+	return details
+}
+
+export { addToCalendar }

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -69,19 +69,6 @@ function addToGoogleCalendar(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event), "clean")
 
 	event.details = sanitizeHtml(event.details)
-	if (isAndroid() || isIOS()) {
-		const format = {
-			startTime,
-			endTime,
-			location: event.location,
-			subject: event.name,
-			details: event.details,
-		}
-
-		generateIcsFormat(format)
-		return
-	}
-
 	const urlParams = {
 		dates: `${startTime}/${endTime}`,
 		text: event.name,
@@ -169,19 +156,6 @@ function addToMicrosoftTeams(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event), "delimiters")
 
 	event.details = sanitizeHtml(event.details)
-	if (isAndroid() || isIOS()) {
-		const format = {
-			startTime,
-			endTime,
-			location: event.location,
-			subject: event.name,
-			details: event.details,
-		}
-
-		generateIcsFormat(format)
-		return
-	}
-
 	const urlParams = {
 		startTime,
 		endTime,
@@ -201,19 +175,6 @@ function addToOutlookCalendar(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event), "delimiters")
 
 	event.details = sanitizeHtml(event.details)
-	if (isAndroid() || isIOS()) {
-		const format = {
-			startTime,
-			endTime,
-			location: event.location,
-			subject: event.name,
-			details: event.details,
-		}
-
-		generateIcsFormat(format)
-		return
-	}
-
 	const urlParams = {
 		startdt: startTime,
 		enddt: endTime,

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -77,7 +77,6 @@ function addToAppleCalendar(event: VeladaEvent): void {
 	}
 
 	generateIcsFormat(format)
-	// window.open(`data:text/calendar;charset=utf8,${calendar}`)
 }
 
 /**

--- a/src/function/calendar.ts
+++ b/src/function/calendar.ts
@@ -1,5 +1,24 @@
 import type { CalendarProviders, VeladaDate, VeladaEvent } from "@/types/Calendar"
 
+function isIOS(): boolean {
+	if (
+		/iPad|iPhone|iPod/i.test(navigator.userAgent || navigator.vendor) ||
+		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+	) {
+		return true
+	} else {
+		return false
+	}
+}
+
+function isAndroid(): boolean {
+	if (/android/i.test(navigator.userAgent || navigator.vendor)) {
+		return true
+	} else {
+		return false
+	}
+}
+
 /**
  * Adds the event to the Calendar dependig on the provider, see {@link CalendarProviders}.
  */
@@ -53,6 +72,19 @@ function addToGoogleCalendar(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event), "clean")
 
 	event.details = sanitizeHtml(event.details)
+	if (isAndroid() || isIOS()) {
+		const format = {
+			startTime,
+			endTime,
+			location: event.location,
+			subject: event.name,
+			details: event.details,
+		}
+
+		generateIcsFormat(format)
+		return
+	}
+
 	const urlParams = {
 		dates: `${startTime}/${endTime}`,
 		text: event.name,
@@ -140,6 +172,19 @@ function addToMicrosoftTeams(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event), "delimiters")
 
 	event.details = sanitizeHtml(event.details)
+	if (isAndroid() || isIOS()) {
+		const format = {
+			startTime,
+			endTime,
+			location: event.location,
+			subject: event.name,
+			details: event.details,
+		}
+
+		generateIcsFormat(format)
+		return
+	}
+
 	const urlParams = {
 		startTime,
 		endTime,
@@ -159,6 +204,19 @@ function addToOutlookCalendar(url: string, event: VeladaEvent): void {
 	const { startTime, endTime } = formatDate(generateDate(event), "delimiters")
 
 	event.details = sanitizeHtml(event.details)
+	if (isAndroid() || isIOS()) {
+		const format = {
+			startTime,
+			endTime,
+			location: event.location,
+			subject: event.name,
+			details: event.details,
+		}
+
+		generateIcsFormat(format)
+		return
+	}
+
 	const urlParams = {
 		startdt: startTime,
 		enddt: endTime,

--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -1,6 +1,7 @@
 ---
 import Action from "@/components/Action.astro"
 import CalendarButton from "@/components/CalendarButton.astro"
+import CalendarComponent from "@/components/CalendarComponent.astro"
 import Typography from "@/components/Typography.astro"
 import MapMarkerIcon from "@/icons/map-marker.astro"
 ---
@@ -67,6 +68,7 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		</div>
 		<div>
 			<CalendarButton />
+			<CalendarComponent />
 		</div>
 	</footer>
 </section>

--- a/src/types/Calendar.ts
+++ b/src/types/Calendar.ts
@@ -17,4 +17,4 @@ export interface VeladaDate {
 	event: VeladaEvent
 }
 
-export type CalendarProviders = "google" | "apple" | "ms365" | "msteams"
+export type CalendarProviders = "google" | "apple" | "outlook" | "msteams"

--- a/src/types/Calendar.ts
+++ b/src/types/Calendar.ts
@@ -1,0 +1,20 @@
+export interface VeladaEvent {
+	name: string
+	details: string
+	startDate: string
+	endDate: string
+	startTime: string
+	endTime: string
+	timeZone: string
+	location: string
+	iCalFileName: string
+}
+
+export interface VeladaDate {
+	start: Date
+	end: Date
+	c: boolean
+	event: VeladaEvent
+}
+
+export type CalendarProviders = "google" | "apple" | "ms365" | "msteams"


### PR DESCRIPTION
## Descripción

He notado que en el algunos dispositivos móviles, se ralentiza un poco a la hora de hacer la carga (en el mío por ejemplo, y emulando algunos dispositivos de hace 2-3 años atrás).

También si se quiere modificar, como ya se ha hecho previamente, al estar `add-to-calendar.{js,css}` minificado, se crean muchos conflictos y resulta difícil a la hora de modificar, debido a los nombres de variables que tiene.

## Problema solucionado

Issues:
- #831
- #483

## Cambios propuestos

1. Quitar el minificado tanto de `js` como de `css`
2. Crear un componente más personalizable
3. Ajustar la carga de datos a lo imprescindible

## Capturas de pantalla (si corresponde)

> [!important]
> El color del botón es para hacer una distinción

Antes:

https://github.com/midudev/la-velada-web-oficial/assets/71392160/59f48536-9f46-4321-b8af-a3322b3fe653

Después:

https://github.com/midudev/la-velada-web-oficial/assets/71392160/f08e19d6-aee9-4cfb-b6d7-e9a48b3b2862

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Reducir ralentización en dispositivos de menos recursos como algunos móviles u ordenadores no tan potentes.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
