### PR TITLE
Eliminate the header line in the internal of the combats

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -26,6 +26,8 @@ const pages = [
 	...page,
 	active: page.active ?? normalizedPathName === page.href,
 }))
+
+const isCombatIntern = normalizedPathName.startsWith("/combates/")
 ---
 
 <header class="mb-10 h-16 max-w-[100vw] lg:h-24">
@@ -112,8 +114,10 @@ const pages = [
 	<div class="relative flex h-2 w-full flex-col items-center">
 		<div class="gridBottomBarContainer absolute grid w-full items-center justify-between">
 			<div
-				class="h-[2px] w-full rounded-l-[30%] border-t-0"
-				style="background:linear-gradient(to right, transparent 3%, white 35%, white 100%)"
+				class:list={[
+					"h-[2px] w-full rounded-l-[30%] border-t-0",
+					{ gridBottomBarContainerLineLeft: !isCombatIntern },
+				]}
 			>
 			</div>
 			<div class="focus-within-ring -ml-[8px] -mr-[4px]">
@@ -121,10 +125,11 @@ const pages = [
 					<HeroLogo class:list={"h-auto w-full"} id="hero-logo-header" noEffect />
 				</a>
 			</div>
-
 			<div
-				class="h-[2px] w-full rounded-r-[30%] border-t-0 bg-white"
-				style="background:linear-gradient(to left, transparent 3%, white 35%, white 100%);"
+				class:list={[
+					"h-[2px] w-full rounded-l-[30%] border-t-0",
+					{ gridBottomBarContainerLineRight: !isCombatIntern },
+				]}
 			>
 			</div>
 		</div>
@@ -195,6 +200,14 @@ const pages = [
 	.gridBottomBarContainer {
 		grid-template-columns: 1fr 6rem 1fr;
 		grid-template-rows: 4px;
+	}
+
+	.gridBottomBarContainerLineLeft {
+		background: linear-gradient(to right, transparent 3%, white 35%, white 100%);
+	}
+
+	.gridBottomBarContainerLineRight {
+		background: linear-gradient(to left, transparent 3%, white 35%, white 100%);
 	}
 
 	@media (min-width: 1024px) {


### PR DESCRIPTION
## Descripción

Se ha implementado una validación para permitir que, cuando los usuarios estén dentro de los combates, la línea del encabezado pueda ocultarse, ya que se considera que la visualización es más adecuada sin ella en ese contexto específico.

## Problema solucionado

Al implementar esta validación, se espera mejorar la apreciación visual del contenido gráfico.

## Capturas de pantalla (si corresponde)

### Actual

![interna-de-combates-anterior](https://github.com/midudev/la-velada-web-oficial/assets/34322534/991d5232-ad2e-4d19-a6fc-6c41e04734d0)

### Propuesta

![interna-de-combates-propuesta](https://github.com/midudev/la-velada-web-oficial/assets/34322534/c6fb857b-7306-4937-8201-5822adc57b68)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.