### PR TITLE
fix(PresentationVideo): glow effect no longer cuts off

### DIFF
--- a/src/sections/PresentationVideo.astro
+++ b/src/sections/PresentationVideo.astro
@@ -4,7 +4,7 @@ import LiteYouTube from "@/components/LiteYouTube.astro"
 import Typography from "@/components/Typography.astro"
 ---
 
-<section class="mt-10 overflow-hidden px-2 pb-48 pt-16 sm:pb-56 sm:pt-20 md:pb-96 md:pt-20">
+<section class="mt-10 overflow-hidden px-2 pb-48 pt-16 sm:pb-56 sm:pt-32 md:pb-96 md:pt-32">
 	<Typography as="h3" variant="h3" color="white" class:list={"text-center"}>
 		Presentación
 	</Typography>


### PR DESCRIPTION
## Descripción

El glow del background en `PresentationVideo` se cortaba con la introducción del banner de **Revolut**.

## Problema solucionado

Deja de haber un corte visible en después del banner de **Revolut**.

## Cambios propuestos

1. Aumentar el `padding-top` de `5rem` a `8rem`.

## Capturas de pantalla (si corresponde)

Antes:
<img width="1055" alt="Se corta el efecto glow" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/957955cf-dfc9-47c3-8f00-67aad6ac87b2">

Después:
<img width="1055" alt="Deja de cortarse el efecto glow" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/214cf56e-1513-4edd-a901-33abf4946628">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Hacer una UI más limpia.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
