### PR TITLE
Update event edition from La Velada 4 to La Velada 5 in h1

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -9,7 +9,7 @@ import { SPONSORS } from "@/consts/sponsors"
 		src="/img/background-la-velada.webp"
 		class="animate-fade-in pointer-events-none absolute top-0 z-0 h-screen w-screen object-cover"
 	/>
-	<h1 class="sr-only">Presentación de la Velada del Año IV</h1>
+	<h1 class="sr-only">Presentación de la Velada del Año V</h1>
 
 	<!-- Sponsors -->
 	<div


### PR DESCRIPTION
## Descripción

Se ha actualizado la edición del evento de "La Velada" de la 4 a la 5 en el h1 de la página principal.

## Problema solucionado

La web aún mencionaba "La Velada 4" en lugar de "La Velada 5", lo que puede afectar al SEO

## Cambios propuestos

- Se ha actualizado el texto del h1 donde se hacía referencia a "La Velada 4" por "La Velada 5"

## Capturas de pantalla (si corresponde)

## Comprobación de cambios

- [x] He revisado que no haya ninguna PR (pull request) ya abierta con un problema similar, siguiendo el apartado de [buenas prácticas](https://github.com/midudev/la-velada-web-oficial/blob/main/CONTRIBUTING.md#buenas-pr%C3%A1cticas-)
- [x] He revisado localmente los cambios para asegurarme de que no haya errores ni problemas.
- [x] He probado estos cambios en múltiples dispositivos y navegadores para asegurarme de que la landing page se vea y funcione correctamente.
- [x] He actualizado la documentación, si corresponde.

## Impacto potencial

Mejora del SEO

## Contexto adicional

## Enlaces útiles

- Documentación del proyecto:
- Código de referencia:
