### PR TITLE
Mejora de las tarjetas de boxeadores con efectos visuales

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -3,22 +3,55 @@ const { id, name } = Astro.props
 ---
 
 <a
-  class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
+  class="boxer-card inline-block transition-all w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded-lg overflow-hidden duration-300 hover:-translate-y-3 hover:scale-105 hover:shadow-lg hover:z-20"
   href={`/luchador/${id}`}
   data-id={id}
 >
-  <img
-    class="aspect-[900/1200] h-full w-full object-cover"
-    src={`/images/fighters/cards/${id}.png`}
-    alt={`Tarjeta del boxeador ${name}`}
-  />
+  <div class="relative overflow-hidden">
+    <img
+      class="aspect-[900/1200] h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+      src={`/images/fighters/cards/${id}.png`}
+      alt={`Tarjeta del boxeador ${name}`}
+    />
+
+    <div
+      class="absolute inset-0 bg-gradient-to-tr from-transparent via-white/20 to-transparent -translate-x-full group-hover:translate-x-full transition-transform duration-700 ease-in-out"
+    >
+    </div>
+
+    <div
+      class="absolute inset-0 border-0 group-hover:border-2 border-theme-tickle-me-pink/70 rounded-lg transition-all duration-300 opacity-0 group-hover:opacity-100"
+    >
+    </div>
+  </div>
 
   <div
-    class="absolute inset-0 flex flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-transparent to-transparent p-1 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+    class="absolute inset-0 flex flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-pink-950/40 to-transparent p-2 opacity-0 group-hover:opacity-100 transition-all duration-300 translate-y-2 group-hover:translate-y-0"
   >
-    <h3 class="text-theme-tickle-me-pink text-sm">{name}</h3>
+    <h3
+      class="text-theme-tickle-me-pink text-sm font-bold tracking-wide drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
+    >
+      {name}
+    </h3>
+  </div>
+
+  <div
+    class="absolute -bottom-1 left-1/2 transform -translate-x-1/2 w-0 h-1 bg-theme-tickle-me-pink rounded-t-md group-hover:w-2/3 transition-all duration-300"
+  >
   </div>
 </a>
+
+<style>
+  @media (prefers-reduced-motion) {
+    .boxer-card,
+    .boxer-card:hover,
+    .boxer-card img,
+    .boxer-card div {
+      transition: opacity 0.3s ease !important;
+      transform: none !important;
+    }
+  }
+</style>
 
 <script>
   document.addEventListener("astro:page-load", () => {
@@ -29,6 +62,7 @@ const { id, name } = Astro.props
       singleBoxerCard.addEventListener("mouseenter", () => {
         if (timeoutId) {
           clearTimeout(timeoutId)
+          timeoutId = null
         }
 
         const id = singleBoxerCard.getAttribute("data-id")
@@ -42,6 +76,23 @@ const { id, name } = Astro.props
       })
 
       singleBoxerCard.addEventListener("mouseleave", () => {
+        timeoutId = setTimeout(() => {
+          const event = new CustomEvent("boxer-card-exit")
+          document.dispatchEvent(event)
+        }, 500)
+      })
+
+      singleBoxerCard.addEventListener("focus", () => {
+        const id = singleBoxerCard.getAttribute("data-id")
+        if (id) {
+          const event = new CustomEvent("boxer-card-hovered", {
+            detail: { id },
+          })
+          document.dispatchEvent(event)
+        }
+      })
+
+      singleBoxerCard.addEventListener("blur", () => {
         timeoutId = setTimeout(() => {
           const event = new CustomEvent("boxer-card-exit")
           document.dispatchEvent(event)


### PR DESCRIPTION
## Descripción
Mejora las tarjetas de boxeadores con efectos visuales como escala y bordes brillantes, animación de brillo en hover y transiciones más suaves (movimiento reducido)

## Impacto
Mejora de la UX/UI

## Videos del antes y el después

### Antes
https://github.com/user-attachments/assets/1b0f94d6-5700-495d-a8a5-5811ce7bc1fb

### Después
https://github.com/user-attachments/assets/57078a59-b30a-4112-8d18-2842f3316d5e

