### PR TITLE
feat: apply grayscale to all cards except hovered one

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -3,7 +3,7 @@ const { id, name } = Astro.props
 ---
 
 <a
-  class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
+  class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden grayscale"
   href={`/luchador/${id}`}
   data-id={id}
 >
@@ -32,6 +32,8 @@ const { id, name } = Astro.props
           clearTimeout(timeoutId)
         }
 
+        singleBoxerCard.classList.remove("grayscale")
+
         const id = singleBoxerCard.getAttribute("data-id")
         if (id) {
           // Dispatch a custom event to notify a boxer card id is hovered
@@ -47,6 +49,7 @@ const { id, name } = Astro.props
           const event = new CustomEvent("boxer-card-exit")
           document.dispatchEvent(event)
         }, 500)
+        singleBoxerCard.classList.add("grayscale")
       })
     })
   })


### PR DESCRIPTION
feat(boxer-cards): implement grayscale effect

- Apply grayscale filter to all cards by default
- Remove grayscale when a card is hovered
- Restore grayscale when mouse leaves

Note: Hi, it's my first time submitting a PR to a public repository, it's not a big change but I hope it can be useful.


