### PR TITLE
fix/Z order of fighter and background

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -21,7 +21,7 @@ export const prerender = false
       src={`/images/fighters/big/${id}.png`}
       alt={fighter?.name}
       decoding="async"
-      class="w-auto h-full"
+      class="w-auto h-full z-50"
       fetchpriority="low"
     />
   </section>


### PR DESCRIPTION
Se agrega z-index a los estilos de la imagen del luchador para evitar que se vea detras del background

Antes:
<img width="1470" alt="Captura de pantalla 2025-03-20 a la(s) 5 02 26 p m" src="https://github.com/user-attachments/assets/f53d8a88-0d87-4607-8207-4a2fcd0fde35" />

Despues:
<img width="1470" alt="Captura de pantalla 2025-03-20 a la(s) 5 02 34 p m" src="https://github.com/user-attachments/assets/02b0e2f2-4729-49ab-84a4-a09411cc93f5" />
