### PR TITLE
fix(#951): fixed `voteId` filtering for `POST /api/votes/<combatId>`

### DIFF
--- a/src/pages/api/votes/[combatId].ts
+++ b/src/pages/api/votes/[combatId].ts
@@ -34,11 +34,10 @@ export const POST: APIRoute = async ({ params, request }) => {
 	if (!success) return res("Bad request", { status: 400 })
 
 	const { voteId } = output
-	let boxerData;
+	let boxerData: string | undefined
 	if (combatData.teams !== undefined) {
 		boxerData = combatData.teams.find((t) => t === voteId)
-	}
-	else {
+	} else {
 		boxerData = combatData.boxers.find((b) => b === voteId)
 	}
 	if (!boxerData) return res("Boxer not found", { status: 404 })

--- a/src/pages/api/votes/[combatId].ts
+++ b/src/pages/api/votes/[combatId].ts
@@ -34,7 +34,12 @@ export const POST: APIRoute = async ({ params, request }) => {
 	if (!success) return res("Bad request", { status: 400 })
 
 	const { voteId } = output
-	const boxerData = combatData.boxers.find((b) => b === voteId)
+	const boxerData = combatData.boxers.find((b) => {
+		if (combatData.teams !== undefined) {
+			return voteId.includes(b)
+		}
+		return b === voteId
+	})
 	if (!boxerData) return res("Boxer not found", { status: 404 })
 
 	const userId = session.user.id

--- a/src/pages/api/votes/[combatId].ts
+++ b/src/pages/api/votes/[combatId].ts
@@ -34,12 +34,13 @@ export const POST: APIRoute = async ({ params, request }) => {
 	if (!success) return res("Bad request", { status: 400 })
 
 	const { voteId } = output
-	const boxerData = combatData.boxers.find((b) => {
-		if (combatData.teams !== undefined) {
-			return voteId.includes(b)
-		}
-		return b === voteId
-	})
+	let boxerData;
+	if (combatData.teams !== undefined) {
+		boxerData = combatData.teams.find((t) => t === voteId)
+	}
+	else {
+		boxerData = combatData.boxers.find((b) => b === voteId)
+	}
 	if (!boxerData) return res("Boxer not found", { status: 404 })
 
 	const userId = session.user.id


### PR DESCRIPTION
## Descripción

Al hacer click en el combate 2v2 en <https://lavelada.es/pronosticos>. Se producía un error por el filtrado, introducido en la PR #947, a la hora de hacer `POST /api/votes/<combatId>`.

## Problema solucionado

Fixes #951 

## Cambios propuestos

1. Mantener filtrado si no es 2v2
2. Si es 2v2, ver si el boxeador a filtrar se encuentra en `voteId`.

## Capturas de pantalla (si corresponde)

https://github.com/midudev/la-velada-web-oficial/assets/71392160/26130211-c29e-427c-a04b-27f91a20ca10

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
