### PR TITLE
Fix bug when passing an unrelated boxer id as a voteId to `POST /api/votes/<combatId>` endpoint

### DIFF
--- a/src/pages/api/votes/[combatId].ts
+++ b/src/pages/api/votes/[combatId].ts
@@ -34,6 +34,8 @@ export const POST: APIRoute = async ({ params, request }) => {
 	if (!success) return res("Bad request", { status: 400 })
 
 	const { voteId } = output
+	const boxerData = combatData.boxers.find((b) => b === voteId)
+	if (!boxerData) return res("Boxer not found", { status: 404 })
 
 	const userId = session.user.id
 	const votedAt = NOW


### PR DESCRIPTION
## Descripción
A malicious user could do a call to `POST /api/votes/<combatId>` endpoint passing an arbitrary boxer id, i.e voting `guanyar` in `1-agustin-51-vs-carreraaa` combat.
To mitigate this issue, we can implement filtering on the `voteId` from combat boxers' IDs. This would prevent the submission or voting of any arbitrary boxer ID that isn't associated with the specified combat.

## Problema solucionado

 Fix bug when passing an unrelated boxer id as a `voteId` to `POST /api/votes/<combatId>` endpoint. 

## Cambios propuestos

Filter `voteId` from combat boxers ids to prevent passing or voting an arbitrary boxer id not related to the given combat

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

<!-- Describa cualquier impacto potencial que estos cambios puedan tener, como posibles problemas de compatibilidad o cambios en el rendimiento. -->

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
