### PR TITLE
Update Promotions.astro

### DIFF
--- a/src/sections/Promotions.astro
+++ b/src/sections/Promotions.astro
@@ -8,7 +8,7 @@ import Typography from "@/components/Typography.astro"
 	</Typography>
 	<div class="mt-10 flex flex-col gap-y-10">
 		<a
-			class="mx-auto w-full transition hover:scale-105 hover:contrast-125"
+			class="mx-auto w-full transition-[0.6s] hover:scale-105 hover:contrast-125"
 			href="https://www.instagram.com/ganasdevicio"
 			target="_blank"
 			rel="noopener"
@@ -22,7 +22,7 @@ import Typography from "@/components/Typography.astro"
 			/>
 		</a>
 		<a
-			class="mx-auto w-full transition hover:scale-105 hover:contrast-125"
+			class="mx-auto w-full transition-[0.6s] hover:scale-105 hover:contrast-125"
 			href="https://revolut.onelink.me/qn5U/velada"
 			target="_blank"
 			rel="noopener"
@@ -36,7 +36,7 @@ import Typography from "@/components/Typography.astro"
 			/>
 		</a>
 		<a
-			class="mx-auto w-full transition hover:scale-105 hover:contrast-125"
+			class="mx-auto w-full transition-[0.6s] hover:scale-105 hover:contrast-125"
 			href="https://bit.ly/4ap0ibz"
 			target="_blank"
 			rel="noopener"


### PR DESCRIPTION
Se aumentó el tiempo de transición para el hover de 250 a 500ms para evitar que se vea tan brusco el scale.

## Descripción

El scale de las imágenes de promoción se llega a ver un poco rápido, por lo que se aumentó al doble, el tiempo de transición.

## Problema solucionado

No es un problema, es solo una recomendación para mejorar la UX.

## Cambios propuestos

1. Cambiar la transición por defecto (250ms) a (500ms).

## Capturas de pantalla (si corresponde)

![imagen](https://github.com/midudev/la-velada-web-oficial/assets/128250217/3e80fecf-6bc9-443c-8e85-52d6647545d0)


## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.