### PR TITLE
fix: mobile view of modal in ClipsModal

### DIFF
--- a/src/components/ClipsModal.astro
+++ b/src/components/ClipsModal.astro
@@ -5,7 +5,7 @@
 <dialog
 	class="clip-dialog items-center justify-center bg-transparent px-4 text-2xl text-white sm:px-0"
 >
-	<div class="relative block w-[560px] overflow-hidden bg-transparent sm:w-[740px]">
+	<div class="relative block w-[80vw] bg-transparent lg:w-[40vw]">
 		<iframe
 			class="yt-iframe block aspect-video h-full w-full overflow-hidden rounded bg-transparent"
 			src=""


### PR DESCRIPTION
## Descripción

Una modificación mínima para permitir que el `iframe` se vea mejor en móvil

## Problema solucionado

El `iframe` se salía de la pantalla en móvil

## Cambios propuestos

- Se cambio de `px` a `viewport` al contenedor del `iframe` para que sea mas legible en móvil

## Capturas de pantalla (si corresponde)
https://github.com/midudev/la-velada-web-oficial/assets/61036343/c10beba6-a183-4496-9f39-46e970336915

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.