### PR TITLE
Añadiendo entrenamiento de Nissaxter

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -168,6 +168,11 @@ export const BOXERS: Boxer[] = addGetters([
 				url: "https://www.youtube.com/embed/ct0Hr6zYZGU?si=XXuWc4c5ywxnBHIZ&amp;clip=UgkxptfPo72fI8yntHVo2UfsuyGjpmsfI3js&amp;clipt=ELTnggMY8smDAw",
 			},
 		],
+		workout: {
+			videoID: "zqatWGonjt4",
+			thumbnail: "/boxers/workoutThumbnails/nissaxter.webp",
+			name: "Nissaxter",
+		},
 	},
 	{
 		id: "carreraaa",


### PR DESCRIPTION
## Descripción

Agregar el entrenamiento de Nissaxter.

Miniatura: 
![nissaxter](https://github.com/midudev/la-velada-web-oficial/assets/105134692/ff7c63ec-ddab-48a5-89ae-06c0f1d8d278)

Drive con la miniatura en formato webp: https://drive.google.com/drive/folders/1UKWS1KHgytcKuMboV1gpPkw8NtI9-CQi?usp=sharing
## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

- Documentación del proyecto: 
- Código de referencia: 
Video de youtube: https://youtu.be/zqatWGonjt4?si=Vl6aQBd0ciVn4s6B
