### PR TITLE
Fix: Modificación de nombre de participantes debido a uppercase

### DIFF
--- a/src/consts/fighters.ts
+++ b/src/consts/fighters.ts
@@ -1,58 +1,58 @@
 export const FIGHTERS = [
   {
     id: 'peereira',
-    name: 'Peereira'
+    name: 'peereira'
   },
   {
     id: 'perxitaa',
-    name: 'Perxitaa'
+    name: 'perxitaa'
   },
   {
     id: 'abby',
-    name: 'Abby'
+    name: 'abby'
   },
   {
     id: 'roro',
-    name: 'Roro'
+    name: 'roro'
   },
   {
     id: 'gaspi',
-    name: 'Gaspi'
+    name: 'gaspi'
   },
   {
     id: 'rivaldios',
-    name: 'Rivaldios'
+    name: 'rivaldios'
   },
   {
     id: 'andoni',
-    name: 'Andoni'
+    name: 'andoni'
   },
   {
     id: 'viruzz',
-    name: 'Viruzz'
+    name: 'viruzz'
   },
   {
     id: 'alana',
-    name: 'Alana'
+    name: 'alana'
   },
   {
     id: 'grefg',
-    name: 'Grefg'
+    name: 'grefg'
   },
   {
     id: 'westcol',
-    name: 'Westcol'
+    name: 'westcol'
   },
   {
     id: 'arigeli',
-    name: 'Arigeli'
+    name: 'arigeli'
   },
   {
     id: 'tomas',
-    name: 'Tomas'
+    name: 'tomas'
   },
   {
     id: 'carlos',
-    name: 'Carlos'
+    name: 'carlos'
   }
 ]


### PR DESCRIPTION
Debido a que la fuente por defecto está en mayúsculas y el formato de las mayúsculas es distinto, cambié los nombres de los participantes de la Velada a minúsculas para que la fuente los convierta automáticamente en mayúsculas con su Uppercase integrado y así lograr un estilo más uniforme en las box cards.

Vista de los nombres antes:

https://github.com/user-attachments/assets/4ea78bb2-c781-4656-a503-403410db574e

Vista con el cambio de nombres a minúsculas para aprovechar el uppercase:

https://github.com/user-attachments/assets/689c5ef8-de1d-4f27-987b-d9bc7fc6f3a7

