### PR TITLE
fix: boxer clips text overflow hidden on desktop

### DIFF
--- a/src/components/BoxerClips.astro
+++ b/src/components/BoxerClips.astro
@@ -15,7 +15,7 @@ const hasClips = clips.length > 0
 
 {
 	hasClips && (
-		<section class="z-20 mx-auto mt-2 max-w-96 overflow-x-hidden py-5 md:mt-0">
+		<section class="z-20 mx-auto mt-2 max-w-96 overflow-x-hidden py-5 md:mt-0 md:overflow-x-visible">
 			<ClipsModal />
 			<div class="carousel flex select-none flex-row flex-nowrap items-center transition duration-700 md:max-w-none md:!translate-x-0 md:flex-wrap md:place-content-center md:gap-4">
 				{clips.map(({ text, url }) => (


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
Se hace visible el `overflow-x` del section que contiene los textos de los clips de los boxeadores en desktop, para evitar que el texto se corte al hacer `:hover` e incluso sin hacer `:hover` en algunos casos; En mobile se mantiene ya que tiene sentido 🤓.

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

Antes: 
![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/adc50947-68df-4a27-8084-a79bebce4925)

Después:
![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/9b31e817-2909-4205-9878-daa7c5b91ecd)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
