### PR TITLE
fix z-index layering so gradient doesn’t block ibai twitch link

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -50,7 +50,7 @@ const secondRow = FIGHTERS.slice(6)
           href="https://twitch.tv/ibai"
           rel="noopener noreferrer"
           target="_blank"
-          class="inline-block transition hover:scale-125"
+          class="inline-block transition hover:scale-125 z-10"
         >
           TWITCH.TV<br /><strong>IBAI</strong>
         </a>


### PR DESCRIPTION
Se agregó un z-index al enlace de Twitch de Ibai para evitar que el gradiente lo cubriera.