### PR TITLE
feat: Add "Ver combate" button to Combates page

### DIFF
--- a/src/consts/combats.ts
+++ b/src/consts/combats.ts
@@ -8,6 +8,7 @@ export const COMBATS: Combat[] = [
 		boxers: ["carreraaa", "agustin-51"],
 		titleSize: [1920, 1012],
 		title: "Agustin 51 vs Carreraaa",
+		videoUrl: "https://www.youtube.com/watch?v=IPbkwObKdlU",
 	},
 	{
 		id: "2-guanyar-vs-la-cobra",
@@ -15,6 +16,7 @@ export const COMBATS: Combat[] = [
 		boxers: ["guanyar", "la-cobra"],
 		titleSize: [1920, 927],
 		title: "Guanyar vs La Cobra",
+		videoUrl: "https://www.youtube.com/watch?v=jdchidzFY6Y",
 	},
 	{
 		id: "3-zeling-y-nissaxter-vs-alana-y-ama-blitz",
@@ -23,6 +25,7 @@ export const COMBATS: Combat[] = [
 		teams: ["zeling-nissaxter", "alana-ama-blitz"],
 		titleSize: [1525, 1525],
 		title: "Zeling y Nissaxter vs Alana y Ama Blitz",
+		videoUrl: "https://www.youtube.com/watch?v=yF-ahJkOYyI",
 	},
 	{
 		id: "4-viruzz-vs-shelao",
@@ -30,6 +33,7 @@ export const COMBATS: Combat[] = [
 		boxers: ["viruzz", "shelao"],
 		titleSize: [1623, 1077],
 		title: "Viruzz vs Shelao",
+		videoUrl: "https://www.youtube.com/watch?v=qW2lfuM8uH4",
 	},
 	{
 		id: REY_DE_LA_PISTA_ID,
@@ -48,6 +52,7 @@ export const COMBATS: Combat[] = [
 		],
 		titleSize: [1185, 1139],
 		title: "Rey de la Pista",
+		videoUrl: "https://www.youtube.com/watch?v=m8Is6KAYIZ4",
 	},
 	{
 		id: "6-el-mariana-vs-plex",
@@ -55,5 +60,6 @@ export const COMBATS: Combat[] = [
 		boxers: ["plex", "el-mariana"],
 		titleSize: [1920, 950],
 		title: "El Mariana vs Plex",
+		videoUrl: "https://www.youtube.com/watch?v=WnryYJ0k-_0",
 	},
 ]

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -1,6 +1,7 @@
 ---
 import { Image } from "astro:assets"
 
+import Action from "@/components/Action.astro"
 import BackgroundVideo from "@/components/Combates/BackgroundVideo.astro"
 import { COMBATS, REY_DE_LA_PISTA_ID } from "@/consts/combats"
 import Layout from "@/layouts/Layout.astro"
@@ -35,7 +36,7 @@ if (!combatData) {
 	}
 }
 
-const { teams, boxers } = combatData
+const { teams, boxers, videoUrl } = combatData
 const [slug1, slug2] = teams ?? boxers
 const [image1, image2] = [
 	{ alt: slug1.replaceAll("-", " "), src: createImgRoute(combatData.number, slug1) },
@@ -102,6 +103,19 @@ export const prerender = true
 			{combatData.boxers.length <= 4 && <CombatFeatures boxerIds={combatData.boxers} />}
 		</div>
 		<Forecasts combatId={id} />
+
+		<div class="action flex w-full flex-col items-center justify-center">
+			<Action
+				class="mt-20 w-full max-w-lg text-center text-base uppercase text-primary"
+				as="a"
+				href={videoUrl}
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label={`Ver combate entre ${boxerNames.join("y ")} en el canal de Ibai`}
+			>
+				¡Ver combate!
+			</Action>
+		</div>
 	</main>
 </Layout>
 

--- a/src/sections/Forecasts.astro
+++ b/src/sections/Forecasts.astro
@@ -1,5 +1,4 @@
 ---
-import Action from "@/components/Action.astro"
 import ForecastBoxer from "@/components/ForecastBoxer.astro"
 import Velocimetro from "@/components/Velocimetro.astro"
 import { BOXERS } from "@/consts/boxers"
@@ -41,16 +40,6 @@ const boxers = combat?.boxers.map((boxer) => BOXERS.find((b) => b.id === boxer))
 				/>
 			))}
 			</div>
-
-			<div class="action flex w-full flex-col items-center justify-center">
-				<Action
-					class="mt-20 w-full max-w-lg text-center text-base uppercase text-primary"
-					as="a"
-					href="/pronosticos"
-				>
-					¡Haz tu pronóstico!
-				</Action>
-			</div>
 	</section>
 }
 
@@ -86,16 +75,6 @@ const boxers = combat?.boxers.map((boxer) => BOXERS.find((b) => b.id === boxer))
 				boxerHref={"/boxers/alana"}
 				class:list={["boxer2"]}
 			/>
-
-		<div class="action flex w-full flex-col items-center justify-center">
-			<Action
-				class="mt-20 w-full max-w-lg text-center text-base uppercase text-primary"
-				as="a"
-				href="/pronosticos"
-			>
-				¡Haz tu pronóstico!
-			</Action>
-		</div>
 	</section>
 )}
 
@@ -132,15 +111,6 @@ const boxers = combat?.boxers.map((boxer) => BOXERS.find((b) => b.id === boxer))
 					class:list={["boxer2"]}
 				/>
 			)}
-			<div class="action flex w-full flex-col items-center justify-center">
-				<Action
-					class="mt-20 w-full max-w-lg text-center text-base uppercase text-primary"
-					as="a"
-					href="/pronosticos"
-				>
-					¡Haz tu pronóstico!
-				</Action>
-			</div>
 		</section>
 	)
 }

--- a/src/types/Combat.ts
+++ b/src/types/Combat.ts
@@ -5,4 +5,5 @@ export interface Combat {
 	teams?: string[]
 	titleSize: [number, number]
 	title: string
+	videoUrl: string
 }


### PR DESCRIPTION
## Descripción

Se agregó el botón "Ver Combate" en la página de los combates con el link directo al video de Youtube de cada combate. Además, se eliminó el botón "Haz tu pronóstico" puesto que una vez terminada la velada no hace mucho sentido que siga habiendo la posibilidad de hacer predicciones.

## Cambios propuestos

1. Añadir boton "Ver combate" con el link para el video correspondiende de YouTube de cada combate.
2. Retirar el boton de "Haz tu pronostico" en la pagina de cada combate.

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.
