### PR TITLE
Responsive Sponsor layout: based on screen width

### DIFF
--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -7,9 +7,13 @@ const secondRow = SPONSORS.slice(5)
 
 <section id="sponsors" class="mx-auto max-w-xl py-36">
   <h2 class="mb-4 text-4xl font-light text-center text-dark-magenta">
-    <strong class="font-normal">Patrocinadores</strong> del evento
+    <div class="block sm:inline">
+      <strong class="font-normal">Patrocinadores</strong>
+    </div>
+    <div class="block sm:inline">del evento</div>
   </h2>
-  <div class="flex justify-around gap-4 flex-wrap w-full">
+  <div class="flex flex-row md:flex-col justify-evenly w-full p-5">
+  <div class="flex flex-col md:flex-row justify-around gap-4 flex-wrap items-center">
     {
       firstRow.map(({ url, image, name, label }) => (
         <a
@@ -27,7 +31,7 @@ const secondRow = SPONSORS.slice(5)
       ))
     }
   </div>
-  <div class="flex justify-around gap-4 w-full flex-wrap">
+  <div class="flex flex-col md:flex-row justify-around gap-4 items-center flex-wrap">
     {
       secondRow.map(({ url, image, name, label }) => (
         <a
@@ -45,4 +49,5 @@ const secondRow = SPONSORS.slice(5)
       ))
     }
   </div>
+</div>
 </section>

--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -12,8 +12,8 @@ const secondRow = SPONSORS.slice(5)
     </div>
     <div class="block sm:inline">del evento</div>
   </h2>
-  <div class="flex flex-row md:flex-col justify-evenly w-full p-5">
-  <div class="flex flex-col md:flex-row justify-around gap-4 flex-wrap items-center">
+  <div class="w-full flex justify-center items-center flex-col-reverse gap-8 md:flex-col md:gap-5 py-5">
+    <div class="w-1/2 flex flex-wrap justify-center gap-8 max-w-md md:flex-row md:w-[100%] md:justify-around md:gap-5">
     {
       firstRow.map(({ url, image, name, label }) => (
         <a
@@ -31,7 +31,7 @@ const secondRow = SPONSORS.slice(5)
       ))
     }
   </div>
-  <div class="flex flex-col md:flex-row justify-around gap-4 items-center flex-wrap">
+  <div class="w-1/2 flex flex-wrap justify-center gap-8 max-w-md md:flex-row md:w-[100%] md:justify-around md:gap-5">
     {
       secondRow.map(({ url, image, name, label }) => (
         <a

--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -13,7 +13,7 @@ const secondRow = SPONSORS.slice(5)
     <div class="block sm:inline">del evento</div>
   </h2>
   <div class="w-full flex justify-center items-center flex-col-reverse gap-8 md:flex-col md:gap-5 py-5">
-    <div class="w-1/2 flex flex-wrap justify-center gap-8 max-w-md md:flex-row md:w-[100%] md:justify-around md:gap-5">
+    <div class="w-1/2 flex flex-wrap justify-evenly gap-8 max-w-md md:flex-row md:w-[100%] md:justify-around md:gap-5">
     {
       firstRow.map(({ url, image, name, label }) => (
         <a
@@ -31,7 +31,7 @@ const secondRow = SPONSORS.slice(5)
       ))
     }
   </div>
-  <div class="w-1/2 flex flex-wrap justify-center gap-8 max-w-md md:flex-row md:w-[100%] md:justify-around md:gap-5">
+  <div class="w-1/2 flex flex-wrap justify-evenly gap-8 max-w-md md:flex-row md:w-[100%] md:justify-around md:gap-5">
     {
       secondRow.map(({ url, image, name, label }) => (
         <a


### PR DESCRIPTION
## Mobile:
![image](https://github.com/user-attachments/assets/8c31406c-37ab-4b6e-aa2d-2e6f9e6132cb)

## Desktop:
![image](https://github.com/user-attachments/assets/599cc58b-ac8c-4380-9efc-7d334017a0d4)

--------------------

## Mobile sin cambios:

![image](https://github.com/user-attachments/assets/be542f8e-a7db-4611-800b-5effcca7bd08)

