### PR TITLE
cambiar orden de boxeadores para que los muestre como las imágenes

### DIFF
--- a/src/consts/forecasts.ts
+++ b/src/consts/forecasts.ts
@@ -5,14 +5,14 @@ export const FORECASTS: Forecast[] = [
 		combatId: "1",
 		forecastData: [
 			{
-				boxerId: "agustin-51",
-				forecast: 0.3,
-				predictionsCount: 30,
-			},
-			{
 				boxerId: "carreraaa",
 				forecast: 0.7,
 				predictionsCount: 70,
+			},
+			{
+				boxerId: "agustin-51",
+				forecast: 0.3,
+				predictionsCount: 30,
 			},
 		],
 	},
@@ -50,14 +50,14 @@ export const FORECASTS: Forecast[] = [
 		combatId: "6",
 		forecastData: [
 			{
-				boxerId: "el-mariana",
-				forecast: 0.6,
-				predictionsCount: 60,
-			},
-			{
 				boxerId: "plex",
 				forecast: 0.4,
 				predictionsCount: 40,
+			},
+			{
+				boxerId: "el-mariana",
+				forecast: 0.6,
+				predictionsCount: 60,
 			},
 		],
 	},


### PR DESCRIPTION
## Descripción

En el apartado pronóstico mostraba la imágen al revés de el nombre. Quizás de esta manera se hace más fácil saber a quién estás votando