### PR TITLE
fix/Date not loading after redirecting to PrincipalDate page

### DIFF
--- a/src/sections/PrincipalDate.astro
+++ b/src/sections/PrincipalDate.astro
@@ -162,7 +162,7 @@ import MapMarkerIcon from "@/icons/map-marker.astro"
 		})
 	}
 
-	document.addEventListener("DOMContentLoaded", main)
+	document.addEventListener("astro:page-load", main)
 
 	// Verifica si el evento ya ha pasado
 	const eventHasPassed = EVENT_TIMESTAMP < Date.now()


### PR DESCRIPTION
## Descripción

Desde cualquier sección de la web, por ejemplo "https://lavelada.es/combates", si vuelves a la pantalla principal desaparece la fecha del evento.

## Problema solucionado

El problema esta en "src\sections\PrincipalDate.astro" en la linea 165 "document.addEventListener("DOMContentLoaded", main)" el cual solo se carga 1 vez al entrar a la web.

## Cambios propuestos

He cambiado el "DOMContentLoaded" por el "astro:page-load" para que se ejecute dicha función siempre que se cargue una página de la web.

## Capturas de pantalla (si corresponde)

ANTES
![image](https://github.com/midudev/la-velada-web-oficial/assets/43236729/9d9e9afb-5535-40b9-bce2-62cca933ca58)

DESPUES
![image](https://github.com/midudev/la-velada-web-oficial/assets/43236729/ab5975ba-eaa1-459b-b41f-798fad9f0642)

## Comprobación de cambios

- [X ] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [X ] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [X ] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [X ] He actualizado la documentación, si corresponde.

## Impacto potencial

Se lanza todo el rato la funcion sin importar la página a la que se esta redirigiendo. Se podría controlar revisando la url pero quizá haya otra opción más óptima.
