### PR TITLE
Feature/fix mouseleave

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -1,5 +1,5 @@
 ---
-const { id, name } = Astro.props
+const { id, name } = Astro.props;
 ---
 
 <a
@@ -21,32 +21,41 @@ const { id, name } = Astro.props
 </a>
 
 <script>
-  document.addEventListener("astro:page-load", () => {
-    const boxerCards = document.querySelectorAll(".boxer-card")
-    let timeoutId: number | null = null
+ document.addEventListener("astro:page-load", () => {
+  const boxerCards = document.querySelectorAll(".boxer-card")
+  let timeoutId: number | null = null
 
-    boxerCards.forEach((singleBoxerCard) => {
-      singleBoxerCard.addEventListener("mouseenter", () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId)
-        }
+  boxerCards.forEach((singleBoxerCard) => {
+    const handleMouseEnter = () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId)
+      }
 
-        const id = singleBoxerCard.getAttribute("data-id")
-        if (id) {
-          // Dispatch a custom event to notify a boxer card id is hovered
-          const event = new CustomEvent("boxer-card-hovered", {
-            detail: { id },
-          })
-          document.dispatchEvent(event)
-        }
-      })
+      const id = singleBoxerCard.getAttribute("data-id")
+      if (id) {
+        const event = new CustomEvent("boxer-card-hovered", {
+          detail: { id },
+        })
+        document.dispatchEvent(event)
+      }
+    }
 
-      singleBoxerCard.addEventListener("mouseleave", () => {
-        timeoutId = setTimeout(() => {
-          const event = new CustomEvent("boxer-card-exit")
-          document.dispatchEvent(event)
-        }, 500)
-      })
+    const handleMouseLeave = () => {
+      timeoutId = setTimeout(() => {
+        const event = new CustomEvent("boxer-card-exit")
+        document.dispatchEvent(event)
+      }, 500)
+    }
+
+    singleBoxerCard.addEventListener("mouseenter", handleMouseEnter)
+    singleBoxerCard.addEventListener("mouseleave", handleMouseLeave)
+
+    // Cleanup on component unmount
+    singleBoxerCard.addEventListener("remove", () => {
+      singleBoxerCard.removeEventListener("mouseenter", handleMouseEnter)
+      singleBoxerCard.removeEventListener("mouseleave", handleMouseLeave)
     })
   })
+})
+
 </script>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -1,7 +1,6 @@
 ---
-const { id, name } = Astro.props;
+const { id, name } = Astro.props
 ---
-
 <a
   class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
   href={`/luchador/${id}`}
@@ -21,41 +20,74 @@ const { id, name } = Astro.props;
 </a>
 
 <script>
- document.addEventListener("astro:page-load", () => {
-  const boxerCards = document.querySelectorAll(".boxer-card")
-  let timeoutId: number | null = null
+  document.addEventListener("astro:page-load", () => {
+    const boxerCards = document.querySelectorAll(".boxer-card");
+    let timeoutId: number | null = null;
 
-  boxerCards.forEach((singleBoxerCard) => {
-    const handleMouseEnter = () => {
-      if (timeoutId) {
-        clearTimeout(timeoutId)
-      }
+    const eventListeners = [];
 
-      const id = singleBoxerCard.getAttribute("data-id")
-      if (id) {
-        const event = new CustomEvent("boxer-card-hovered", {
-          detail: { id },
-        })
-        document.dispatchEvent(event)
-      }
-    }
+    boxerCards.forEach((singleBoxerCard) => {
+      // Flag to track if the card is clicked
+      let isClicked = false;
 
-    const handleMouseLeave = () => {
-      timeoutId = setTimeout(() => {
-        const event = new CustomEvent("boxer-card-exit")
-        document.dispatchEvent(event)
-      }, 500)
-    }
+      const mouseEnterHandler = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
 
-    singleBoxerCard.addEventListener("mouseenter", handleMouseEnter)
-    singleBoxerCard.addEventListener("mouseleave", handleMouseLeave)
+        const id = singleBoxerCard.getAttribute("data-id");
+        if (id) {
+          const event = new CustomEvent("boxer-card-hovered", {
+            detail: { id },
+          });
+          document.dispatchEvent(event);
+        }
+      };
 
-    // Cleanup on component unmount
-    singleBoxerCard.addEventListener("remove", () => {
-      singleBoxerCard.removeEventListener("mouseenter", handleMouseEnter)
-      singleBoxerCard.removeEventListener("mouseleave", handleMouseLeave)
-    })
-  })
-})
+      const mouseLeaveHandler = () => {
+        if (isClicked) {
+          return;
+        }
 
+        timeoutId = setTimeout(() => {
+          const event = new CustomEvent("boxer-card-exit");
+          document.dispatchEvent(event);
+        }, 500);
+      };
+
+      const clickHandler = () => {
+        isClicked = true;
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+      };
+
+      // Attach event listeners
+      singleBoxerCard.addEventListener("mouseenter", mouseEnterHandler);
+      singleBoxerCard.addEventListener("mouseleave", mouseLeaveHandler);
+      singleBoxerCard.addEventListener("click", clickHandler);
+
+      // Store references to the listeners for cleanup
+      eventListeners.push({
+        element: singleBoxerCard,
+        events: [
+          { type: "mouseenter", handler: mouseEnterHandler },
+          { type: "mouseleave", handler: mouseLeaveHandler },
+          { type: "click", handler: clickHandler },
+        ],
+      });
+    });
+
+    // Cleanup function for removing event listeners
+    const cleanupEventListeners = () => {
+      eventListeners.forEach(({ element, events }) => {
+        events.forEach(({ type, handler }) => {
+          element.removeEventListener(type, handler);
+        });
+      });
+    };
+
+    // Call cleanup on page unload or when Astro component is destroyed
+    window.addEventListener("beforeunload", cleanupEventListeners);
+  });
 </script>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -1,6 +1,7 @@
 ---
