### PR TITLE
fix(Vote): proper separations for boxer's names

### DIFF
--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -112,8 +112,9 @@ votes.forEach((vote) => {
 					{
 						alt: () => {
 							const splittedSlug2 = slug2.split("-")
+							if (slug2 === "agustin-51") return slug2.replace("-", "")
 							if (splittedSlug2.length > 2) return slug2.replace("-", " y ").replace("-", "")
-							return slug2.replaceAll("-", "")
+							return slug2.replaceAll("-", " ")
 						},
 						src: createImgRoute(combatData.number, slug2),
 					},


### PR DESCRIPTION
## Descripción

Se añade espacio a los boxeadores como `la-cobra` -> `la cobra` y se dejan sin espacio boxeadores como `agustin-51` -> `agustin51`.

## Problema solucionado

No había separación para los nombres como `La Cobra` o `El Mariana`. Ahora sí.

## Cambios propuestos

1. Reemplazar `-` por espacio si no es `agustin-51`.

## Capturas de pantalla (si corresponde)

Antes:
<img width="641" alt="Se muestra LaCobra" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/7d417727-72da-4b6c-b98a-490b0ded3ebd">

<img width="641" alt="Se muestra agustin51" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/d479375f-f6da-4bac-b7c6-59a7c2245ecb">

Después:
<img width="641" alt="Se sigue mostrando agustin51" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/b9277fdf-8740-4a09-93d2-ba7ed0467d0b">

<img width="641" alt="Se muesta La Cobra" src="https://github.com/midudev/la-velada-web-oficial/assets/71392160/cfb702f0-1d7e-42ca-868a-d54ef266e75f">

## Comprobación de cambios

- [X] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X] He actualizado la documentación, si corresponde.

## Impacto potencial

Ajustar acorde con los nombres de los participantes.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
