### PR TITLE
Estado de enlace activo corregido

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -18,7 +18,9 @@ const pages = [
 	},
 ].map((page) => ({
 	...page,
-	active: Astro.url.pathname === page.href,
+	active:
+		(Astro.url.pathname === page.href || Astro.url.pathname === `${page.href}/`) &&
+		(page.href !== "/" || Astro.url.pathname === "/"),
 }))
 ---
 


### PR DESCRIPTION
## Descripción

Corrección del estado activo de los enlaces en el header para reflejar correctamente la página actual, ajustando la lógica de comparación de URLs.

## Problema solucionado

Resuelve el problema de que el enlace "Combates" no se marcaba como activo en producción. Issue relacionada: [#883](https://github.com/midudev/la-velada-web-oficial/issues/883)

## Cambios propuestos

Ajuste en la comparación de URLs para manejar rutas con y sin barra final.
Condición específica para activación correcta del enlace de inicio.

## Capturas de pantalla

Antes en producción:
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/c781bf18-89e5-4a36-932f-07ed0dd01a60)

Ahora en producción:
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/8b5d2f4d-156f-4d0e-bd52-25874c4bee9f)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora la experiencia del usuario sin afectar el rendimiento o compatibilidad.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- #883 