### PR TITLE
fix(prettier): fixed prettier warnings

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -14,7 +14,10 @@ const getBoxerNames = (boxerIds: string[]): string[] => {
 }
 ---
 
-<Layout description={"Todos los combates de La Velada del Año IV"} title={"Combates - La Velada del Año IV"}>
+<Layout
+	description={"Todos los combates de La Velada del Año IV"}
+	title={"Combates - La Velada del Año IV"}
+>
 	<main class="flex min-h-screen flex-col items-center text-[#b4cd02]">
 		<div class="mx-auto w-full max-w-4xl p-8">
 			<Typography

--- a/src/pages/legal-advice.astro
+++ b/src/pages/legal-advice.astro
@@ -2,4 +2,7 @@
 import Layout from "@/layouts/Layout.astro"
 ---
 
-<Layout description="Aviso Legal de La Velada del Año IV " title="Aviso Legal - La Velada del Año IV" />
+<Layout
+	description="Aviso Legal de La Velada del Año IV "
+	title="Aviso Legal - La Velada del Año IV"
+/>


### PR DESCRIPTION
## Descripción

Arreglados errors/warnings de formato

## Problema solucionado

Formateado de prettier lanzando warnings

## Cambios propuestos

1. Formatear el código con `pnpm run format`

## Capturas de pantalla (si corresponde)

<img width="819" alt="Screenshot 2024-04-04 at 15 16 58" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/3d081ed0-60c4-4938-9fee-c20a46103f2d">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Evitar problemas de formateado

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
