### PR TITLE
fix(#848): Combat background video not playing on Safari

### DIFF
--- a/src/components/Combates/BackgroundVideo.astro
+++ b/src/components/Combates/BackgroundVideo.astro
@@ -8,7 +8,6 @@ const { id } = Astro.props
 
 <div class="fixed left-0 top-0 -z-10 aspect-video h-[100vh] w-screen" id="bg-video">
 	<video
-		autoplay
 		muted
 		loop
 		class="aspect-video size-full overflow-hidden object-cover opacity-0 transition-opacity duration-500"

--- a/src/components/Combates/BackgroundVideo.astro
+++ b/src/components/Combates/BackgroundVideo.astro
@@ -6,7 +6,7 @@ interface Props {
 const { id } = Astro.props
 ---
 
-<div class="fixed left-0 top-0 -z-10 aspect-video h-[100vh] w-screen">
+<div class="fixed left-0 top-0 -z-10 aspect-video h-[100vh] w-screen" id="bg-video">
 	<video
 		autoplay
 		muted
@@ -18,3 +18,16 @@ const { id } = Astro.props
 		<source type="video/mp4" src={`https://cdn.lavelada.dev/${id}-corto.mp4`} />
 	</video>
 </div>
+
+<script>
+	import { $ } from "@/lib/dom-selector"
+
+	const $bgVideoDiv = $("#bg-video")
+
+	const playVideo = () => {
+		if ($bgVideoDiv) $bgVideoDiv.querySelector("video")?.play()
+		else document.removeEventListener("astro:page-load", playVideo)
+	}
+
+	document.addEventListener("astro:page-load", playVideo)
+</script>


### PR DESCRIPTION
## Descripción

El vídeo corto del combate no se reproducía en la carga inicial de `lavelada.es/combates/[id]`

## Problema solucionado

#848

## Cambios propuestos

1. Añadir un evento `astro:page-load` reproducir el vídeo si está y sino eliminar el evento.

## Capturas de pantalla (si corresponde)

Todas las pruebas necesarias están en #848

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la experiencia de usuario de las personas que usan Safari

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
