### PR TITLE
feature: boxer cards entrance animation

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -101,15 +101,15 @@ const secondRow = FIGHTERS.slice(6)
       class="relative flex flex-col items-center justify-end p-8 h-full w-full max-w-6xl gap-4"
     >
       <div class="flex flex-wrap justify-between w-full px-4">
-        <div class="flex flex-wrap justify-start gap-4 animate-fade-in-right animate-delay-500">
+        <div class="flex flex-wrap justify-start gap-4">
           {leftRow.map(({ id, name }) => <BoxerCard id={id} name={name} />)}
         </div>
-        <div class="flex flex-wrap justify-end gap-4 animate-fade-in-left animate-delay-500">
+        <div class="flex flex-wrap justify-end gap-4">
           {rightRow.map(({ id, name }) => <BoxerCard id={id} name={name} />)}
         </div>
       </div>
 
-      <div class="flex flex-wrap justify-between gap-4 animate-fade-in-up animate-delay-700">
+      <div class="flex flex-wrap justify-between gap-4">
         {secondRow.map(({ id, name }) => <BoxerCard id={id} name={name} />)}
       </div>
     </div>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -101,15 +101,15 @@ const secondRow = FIGHTERS.slice(6)
       class="relative flex flex-col items-center justify-end p-8 h-full w-full max-w-6xl gap-4"
     >
       <div class="flex flex-wrap justify-between w-full px-4">
-        <div class="flex flex-wrap justify-start gap-4">
+        <div class="flex flex-wrap justify-start gap-4 animate-fade-in-right animate-delay-500">
           {leftRow.map(({ id, name }) => <BoxerCard id={id} name={name} />)}
         </div>
-        <div class="flex flex-wrap justify-end gap-4">
+        <div class="flex flex-wrap justify-end gap-4 animate-fade-in-left animate-delay-500">
           {rightRow.map(({ id, name }) => <BoxerCard id={id} name={name} />)}
         </div>
       </div>
 
-      <div class="flex flex-wrap justify-between gap-4">
+      <div class="flex flex-wrap justify-between gap-4 animate-fade-in-up animate-delay-700">
         {secondRow.map(({ id, name }) => <BoxerCard id={id} name={name} />)}
       </div>
     </div>


### PR DESCRIPTION
Add an entrance animation to the boxer cards for a smoother loading and to match the logo animation style.

Before:

https://github.com/user-attachments/assets/f04869e0-557a-4033-9941-167f88d4e856

After:

https://github.com/user-attachments/assets/7670b6bb-6281-4e8c-8ab7-1a4ca93a7d29

NOTE: If it looks lag, it's not the animation, it's my screen recorder. 🥲