### PR TITLE
Update page titles

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -5,7 +5,7 @@ import Error from "@/sections/Error.astro"
 
 <Layout
 	description="Web Oficial de La Velada del Año IV, evento de boxeo entre streamers y creadores de contenido, organizado por Ibai Llanos"
-	title="La Velada del Año 4 - Página no encontrada"
+	title="Página no encontrada - La Velada del Año IV"
 >
 	<main>
 		<Error

--- a/src/pages/boxers/[id].astro
+++ b/src/pages/boxers/[id].astro
@@ -90,7 +90,7 @@ const flagAlt = countryName === undefined ? "un país" : countryName.name
 
 <Layout
 	description={`Información del luchador ${boxer.name}`}
-	title={`${boxer.name} - Información del boxeador de La Velada IV`}
+	title={`${boxer.name} - La Velada del Año IV`}
 	preload={preloadBoxerImage}
 >
 	<main>

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -42,8 +42,8 @@ const [imageWidth, imageHeight] = combatData.titleSize
 ---
 
 <Layout
-	title={`Combate número ${combatData.number} de La Velada IV`}
-	description={`Combate entre ${formattedBoxerNames}`}
+	title={`Combate #${combatData.number} - La Velada del Año IV`}
+	description={`Combate entre ${formattedBoxerNames} en La Velada del Año IV`}
 	image={`https://cdn.lavelada.dev/matches/og-${id}-min.jpg`}
 >
 	<BackgroundVideo id={id} />

--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -14,7 +14,7 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 }
 ---
 
-<Layout description={"Todos los combates de la Velada IV"} title={"Combates de La Velada IV"}>
+<Layout description={"Todos los combates de La Velada del Año IV"} title={"Combates - La Velada del Año IV"}>
 	<main class="flex min-h-screen flex-col items-center text-[#b4cd02]">
 		<div class="mx-auto w-full max-w-4xl p-8">
 			<Typography

--- a/src/pages/legal-advice.astro
+++ b/src/pages/legal-advice.astro
@@ -2,4 +2,4 @@
 import Layout from "@/layouts/Layout.astro"
 ---
 
-<Layout description="Avido Legal de La Velada IV " title="Avido Legal - La Velada IV" />
+<Layout description="Aviso Legal de La Velada del Año IV " title="Aviso Legal - La Velada del Año IV" />

--- a/src/pages/privacy-policy.astro
+++ b/src/pages/privacy-policy.astro
@@ -3,6 +3,6 @@ import Layout from "@/layouts/Layout.astro"
 ---
 
 <Layout
-	description="Política de privacidad de La Velada IV "
-	title="Política de privacidad - La Velada IV"
+	description="Política de privacidad de La Velada del Año IV "
+	title="Política de privacidad - La Velada del Año IV"
 />

--- a/src/pages/pronosticos.astro
+++ b/src/pages/pronosticos.astro
@@ -9,7 +9,7 @@ const session = await getSession(Astro.request)
 ---
 
 <Layout
-	title="Pronostica los ganadores de La Velada IV"
+	title="Pronostica los ganadores - La Velada del Año IV"
 	description="¡Participa votando a los boxeadores que crees que ganarán sus combates!"
 >
 	<main class="flex flex-col items-center justify-center text-white">


### PR DESCRIPTION
## Descripción

Se han actualizado los títulos de las páginas para mantener el mismo estilo/formato.

## Problema solucionado

Mantener el mismo formato en todos los títulos de las páginas.

## Cambios propuestos

Cambiar los títulos de las páginas siguiendo el siguiente formato: '{titulo de la página} - La Velada del Año IV'

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
