### PR TITLE
Add speculation rules

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -167,5 +167,15 @@ const { title, description, preload, canonical, image } = Astro.props
 				pointer-events: all;
 			}
 		</style>
+		<script type="speculationrules">
+			{
+			  "prerender": [{
+				"where": {
+				  "href_matches": "/*"
+				},
+				"eagerness": "moderate"
+			  }]
+			}
+		</script>
 	</body>
 </html>


### PR DESCRIPTION
## Descripción

Se añade reglas de especulación para una navegación interna instantánea
## Cambios propuestos

Prerender a todos los links en modo moderado ( al hacer hover por +0.2s )

```js
<script type="speculationrules">
	{
			"prerender": [{
		"where": {
				"href_matches": "/*"
		},
		"eagerness": "moderate"
			}]
	}
</script>
```

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Enlaces útiles

Documentación Chrome for Developers [Prerender pages in Chrome](https://developer.chrome.com/docs/web-platform/prerender-pages?hl=es-419)

