### PR TITLE
fix(pronósticos): images in mobile with no `mask-image`

### DIFF
--- a/src/components/Pronosticos/Vote.astro
+++ b/src/components/Pronosticos/Vote.astro
@@ -169,6 +169,7 @@ votes.forEach((vote) => {
 							]}
 							src={`https://cdn.lavelada.dev/matches/title-${combat.id}.webp`}
 							alt={`Fotografía del combate entre ${boxerNames.join(", ")}`}
+							style="mask-image: linear-gradient(black 80%, transparent)"
 						/>
 						<button
 							class:list={[

--- a/src/sections/Combat.astro
+++ b/src/sections/Combat.astro
@@ -66,6 +66,7 @@ const boxerNames = combatData?.boxers ?? []
 						class="inset-0 h-auto max-h-96 w-full max-w-80 scale-100 object-contain sm:scale-110 lg:max-w-3xl"
 						src={`https://cdn.lavelada.dev/matches/title-${combatId}.webp`}
 						alt={`Fotografía del combate entre ${boxerNames.join(", ")}`}
+						style="mask-image: linear-gradient(black 80%, transparent)"
 					/>
 				) : (
 					<Typography


### PR DESCRIPTION
## Descripción

Las imágenes en la sección de `Pronósticos` en dispositivos móviles, no correspondían con el diseño general de `Combates` o `Pronósticos` en dispositivos de escritorio.

## Problema solucionado

Incluir `mask-image` en las imágenes.

## Cambios propuestos

1. Añadir `style="mask-image: ..."` a los componentes `Image`.

## Capturas de pantalla (si corresponde)

- Antes:
![Screenshot 2024-06-18 at 11 49 57](https://github.com/midudev/la-velada-web-oficial/assets/71392160/23add646-f8ff-4585-ba28-cc4bead9dc81)

- Después:
![Screenshot 2024-06-18 at 11 50 05](https://github.com/midudev/la-velada-web-oficial/assets/71392160/651f6dc5-3174-4705-bc5f-3707c202f78d)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejorar la coherencia en la UI.

## Contexto adicional

<!-- Agregue cualquier contexto adicional que considere relevante para esta solicitud de extracción. -->

## Enlaces útiles

- Documentación del proyecto: <!-- Enlace a la documentación del proyecto, si está disponible. -->
- Código de referencia: <!-- Enlace al código de referencia o a la sección relevante del código fuente, si es aplicable. -->
