### PR TITLE
Añadir entrenamiento Will

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -362,6 +362,11 @@ export const BOXERS: Boxer[] = addGetters([
 				url: "https://www.youtube.com/embed/ct0Hr6zYZGU?si=2BO21jfm469U_i_5&amp;clip=UgkxHy3xXDVJdgv9BUaArwgIYrA_ae1M5FIX&amp;clipt=EJ3ipQUYtdemBQ",
 			},
 		],
+		workout: {
+			videoID: "GWLZSfJsSCo",
+			thumbnail: "/boxers/workoutThumbnails/will.webp",
+			name: "Will",
+		},
 	},
 	{
 		id: "sezar-blue",


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
Agregar entrenamiento de Will con los datos al archivos boxers.

Miniatura:

![miniatura-will](https://github.com/midudev/la-velada-web-oficial/assets/107658697/3cb0f887-b92f-4390-90b4-6f5aef329d63)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->

Video de youtube: https://www.youtube.com/watch?v=GWLZSfJsSCo&ab_channel=MisterFactous
