### PR TITLE
Added animation when opening ClipsModal

### DIFF
--- a/src/components/ClipsModal.astro
+++ b/src/components/ClipsModal.astro
@@ -3,7 +3,7 @@
 ---
 
 <dialog
-	class="clip-dialog items-center justify-center bg-transparent px-4 text-2xl text-white backdrop:bg-black/70 sm:px-0"
+	class="clip-dialog items-center justify-center bg-transparent px-4 text-2xl text-white sm:px-0"
 >
 	<div class="relative block w-[560px] overflow-hidden bg-transparent sm:w-[740px]">
 		<iframe
@@ -35,6 +35,26 @@
 		</button>
 	</div>
 </dialog>
+
+<style>
+	.clip-dialog[open]::backdrop {
+		background-color: rgba(0, 0, 0, 0.7);
+
+		animation-name: join-anim;
+		animation-duration: 200ms;
+		animation-fill-mode: forwards;
+		animation-timing-function: ease-in-out;
+	}
+
+	@keyframes join-anim {
+		from {
+			background-color: rgba(0, 0, 0, 0);
+		}
+		to {
+			background-color: rgba(0, 0, 0, 0.7);
+		}
+	}
+</style>
 
 <script>
 	document.addEventListener("astro:page-load", () => {


### PR DESCRIPTION
## Descripción
Una animación simple al abrir ClipsModal

## Cambios propuestos

- Se agrego un `keyframes` al `backdrop` que genera un cambio en el `background-color` durante 200ms

## Capturas de pantalla (si corresponde)

https://github.com/midudev/la-velada-web-oficial/assets/61036343/f47e2492-e289-46c7-86e8-d79c5351c66a

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Contexto adicional

Se que no se ve la bandera ya que el asset por lo visto funciona con `src/middleware.ts` el cual tuve que deshabilitar para poder ejecutar el entorno de desarrollo.

![imagen](https://github.com/midudev/la-velada-web-oficial/assets/61036343/75f08abf-02ac-4af3-9ed7-6539c732a5a8)