### PR TITLE
Generic types in the dom-selector library

### DIFF
--- a/src/components/HamburgerButton.astro
+++ b/src/components/HamburgerButton.astro
@@ -42,7 +42,7 @@ const genericHamburgerLine = `h-[2px] ${width} bg-gray-300 transition ease trans
 
 		$$(DISPLAY.hamburgerMenuClass).forEach((button) => {
 			button.addEventListener("click", () => {
-				const hamburgerButton = $(DISPLAY.hamburgerMenuClass)
+				const hamburgerButton = $(DISPLAY.hamburgerMenuClass)!
 				hamburgerButton.classList.toggle(DISPLAY.open)
 				const isMenuOpen = hamburgerButton.classList.contains(DISPLAY.open)
 				hamburgerButton.setAttribute("aria-expanded", String(isMenuOpen))

--- a/src/components/KonamiCode.astro
+++ b/src/components/KonamiCode.astro
@@ -41,7 +41,7 @@
 
 	const { rotateY, gloveCursor, amongUsCursor, lolCursor, midu, devContributors } = konamiCodes
 	let konamiCodeInprogress = false
-	const $container = $("#main-content")
+	const $container = $("#main-content")!
 	const $miduContainer = document.createElement("div")
 	const audioManager: {
 		audioInstance: HTMLAudioElement | null
@@ -76,7 +76,7 @@
 			code: lolCursor,
 			keyPressed: key,
 			onSuccess: () => {
-				$("body").style.cursor = "url('/img/cursor/lol.cur'), auto"
+				$("body")!.style.cursor = "url('/img/cursor/lol.cur'), auto"
 			},
 		})
 
@@ -84,7 +84,7 @@
 			code: gloveCursor,
 			keyPressed: key,
 			onSuccess: () => {
-				$("body").style.cursor = "url('/img/cursor/boxing-glove.cur'), auto"
+				$("body")!.style.cursor = "url('/img/cursor/boxing-glove.cur'), auto"
 			},
 		})
 
@@ -92,7 +92,7 @@
 			code: amongUsCursor,
 			keyPressed: key,
 			onSuccess: () => {
-				$("body").style.cursor = "url('/img/cursor/among-us.cur'), auto"
+				$("body")!.style.cursor = "url('/img/cursor/among-us.cur'), auto"
 			},
 		})
 

--- a/src/lib/dom-selector.ts
+++ b/src/lib/dom-selector.ts
@@ -7,8 +7,10 @@
  * @param context
  * @returns  HTMLElement
  */
-export const $ = (selector: string, context: Document | HTMLElement = document) =>
-	context.querySelector(selector) as HTMLElement
+export const $ = <T extends HTMLElement>(
+	selector: string,
+	context: Document | HTMLElement = document
+) => context.querySelector<T>(selector)!
 
 /**
  * Get elements from dom by selector string
@@ -18,5 +20,7 @@ export const $ = (selector: string, context: Document | HTMLElement = document) 
  * @param context
  * @returns  NodeList
  */
-export const $$ = (selector: string, context: Document | HTMLElement = document) =>
-	context.querySelectorAll(selector)
+export const $$ = <T extends HTMLElement>(
+	selector: string,
+	context: Document | HTMLElement = document
+) => context.querySelectorAll<T>(selector)

--- a/src/lib/dom-selector.ts
+++ b/src/lib/dom-selector.ts
@@ -10,7 +10,7 @@
 export const $ = <T extends HTMLElement>(
 	selector: string,
 	context: Document | HTMLElement = document
-) => context.querySelector<T>(selector)!
+) => context.querySelector<T>(selector)
 
 /**
  * Get elements from dom by selector string


### PR DESCRIPTION
## Descripción

Simplemente he añadido [tipos genéricos](https://www.typescriptlang.org/docs/handbook/2/generics.html) a la librería dom-selector y solucionar algunos errores de tipos con respecto a la implementación anterior.

Este cambio hace que el uso de $ y $$ sea más claro, corto y ayude al manejo de gestión de errores (por que antes en $ no avisaba de un caso `null`):

```typescript
// antes
const element = $("#my-id") as HTMLDivElement
const elements = $$(".my-class") as globalThis.NodeListOf<HTMLDivElement>

// después
const element = $<HTMLDivElement>("#my-id")!
const elements = $$<HTMLDivElement>(".my-class")
```

![Screenshot from 2024-04-14 18-04-45](https://github.com/midudev/la-velada-web-oficial/assets/135858738/b0518401-8f2d-4c32-9079-ee4cab4bf37a)

## Enlaces útiles

- Tipos genéricos: https://www.typescriptlang.org/docs/handbook/2/generics.html
