### PR TITLE
Add custom colors to global styles based on La Velada del Año V color palette

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -29,6 +29,15 @@
   font-display: swap;
 }
 
+@theme{
+  /* Velada V Custom Colors */
+  --color-french-mauve:oklch(67.65% 0.1539 329.18);
+  --color-raisin-black:oklch(25.53% 0.0209 340.25);
+  --color-tickle-me-pink:oklch(75.65% 0.143 355.9);
+  --color-seashell:oklch(95.25% 0.0147 33.07);
+  --color-turquoise:oklch(82.97% 0.148864 181.7442);
+}
+
 html {
   font-family: 'Anisette', sans-serif;
 }


### PR DESCRIPTION
It extracts the most suitable colors from the original La Velada del Año V flyer and defines them in OKLCH format within the global styles, enabling seamless manipulation by Tailwind CSS.

![image](https://github.com/user-attachments/assets/93272cb9-62be-4665-b6b7-93f784e195ad)

