### PR TITLE
feat(Vote): added `title` and improved `alt`

### DIFF
--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -83,13 +83,13 @@ votes.forEach((vote) => {
 										]}
 										data-combat-id={combatData.id}
 										data-vote-id={boxer}
+										title={`Votar a ${boxer.replaceAll("-", " ")}`}
 									>
 										<div class="relative h-auto text-xs">
 											<img
 												class="h-auto max-h-96 w-full object-contain"
 												src={`https://cdn.lavelada.dev/boxers/${boxer}-small.webp`}
 												alt={`Fotografía de ${boxer.replaceAll("-", " ")}`}
-												title={`Votar a ${boxer.replaceAll("-", " ")}`}
 												style="mask-image: linear-gradient(black 80%, transparent)"
 											/>
 											<span class="to-vote-text small">{boxer.replaceAll("-", " ")}</span>
@@ -128,13 +128,13 @@ votes.forEach((vote) => {
 							]}
 							data-combat-id={combatData.id}
 							data-vote-id={slug1}
+							title={`Votar a ${image1.alt()}`}
 						>
 							<div class="relative h-auto">
 								<img
 									class="h-auto max-h-96 w-full object-contain"
 									src={image1.src}
 									alt={`Fotografía de ${image1.alt()}`}
-									title={`Votar a ${image1.alt()}`}
 									style="mask-image: linear-gradient(black 80%, transparent)"
 								/>
 								<span class="to-vote-text">¡voto por {image1.alt()}!</span>
@@ -159,13 +159,13 @@ votes.forEach((vote) => {
 							]}
 							data-combat-id={combatData.id}
 							data-vote-id={slug2}
+							title={`Votar a ${image2.alt()}`}
 						>
 							<div class="relative h-auto">
 								<img
 									class="h-auto max-h-96 w-full object-contain"
 									src={image2.src}
 									alt={`Fotografía de ${image2.alt()}`}
-									title={`Votar a ${image2.alt()}`}
 									style="mask-image: linear-gradient(black 80%, transparent)"
 								/>
 								<span class="to-vote-text">¡voto por {image2.alt()}!</span>

--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -89,6 +89,7 @@ votes.forEach((vote) => {
 												class="h-auto max-h-96 w-full object-contain"
 												src={`https://cdn.lavelada.dev/boxers/${boxer}-small.webp`}
 												alt={`Fotografía de ${boxer.replaceAll("-", " ")}`}
+												title={`Votar a ${boxer.replaceAll("-", " ")}`}
 												style="mask-image: linear-gradient(black 80%, transparent)"
 											/>
 											<span class="to-vote-text small">{boxer.replaceAll("-", " ")}</span>
@@ -132,10 +133,11 @@ votes.forEach((vote) => {
 								<img
 									class="h-auto max-h-96 w-full object-contain"
 									src={image1.src}
-									alt={`Fotografía de ${image1.alt}`}
+									alt={`Fotografía de ${image1.alt()}`}
+									title={`Votar a ${image1.alt()}`}
 									style="mask-image: linear-gradient(black 80%, transparent)"
 								/>
-								<span class="to-vote-text">¡voto por {image1.alt}!</span>
+								<span class="to-vote-text">¡voto por {image1.alt()}!</span>
 								<span class="already-voted-text">¡tu voto!</span>
 							</div>
 						</button>
@@ -162,10 +164,11 @@ votes.forEach((vote) => {
 								<img
 									class="h-auto max-h-96 w-full object-contain"
 									src={image2.src}
-									alt={`Fotografía de ${image2.alt}`}
+									alt={`Fotografía de ${image2.alt()}`}
+									title={`Votar a ${image2.alt()}`}
 									style="mask-image: linear-gradient(black 80%, transparent)"
 								/>
-								<span class="to-vote-text">¡voto por {image2.alt}!</span>
+								<span class="to-vote-text">¡voto por {image2.alt()}!</span>
 								<span class="already-voted-text">¡tu voto!</span>
 							</div>
 						</button>


### PR DESCRIPTION
## Descripción

Se mejora la experiencia de usuario añadiendo `title` en los `<button>`.

## Problema solucionado

Si hacías hover no te describía qué hacía el botón.

En la renderización del HTML, se mostraba la función de los separadores.

## Cambios propuestos

1. Añadir `title` a los `<button>` de `Vote.astro`.
2. Llamar a la función para hacer la separación de los nombres.

## Capturas de pantalla (si corresponde)

Antes:
<img width="1297" alt="Renderización de la función de separación" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/3404c63d-4d48-4b43-96fa-09cf187a078f">

Después:
<img width="448" alt="Añadidos title y mejorada la renderización" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/bbbf96f3-f4bc-46d4-9dd2-9633754c128c">

<img width="801" alt="Muestra de title en agustin51" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/8b00a449-cb91-4c8d-8663-c2a7445618b7">


## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora de la experiencia de usuario.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
