### PR TITLE
HeaderComponent - correct current link highlighting - Nombre de ruta (Astro.url.pathname) normalizada

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -6,6 +6,8 @@ import HeroLogo from "@/components/HeroLogo.astro"
 import SocialButtons from "@/components/SocialButtons.astro"
 import { MOBILE_MENU_CONTENT_ID } from "@/consts/mobile-menu"
 
+const normalizedPath = Astro.url.pathname.endsWith('/') ? Astro.url.pathname.slice(0,-1) : Astro.url.pathname;
+
 const pages = [
 	{ name: "El Evento", href: "/" },
 	{ name: "Combates", href: "/combates" },
@@ -18,7 +20,7 @@ const pages = [
 	},
 ].map((page) => ({
 	...page,
-	active: Astro.url.pathname === page.href,
+	active: normalizedPath === page.href,
 }))
 ---
 


### PR DESCRIPTION
## Descripción

Se normalizó el `Astro.url.pathname` antes de comparar con los urls de los enlaces

## Problema solucionado

En la web oficial de la védala, los enlaces se iluminan al entrar a "EL EVENTO" y "PRONÓSTICOS", pero en "COMBATES"

## Cambios propuestos

Normalizar el `Astro.url.pathname` antes de comparar con los urls de los enlaces. Es decir, remover el "/" al final del path si este existe.

