### PR TITLE
Fix(#830) boxer name size

### DIFF
--- a/src/components/Typography.astro
+++ b/src/components/Typography.astro
@@ -14,7 +14,7 @@ const variantClasses: { [key: string]: string } = {
 	"h3": "text-2xl font-semibold uppercase",
 	"atomic-title": "text-5xl font-atomic lowercase",
 	"atomic-quote": "text-2xl font-atomic lowercase",
-	"boxer-title": "text-6xl md:text-8xl font-atomic lowercase",
+	"boxer-title": "text-6xl md:text-7xl font-atomic lowercase",
 	"body": "text-xl",
 	"medium": "text-md",
 	"small": "text-sm",


### PR DESCRIPTION
## Descripción
Se intenta solucionar la issue #830 donde el nombre de roberto colisionaba con las imágenes de los luchadores


![Captura de pantalla 2024-04-01 230230](https://github.com/midudev/la-velada-web-oficial/assets/96151177/736ab3f6-dca9-4c2d-8d76-8d4763814c2e)

**La issue comentaba poder hacerlo en 2 lineas pero la verdad no me convence, quedaría así:**

![issue](https://github.com/midudev/la-velada-web-oficial/assets/96151177/75118024-a6c6-458e-aa20-1bcb906f3411)


**creo que bajando solo un poquito el tamaño del texto queda bien**


![now](https://github.com/midudev/la-velada-web-oficial/assets/96151177/b8a365c0-f874-4bfa-974c-6c6bd1c06da1)


