### PR TITLE
fix width calendar button

### DIFF
--- a/src/components/CalendarButton.astro
+++ b/src/components/CalendarButton.astro
@@ -3,7 +3,7 @@ import Action from "@/components/Action.astro"
 ---
 
 <Action
-	class="w-full text-base"
+	class="w-max text-base"
 	as="button"
 	id="add-to-calendar"
 	aria-label="agregar al calendario se abrirá ventana flotante"


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->

Arreglo el ancho del botón de "agregar al calendario" para que el texto dentro no haga un salto de línea (el salto de línea lo hace cuando la ventana tiene un ancho de 768px a 782px)

## Cambios propuestos

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->

cambio la clase w-full por w-max

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->
Antes:
![Captura de pantalla 2024-04-10 202835](https://github.com/midudev/la-velada-web-oficial/assets/89364260/d01b4365-cbe5-4be8-bab1-c53d87d7dcca)

Después:
![Captura de pantalla 2024-04-10 202952](https://github.com/midudev/la-velada-web-oficial/assets/89364260/fc723970-afa2-46cd-adb0-66650da4014d)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.