### PR TITLE
README | Ampliación del límite de la lista de contribuidores (contrib.rocks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Si quieres contribuir de una manera mas sencilla, puedes iniciar este proyecto d
 
 **¡Gracias a todos los colaboradores que han hecho posible este proyecto!**
 
-[![Contribuidores](https://contrib.rocks/image?repo=midudev/la-velada-web-oficial)](https://github.com/midudev/la-velada-web-oficial/graphs/contributors)
+[![Contribuidores](https://contrib.rocks/image?repo=midudev/la-velada-web-oficial&max=500&columns=20)](https://github.com/midudev/la-velada-web-oficial/graphs/contributors)
 
 <p align="right">(<a href="#readme-top">volver arriba</a>)</p>
 


### PR DESCRIPTION
## Descripción

Propongo modificar la URL de contrib.rocks del README para mostrar todos los contribuyentes del repositorio en vez de solo 100

## Problema solucionado

La lista de contribuyentes estaba limitada a 100 (actualmente hay casi 200)
Con este cambio se muestran todos los contribuidores actuales.

## Cambios propuestos

Actualizo la URL de contrib.rocks agregando 2 parámetros para mostrar hasta 500 contribuyentes, en lugar del límite predeterminado de 100 y la disposición de 12 a 20 columnas para mostrar una lista completa ocupando el mismo espacio mostrando todos los contribuidores.

## Capturas de pantalla

**ANTES**
![antes](https://github.com/midudev/la-velada-web-oficial/assets/89773173/9a9e4cef-7cad-46e7-b1ef-a3320753aab4)

**DESPUÉS**
![después](https://github.com/midudev/la-velada-web-oficial/assets/89773173/c15b5c2c-36f7-4944-8bdf-f3b50161abff)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Contexto adicional

Contrib.rocks por defecto limita la lista a un máximo de 100 contribuidores en 12 columnas.
![image](https://github.com/midudev/la-velada-web-oficial/assets/89773173/9364ed25-13d7-4705-a8b8-edce5e4f6d8d)


## Enlaces útiles

- https://contrib.rocks
- https://contrib.rocks/image?repo=midudev/la-velada-web-oficial&max=500&columns=20