### PR TITLE
FIX Screenshots images from SEO (not found)

### DIFF
--- a/src/utils/seoConfig.ts
+++ b/src/utils/seoConfig.ts
@@ -52,25 +52,25 @@ export const manifest: Partial<ManifestOptions> = {
 	],
 	screenshots: [
 		{
-			src: "/img/screenshots/desktop_1.jpg",
+			src: "https://cdn.lavelada.dev/screenshots/desktop_1.jpg",
 			type: "image/jpeg",
 			sizes: "1024x964",
 			form_factor: "wide",
 		},
 		{
-			src: "/img/screenshots/desktop_2.jpg",
+			src: "https://cdn.lavelada.dev/screenshots/desktop_2.jpg",
 			type: "image/jpeg",
 			sizes: "1024x964",
 			form_factor: "wide",
 		},
 		{
-			src: "/img/screenshots/mobile_1.jpg",
+			src: "https://cdn.lavelada.dev/screenshots/mobile_1.jpg",
 			type: "image/jpeg",
 			sizes: "360x593",
 			form_factor: "narrow",
 		},
 		{
-			src: "/img/screenshots/mobile_2.jpg",
+			src: "https://cdn.lavelada.dev/screenshots/mobile_2.jpg",
 			type: "image/jpeg",
 			sizes: "360x593",
 			form_factor: "narrow",


### PR DESCRIPTION
## Descripción

Algunas de las imágenes borradas del proyecto siguen con la ruta relativa en el archivo `seoConfig.ts` y se siguen llamando en la página

![image](https://github.com/midudev/la-velada-web-oficial/assets/44408822/c140b1bb-ef69-4e2a-8b5f-f2eada9ba161)
## Problema solucionado
Se han actualizado el link de las imágenes según la url del cdn
## Cambios propuestos
### Antes
```typescript
screenshots: [
	{
		src: "/img/screenshots/desktop_1.jpg",
		type: "image/jpeg",
		sizes: "1024x964",
		form_factor: "wide",
	},
``` 

### Después
```typescript
screenshots: [
	{
		src: "https://cdn.lavelada.dev/screenshots/desktop_1.jpg", // modicada
		type: "image/jpeg",
		sizes: "1024x964",
		form_factor: "wide",
	},
``` 

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.