### PR TITLE
fix: fixed /boxers/[id]/ -> /boxers/[id]/[id]

### DIFF
--- a/src/components/BoxerDetailInfoRival.astro
+++ b/src/components/BoxerDetailInfoRival.astro
@@ -34,7 +34,7 @@ const isVersus = value[0].versus.length === 2
 							`${isVersus ? "mx-2  p-1" : ""}`,
 							`${isKingOfTheTrack ? "p-1" : "boxer-link text-xl font-bold text-accent"}`,
 						]}
-						href={item.id}
+						href={`/boxers/${item.id}`}
 						title={`Visita la página ${item.gender === "masculino" ? "del boxeador" : "de la boxeadora"} ${item.name}`}
 						id={id + (index + 1)}
 					>


### PR DESCRIPTION
## Descripción

Se arregla un problema el cual ocurría en el path "/boxers/[id]", cuando la ruta terminaba en "/" (ejemplo: /boxers/sezar-blue/" y se seleccionaba algún rival, este redireccionaba de manera errónea debido al "/" al final (ejemplo: /boxers/sezar-blue/skain).

Los indexadores como Google hacen que la página por defecto al final de la URL utilice "/", por lo que puede dañar la experiencia de usuario.

## Problema solucionado

No encontré una issue relacionada. Fue por experiencia propia al buscar "Sezar blue velada 4" en el buscador de Google que encontré el bug.

## Cambios propuestos

El cambio propuesto consiste en utilizar una ruta absoluta (/boxers/[id]`) en el href de los enlaces de los rivales, en vez de una ruta relativa ([id]).

## Capturas de pantalla (si corresponde)

En la siguiente captura se ve el problema cuando la ruta termina en "/":
![image](https://github.com/midudev/la-velada-web-oficial/assets/67121413/5ca74077-2b41-424d-a81e-8c8a398d5f5c)

Acá solucionado:
![image](https://github.com/midudev/la-velada-web-oficial/assets/67121413/02ec9719-6e7d-41f7-84d0-e57743b6f39c)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

N/A

## Contexto adicional

N/A

## Enlaces útiles

- Documentación del proyecto: N/A
- Código de referencia: https://github.com/jeanpierm/la-velada-web-oficial/commit/6e54525792d5ebb9b0534541969526b83ddeea3a
