### PR TITLE
fix: ForecastBoxer texts overflow

### DIFF
--- a/src/components/ForecastBoxer.astro
+++ b/src/components/ForecastBoxer.astro
@@ -13,30 +13,33 @@ const { image, imageAlt, boxerId, boxerName, boxerHref, isSmall = false } = Astr
 
 <a
 	href={boxerHref}
-	class="group overflow-hidden transition-transform hover:scale-105"
+	class:list={[
+		"group relative transition-transform hover:scale-105 ",
+		isSmall ? "pb-[68px]" : "pb-[72px] md:pb-[96px]",
+	]}
 	aria-label={`Ir a la página de ${boxerName}`}
 >
 	<article>
 		<img decoding="async" class="image" src={image} alt={imageAlt} />
-		<h3
-			class:list={[
-				"text-center font-medium uppercase text-white transition-transform group-hover:scale-125 md:group-hover:scale-150",
-				isSmall && "text-lg",
-				!isSmall && "text-2xl",
-			]}
-		>
-			{boxerName}
-		</h3>
-		<h4
-			data-id={boxerId}
-			class:list={[
-				"boxer-forecast mt-1 text-center font-semibold text-accent transition-transform group-hover:scale-75",
-				isSmall && "text-3xl",
-				!isSmall && "text-6xl",
-			]}
-		>
-			&nbsp;
-		</h4>
+		<div class="absolute bottom-0 left-2/4 -translate-x-2/4 text-center">
+			<h3
+				class:list={[
+					"text-nowrap font-medium uppercase text-white transition-transform group-hover:scale-110 md:group-hover:scale-150",
+					isSmall ? "text-lg" : "text-2xl",
+				]}
+			>
+				{boxerName}
+			</h3>
+			<h4
+				data-id={boxerId}
+				class:list={[
+					"boxer-forecast mt-1 text-3xl font-semibold text-accent transition-transform group-hover:scale-75",
+					!isSmall && "md:text-6xl",
+				]}
+			>
+				&nbsp;
+			</h4>
+		</div>
 	</article>
 </a>
 


### PR DESCRIPTION
## Descripción

<!-- Describa brevemente los cambios realizados en esta solicitud de extracción. -->
Se corrige contenido cortado en el componente `ForecastBoxer`

## Cambios propuestos

Se remueve el `overflow-hidden` del `wrapper` para evitar que se corte el contenido que sobresale o que puede llegar a sobresalir, en este caso, el nombre del boxeador y el porcentaje. El `overflow-hidden` se usaba para mantener el `aspect-ratio` de la imagen del boxeador, ya que la imagen crecía con el contenido. Para solucionar esto, se usa `absolute` en el contenedor del título y porcentaje, posicionándolo debajo y al centro de la imagen, y se agrega al `wrapper` un `pb-[content-height]`. De esta manera, al "no tener" el contenido en el `wrapper`, la imagen mantiene su aspect ratio y el contenido no se corta.

## Capturas de pantalla

Antes:

![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/dc5b62c5-32bb-4d88-804d-8da0d50568e3)

Después:

![image](https://github.com/midudev/la-velada-web-oficial/assets/79766563/a1c75c25-6e7e-4cdb-beab-775f482e8b0b)

<!-- Si los cambios afectan la apariencia visual de la landing page, incluya capturas de pantalla antes y después, si es posible. -->

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
