### PR TITLE
Refactor: change hover card functionality to CSS only

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -3,7 +3,7 @@ const { id, name } = Astro.props
 ---
 
 <a
-  class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
+  class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group/card relative rounded overflow-hidden pointer-events-auto"
   href={`/luchador/${id}`}
   data-id={id}
 >
@@ -14,7 +14,7 @@ const { id, name } = Astro.props
   />
 
   <div
-    class="absolute inset-0 flex flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-transparent to-transparent p-1 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+    class="absolute inset-0 flex flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-transparent to-transparent p-1 opacity-0 group-hover/card:opacity-100 transition-opacity duration-300"
   >
     <h3 class="text-theme-tickle-me-pink text-sm">{name}</h3>
   </div>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -20,33 +20,3 @@ const { id, name } = Astro.props
   </div>
 </a>
 
-<script>
-  document.addEventListener("astro:page-load", () => {
-    const boxerCards = document.querySelectorAll(".boxer-card")
-    let timeoutId: number | null = null
-
-    boxerCards.forEach((singleBoxerCard) => {
-      singleBoxerCard.addEventListener("mouseenter", () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId)
-        }
-
-        const id = singleBoxerCard.getAttribute("data-id")
-        if (id) {
-          // Dispatch a custom event to notify a boxer card id is hovered
-          const event = new CustomEvent("boxer-card-hovered", {
-            detail: { id },
-          })
-          document.dispatchEvent(event)
-        }
-      })
-
-      singleBoxerCard.addEventListener("mouseleave", () => {
-        timeoutId = setTimeout(() => {
-          const event = new CustomEvent("boxer-card-exit")
-          document.dispatchEvent(event)
-        }, 500)
-      })
-    })
-  })
-</script>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -67,7 +67,7 @@ const secondRow = FIGHTERS.slice(6)
               src={`/images/fighters/text/${id}.png`}
               alt={name}
               decoding="async"
-              class="w-auto h-full absolute opacity-0 mask-fade-text transition-opacity duration-300 delay-300"
+              class="w-auto h-full absolute opacity-0 mask-fade-text transition-opacity duration-300"
               fetchpriority="low"
             />
           ))
@@ -85,7 +85,7 @@ const secondRow = FIGHTERS.slice(6)
               src={`/images/fighters/big/${id}.png`}
               alt={name}
               decoding="async"
-              class="w-auto h-full absolute opacity-0 transition-opacity duration-300 delay-500"
+              class="w-auto h-full absolute opacity-0 transition-opacity duration-300"
               fetchpriority="low"
             />
           ))

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -67,7 +67,7 @@ const secondRow = FIGHTERS.slice(6)
               src={`/images/fighters/text/${id}.png`}
               alt={name}
               decoding="async"
-              class="w-auto h-full absolute hidden mask-fade-text"
+              class="w-auto h-full absolute opacity-0 mask-fade-text transition-opacity duration-300 delay-300"
               fetchpriority="low"
             />
           ))
@@ -85,7 +85,7 @@ const secondRow = FIGHTERS.slice(6)
               src={`/images/fighters/big/${id}.png`}
               alt={name}
               decoding="async"
-              class="w-auto h-full absolute hidden"
+              class="w-auto h-full absolute opacity-0 transition-opacity duration-300 delay-500"
               fetchpriority="low"
             />
           ))
@@ -124,53 +124,12 @@ const secondRow = FIGHTERS.slice(6)
   }
 </style>
 
-<script>
-  document.addEventListener("astro:page-load", () => {
-    let currentFighterId: string | null = null
+<!-- /* Estilos para detectar hover en boxerCard y mostrar la imagen correspondiente */ -->
+<style is:inline set:html={FIGHTERS.map(({id}) => `
+  section:has(.boxer-card[data-id="${id}"]:hover) [data-id="hero-text-${id}"],
+  section:has(.boxer-card[data-id="${id}"]:hover) [data-id="hero-image-${id}"] {
+    opacity: 1;
+  }
+`).join('\n')}>
+</style>
 
-    document.addEventListener("boxer-card-exit", () => {
-      if (currentFighterId) {
-        document
-          .querySelector(`[data-id="hero-text-${currentFighterId}"]`)
-          ?.classList.add("hidden")
-
-        document
-          .querySelector(`[data-id="hero-image-${currentFighterId}"]`)
-          ?.classList.add("hidden")
-
-        currentFighterId = null
-      }
-    })
-
-    document.addEventListener("boxer-card-hovered", (event: Event) => {
-      const customEvent = event as CustomEvent<{ id: string }>
-      const id = customEvent.detail.id
-
-      // si el luchador que entras es el mismo que ya se muestra
-      // entonces no hacemos nada
-      if (currentFighterId === id) return
-
-      // si ya estamos mostrando un luchador, tenemos que ocultarlo
-      if (currentFighterId) {
-        document
-          .querySelector(`[data-id="hero-text-${currentFighterId}"]`)
-          ?.classList.add("hidden")
-
-        document
-          .querySelector(`[data-id="hero-image-${currentFighterId}"]`)
-          ?.classList.add("hidden")
-      }
-
-      // mostramos el luchador que quiere ver el usuario
-      document
-        .querySelector(`[data-id="hero-text-${id}"]`)
-        ?.classList.remove("hidden")
-
-      document
-        .querySelector(`[data-id="hero-image-${id}"]`)
-        ?.classList.remove("hidden")
-
-      currentFighterId = id
-    })
-  })
-</script>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -8,7 +8,7 @@ const rightRow = firstRow.slice(3)
 const secondRow = FIGHTERS.slice(6)
 ---
 