-const { id, name } = Astro.props
+const { id, name } = Astro.props;
 ---
+
 <a
   class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
   href={`/luchador/${id}`}
@@ -22,36 +23,26 @@ const { id, name } = Astro.props
 <script>
   document.addEventListener("astro:page-load", () => {
     const boxerCards = document.querySelectorAll(".boxer-card");
-    let timeoutId: number | null = null;
-
+    let timeoutId = null;
     const eventListeners = [];
 
     boxerCards.forEach((singleBoxerCard) => {
-      // Flag to track if the card is clicked
-      let isClicked = false;
+      let isClicked = false; //para evitar que se dispare el evento mouseleave si se hizo click
 
       const mouseEnterHandler = () => {
         if (timeoutId) {
           clearTimeout(timeoutId);
         }
-
         const id = singleBoxerCard.getAttribute("data-id");
         if (id) {
-          const event = new CustomEvent("boxer-card-hovered", {
-            detail: { id },
-          });
-          document.dispatchEvent(event);
+          document.dispatchEvent(new CustomEvent("boxer-card-hovered", { detail: { id } }));
         }
       };
 
       const mouseLeaveHandler = () => {
-        if (isClicked) {
-          return;
-        }
-
+        if (isClicked) return;
         timeoutId = setTimeout(() => {
-          const event = new CustomEvent("boxer-card-exit");
-          document.dispatchEvent(event);
+          document.dispatchEvent(new CustomEvent("boxer-card-exit"));
         }, 500);
       };
 
@@ -62,12 +53,10 @@ const { id, name } = Astro.props
         }
       };
 
-      // Attach event listeners
       singleBoxerCard.addEventListener("mouseenter", mouseEnterHandler);
       singleBoxerCard.addEventListener("mouseleave", mouseLeaveHandler);
       singleBoxerCard.addEventListener("click", clickHandler);
 
-      // Store references to the listeners for cleanup
       eventListeners.push({
         element: singleBoxerCard,
         events: [
@@ -78,7 +67,8 @@ const { id, name } = Astro.props
       });
     });
 
-    // Cleanup function for removing event listeners
+
+    //limpiar los eventos para evitar memory leak
     const cleanupEventListeners = () => {
       eventListeners.forEach(({ element, events }) => {
         events.forEach(({ type, handler }) => {
@@ -87,7 +77,6 @@ const { id, name } = Astro.props
       });
     };
 
-    // Call cleanup on page unload or when Astro component is destroyed
     window.addEventListener("beforeunload", cleanupEventListeners);
   });
 </script>


### PR DESCRIPTION
En desktop cuando se hace click en la card del luchador, se ejecuta el timeout de mouseleave, por lo que cuando la imagen se abre en la pagina siguiente, desaparece despues de los 500ms.  He modificado bastante el codigo, para hacer track del click, y evitar el mouseout. Quizas hay otra manera mas eficiente de hacerlo

Tambien agregue event listener cleanups para evitar memory leaks

Sorry, he tenido que modificar bastante el codigo original