### PR TITLE
Fix font width of "Próximamente" in header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -20,7 +20,7 @@
         >COMPRA LAS <strong>ENTRADAS</strong>
         <span
           class="absolute top-4 inset-0 text-[10px] text-yellow-500 mt-1 text-center"
-          >Próximamente</span
+          >PRÓXIMAMENTE</span
         >
       </span>
     </div>


### PR DESCRIPTION
Arregla la anchura de la frase "Próximamente" en el header de la web

Comparación:
- Antes: 
![image](https://github.com/user-attachments/assets/2743d526-a528-4127-903c-f26d1369016a)
- Después: 
![image](https://github.com/user-attachments/assets/0542536b-08e5-4e77-9ac9-c593f540aac0)
