### PR TITLE
Se cambia la estrategia de prefetching por defecto a viewport para evitar ban por request's limits

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -12,7 +12,9 @@ import { manifest, seoConfig } from "./src/utils/seoConfig"
 // https://astro.build/config
 export default defineConfig({
 	compressHTML: true,
-	prefetch: true,
+	prefetch: {
+		defaultStrategy: "viewport",
+	},
 	devToolbar: {
 		enabled: false,
 	},


### PR DESCRIPTION
## Descripción

Se modifica la configuración de prefetching en Astro para evitar sobrepasar el límite de solicitudes y hacer que el prefetching se realice de manera más eficiente. Anteriormente, se estaba haciendo prefetching cada vez que se realizaba un hover, lo que generaba demasiadas solicitudes y podría llevar a un posible bloqueo por parte del proveedor.

## Problema solucionado

Se hacian demasiadas request's de prefetching al hacer hover en los boxeadores y estoy hacia que podrian llegar a banearnos por el request's limit

## Cambios propuestos

Cambiar la configuracion de astro para hacer el prefeching solo cuando entre en viewport y hacerlo con una baja prioridad de red para mejorar la navegacion y evitar problemas.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [ ] He actualizado la documentación, si corresponde.

## Impacto potencial

Estos cambios mejorarán la navegación y evitarán problemas relacionados con el límite de solicitudes, lo que garantizará una mejor experiencia de usuario.

## Enlaces útiles

- https://docs.astro.build/es/guides/prefetch/
- https://docs.astro.build/es/reference/configuration-reference/#prefetchdefaultstrategy