-<section class="relative flex min-h-screen w-full">
+<section class="relative flex min-h-screen w-full group pointer-events-none">
   <div
     class="bg-[url('/images/hero.png')] bg-cover bg-center w-full mask-fade-bottom absolute inset-0"
   >
@@ -17,7 +17,7 @@ const secondRow = FIGHTERS.slice(6)
   <div class="relative flex flex-col items-center p-8 w-full text-center">
     <div
       id="landing"
-      class="absolute inset-0 flex flex-col items-center w-full py-32"
+      class="absolute inset-0 flex flex-col items-center w-full py-32 group-hover:opacity-0 transition-opacity duration-300"
     >
       <h3
         class="font-light text-theme-seashell leading-[100%] mt-4 animate-fade-in animate-delay-300"
@@ -126,13 +126,9 @@ const secondRow = FIGHTERS.slice(6)
 
 <script>
   document.addEventListener("astro:page-load", () => {
-    const $landing = document.querySelector("#landing")
-
     let currentFighterId: string | null = null
 
     document.addEventListener("boxer-card-exit", () => {
-      $landing?.classList.remove("hidden")
-
       if (currentFighterId) {
         document
           .querySelector(`[data-id="hero-text-${currentFighterId}"]`)
@@ -164,8 +160,6 @@ const secondRow = FIGHTERS.slice(6)
           .querySelector(`[data-id="hero-image-${currentFighterId}"]`)
           ?.classList.add("hidden")
       }
-
-      $landing?.classList.add("hidden")
 
       // mostramos el luchador que quiere ver el usuario
       document


### PR DESCRIPTION
## ¿Qué se ha hecho en esta PR?

Se ha remplazado el JavaScript por CSS para la funcionalidad donde el **_hover_** sobre las cartas de boxeadores oculte el "**Landing**" y muestren la foto del boxeador.

---

## Tipo de cambio

Marca las opciones relevantes para esta PR:

- [ ] Corrección de errores (cambio no disruptivo que soluciona un problema)
- [ ] Nueva funcionalidad (cambio no disruptivo que añade una nueva funcionalidad)
- [x] Cambio disruptivo (corrección o funcionalidad que causa que una funcionalidad existente no funcione como se espera)
- [ ] Mejora de documentación

---

## ¿Se han realizado tests automáticos?

- [ ] Sí
- [x] No

---

## ¿Cuál es el comportamiento esperado tras el cambio?

Mantiene el comportamiento, mejorando el rendimiento y reduciendo la cantidad de JavaScript

---

## ¿Cómo se pueden testear las características introducidas en esta PR?

Ejecutando la aplicación, llendo al home y pasando el mouse sobre las cartas de boxeadores.

---

## Capturas de pantalla

### Funcionalidad

**Antes**

https://github.com/user-attachments/assets/b7af7c28-0820-408d-a6b9-687b62b23805 

**Después**

https://github.com/user-attachments/assets/60343a42-545e-4830-855f-ee2d8ffad6ed 

### Lighthouse

| Antes                   | Después                      |
|---------------------------------|---------------------------------|
| ![Lighthouse antes](https://github.com/user-attachments/assets/72ab7e4d-5369-4510-860b-3d1191ac0d4d) | ![Ligthhouse despues](https://github.com/user-attachments/assets/604eadcb-76d1-471f-b311-c54117c66e4f) |

### Rendimiento

| Antes                   | Después                      |
|---------------------------------|---------------------------------|
| ![Rendimiento antes](https://github.com/user-attachments/assets/85abff9f-a0cd-40e3-9f13-07be486a64b3) | ![Rendimiento despues](https://github.com/user-attachments/assets/76626af5-4447-46b9-8489-a8d4cfadfdd0) |

### Bundle

| Antes                   | Después                      |
|---------------------------------|---------------------------------|
| ![bundle antes](https://github.com/user-attachments/assets/63eca8d2-07dc-4513-a37b-48b70b6b5d3b) | ![bundle despues](https://github.com/user-attachments/assets/a9958228-f00b-4ba6-b431-a2979a258dee) |

---

## Enlaces adicionales

No hay enlaces adicionales.