### PR TITLE
Corrección de la superposición del div de boxeadores sobre el menú y las secciones

### DIFF
--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -60,7 +60,7 @@ export const prerender = true
 	<BackgroundVideo id={id} />
 	<main class="pointer-events-none md:-mt-12">
 		<div
-			class="full-width relative flex h-[60vh] w-screen items-center justify-center overflow-x-clip md:h-[76vh]"
+			class="full-width relative z-[-10] flex h-[60vh] w-screen items-center justify-center overflow-x-clip md:h-[76vh]"
 		>
 			<img
 				transition:name={`${combatData.id}-member-1`}


### PR DESCRIPTION
## Descripción

En la página de combates, las imágenes de los boxeadores superponen parte del header y de la sección de características, afectando la visibilidad y el diseño de la página.

## Problema solucionado

Soluciona el problema de superposición visual en la página de combates donde las imágenes de los boxeadores interfieren con otras secciones.
Afectaba a la visibilidad del botón hamburguesa (del menú) en dispositivos móviles haciendo imposible verlo y usarlo, la etiqueta "vendidas" de Entradas en ordenadores y texto de la sección de características de los boxeadores.

## Cambios propuestos

He agregado un z-index de -10 al div de imágenes de los boxeadores para prevenir que estas sobresalgan sobre el header.
Esta solución no afecta a otros componentes de la interfaz al cambiar la superposición.

## Capturas de pantalla [diferentes resoluciones]
**ANTES**
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/60a14f3d-eed4-4667-90ff-877b05afd583)
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/042d6196-5fcb-49df-9d94-756570a63313)
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/3b5cb13b-edc7-4417-becc-92720a02b193)
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/57c781a9-fa11-490d-a572-8caabb5332f6)

**DESPUÉS**
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/79c9e726-87e2-4a1b-8b76-167166e159d3)
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/2cae687d-4815-44c0-979b-28e4c6807790)
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/ccca46f0-099d-4227-9da3-7eb63e00bdb7)
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/28569d79-7d51-460f-87c9-fb120210d199)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.