### PR TITLE
fix(#853): added separators to team boxer votes text

### DIFF
--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -109,9 +109,16 @@ votes.forEach((vote) => {
 				const { teams, boxers } = combatData
 				const [slug1, slug2] = teams ?? boxers
 				const [image1, image2] = [
-					{ alt: slug1.replaceAll("-", " y "), src: createImgRoute(combatData.number, slug1) },
 					{
-						alt: slug2.replace("-", " y ").replace("-", ""),
+						alt: () => slug1.replaceAll("-", " y "),
+						src: createImgRoute(combatData.number, slug1),
+					},
+					{
+						alt: () => {
+							const splittedSlug2 = slug2.split("-")
+							if (splittedSlug2.length > 2) return slug2.replace("-", " y ").replace("-", "")
+							return slug2.replaceAll("-", "")
+						},
 						src: createImgRoute(combatData.number, slug2),
 					},
 				]
@@ -133,7 +140,7 @@ votes.forEach((vote) => {
 									alt={`Fotografía de ${image1.alt}`}
 									style="mask-image: linear-gradient(black 80%, transparent)"
 								/>
-								<span class="to-vote-text">¡voto a {image1.alt}!</span>
+								<span class="to-vote-text">¡voto por {image1.alt}!</span>
 								<span class="already-voted-text">¡tu voto!</span>
 							</div>
 						</button>
@@ -163,7 +170,7 @@ votes.forEach((vote) => {
 									alt={`Fotografía de ${image2.alt}`}
 									style="mask-image: linear-gradient(black 80%, transparent)"
 								/>
-								<span class="to-vote-text">¡voto a {image2.alt}!</span>
+								<span class="to-vote-text">¡voto por {image2.alt}!</span>
 								<span class="already-voted-text">¡tu voto!</span>
 							</div>
 						</button>

--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -109,8 +109,11 @@ votes.forEach((vote) => {
 				const { teams, boxers } = combatData
 				const [slug1, slug2] = teams ?? boxers
 				const [image1, image2] = [
-					{ alt: slug1.replaceAll("-", " "), src: createImgRoute(combatData.number, slug1) },
-					{ alt: slug2.replaceAll("-", " "), src: createImgRoute(combatData.number, slug2) },
+					{ alt: slug1.replaceAll("-", " y "), src: createImgRoute(combatData.number, slug1) },
+					{
+						alt: slug2.replace("-", " y ").replace("-", ""),
+						src: createImgRoute(combatData.number, slug2),
+					},
 				]
 
 				return (


### PR DESCRIPTION
## Descripción

No se mostraba los nombres de las boxeadoras unidos por un `y` siendo equipo.

## Problema solucionado

Closes #853

## Cambios propuestos

1. Añadido separador `y` entre ambas boxeadoras.
2. Juntado el nombre de `ama-blitz` para que aparezca como `amablitz`.

## Capturas de pantalla (si corresponde)

Antes:
<img width="910" alt="Screenshot 2024-04-05 at 08 20 24" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/270ae08d-71ef-4ce3-aafd-08c10120be04">

Después:
<img width="910" alt="Screenshot 2024-04-05 at 08 19 57" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/533f4281-1921-4f19-8edd-ed58f9ee8652">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la experiencia del usuario con la mejora de la legibilidad de los equipos.

## Contexto adicional

#853 

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
