### PR TITLE
Update weight of Nissaxter

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -126,7 +126,7 @@ export const BOXERS: Boxer[] = addGetters([
 		name: "Nissaxter",
 		realName: "Cristina Magadán",
 		birthDate: new Date(1994, 3, 4),
-		weight: 55, // No es seguro
+		weight: 45,
 		height: 1.64,
 		country: "es",
 		gallery: true,


### PR DESCRIPTION
## Descripción

Luzu tiene un podcast sobre la Velada y a confirmado el peso de Nissaxter

## Problema solucionado

Actualizar peso de Nissaxter

## Cambios propuestos

Cambiar peso a 45kg

## Capturas de pantalla

![CleanShot 2024-04-02 at 17 54 49@2x](https://github.com/midudev/la-velada-web-oficial/assets/13372238/edcdff92-be08-43b7-ad93-f49bf161863e)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.


## Enlaces útiles

-  [Video de Luzu](https://youtu.be/h5Ptj-rfnM8?si=gE4B83eoOi6VJ1E8&t=316)
