### PR TITLE
Fix spelling errors in conflict comments

### DIFF
--- a/.github/workflows/tag-conflicts.yml
+++ b/.github/workflows/tag-conflicts.yml
@@ -18,5 +18,5 @@ jobs:
           dirtyLabel: "conflictos"
           removeOnDirtyLabel: "conflictos"
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
-          commentOnDirty: "⚠️ Esta Pull Request tiene conflictos. Por favor, resuelvelos antes de que podamos evaluar los cambios."
-          commentOnClean: "✅ ¡Los conflictos han sido resuletos! Un colaborador revisará pronto la Pull Request."
+          commentOnDirty: "⚠️ Esta Pull Request tiene conflictos. Por favor, resuélvelos antes de que podamos evaluar los cambios."
+          commentOnClean: "✅ ¡Los conflictos han sido resueltos! Un colaborador revisará pronto la Pull Request."


### PR DESCRIPTION
Related to #943

Corrects spelling errors in `.github/workflows/tag-conflicts.yml`.
- Updates the `commentOnDirty` message to correctly spell "resuélvelos" instead of "resuelvelos".
- Updates the `commentOnClean` message to correctly spell "resueltos" instead of "resuletos".

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/midudev/la-velada-web-oficial/issues/943?shareId=3f6cf96c-201f-4868-bbff-223c5bff4abe).