### PR TITLE
Fix: It was not possible to access Ibai's Twitch anchor

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -14,11 +14,8 @@ const secondRow = FIGHTERS.slice(6)
   >
   </div>
 
-  <div class="relative flex flex-col items-center p-8 w-full text-center">
-    <div
-      id="landing"
-      class="absolute inset-0 flex flex-col items-center w-full py-32"
-    >
+  <div class="relative flex flex-col items-center w-full text-center">
+    <div id="landing" class="flex flex-col items-center w-full pt-32">
       <h3
         class="font-light text-theme-seashell leading-[100%] mt-4 animate-fade-in animate-delay-300"
       >
@@ -36,25 +33,24 @@ const secondRow = FIGHTERS.slice(6)
       </figure>
 
       <div class="relative">
-      <h3
-        class="font-light text-theme-seashell leading-[100%] mt-4 animate-fade-in animate-delay-500"
-      >
-        ESTADIO<br />LA CARTUJA,<br /><strong>SEVILLA</strong>
-      </h3>
-      <div class="absolute bg-pink-400/80 blur-2xl z-0 w-full h-full -inset-2"></div>
-      <h3
-        class="font-light text-theme-raisin-black leading-[100%] mt-4 animate-fade-in animate-delay-700"
-      >
-        </div>
+        <h3
+          class="font-light text-theme-seashell leading-[100%] mt-4 animate-fade-in animate-delay-500"
+        >
+          ESTADIO<br />LA CARTUJA,<br /><strong>SEVILLA</strong>
+        </h3>
+        <h3
+          class="font-light text-theme-raisin-black leading-[100%] mt-4 animate-fade-in animate-delay-700"
+        >
+        </h3>
         <a
           href="https://twitch.tv/ibai"
           rel="noopener noreferrer"
           target="_blank"
-          class="inline-block transition hover:scale-125"
+          class="text-theme-raisin-black inline-block transition hover:scale-125 hover:underline animate-fade-in animate-delay-800"
         >
           TWITCH.TV<br /><strong>IBAI</strong>
         </a>
-      </h3>
+      </div>
     </div>
 
     <div
@@ -98,7 +94,7 @@ const secondRow = FIGHTERS.slice(6)
     </div>
 
     <div
-      class="relative flex flex-col items-center justify-end p-8 h-full w-full max-w-6xl gap-4"
+      class="absolute bottom-0 flex flex-col items-center p-8 w-full max-w-6xl gap-4"
     >
       <div class="flex flex-wrap justify-between w-full px-4">
         <div class="flex flex-wrap justify-start gap-4">


### PR DESCRIPTION
The anchor was not accessible because another element was covering it. An animation and an underline have also been added to the anchor. Lastly, a pink background was removed because the text 'ESTADIO LA CARTUJA SEVILLA' was not clearly visible.

---

BEFORE: 

https://github.com/user-attachments/assets/18c165a1-036f-4830-8e96-d58df02fcfdc

---

AFTER:


https://github.com/user-attachments/assets/7856c09d-0880-4b4f-9dad-0631bbd81154
