### PR TITLE
fix: background (noise and lights) with dvh

### DIFF
--- a/src/components/LightsBackground.astro
+++ b/src/components/LightsBackground.astro
@@ -1,4 +1,5 @@
-<div class="fixed -z-50 h-full w-full bg-no-repeat opacity-50 blur-sm md:opacity-30"></div>
+<div class="fixed inset-x-0 top-0 -z-50 h-screen bg-no-repeat opacity-50 blur-sm md:opacity-30">
+</div>
 
 <style>
 	div {

--- a/src/components/NoiseBackground.astro
+++ b/src/components/NoiseBackground.astro
@@ -1,4 +1,4 @@
-<div class="fixed inset-0 -z-30 m-auto bg-black/10">
+<div class="fixed inset-x-0 top-0 -z-30 h-screen bg-black/10">
 	<svg fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true"></svg>
 </div>
 


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
Se hace que el background no se reposicione en los dispositivos con viewport dinámico.

## Cambios propuestos

<!-- Enumere los cambios específicos que ha realizado en el código, incluidas las nuevas características agregadas, las modificaciones existentes y cualquier eliminación de código. Proporcione una explicación clara de los cambios y su propósito. -->
Se da altura explicita de `100vh` a los elementos parte del background (Noise and Lights)

## Capturas de pantalla (si corresponde)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->
Estado inicial:
![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/57c58508-34fa-44c5-a10e-289f100cccc4)

Al hacer scroll (Antes):
![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/200cc879-e40f-4670-a42c-069157575c6a)

Al hacer scroll (Despúes):
![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/cb0310ff-6cc5-4f95-b72d-4dc251f8cb2e)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.