### PR TITLE
Emparejamiento de boxeadores

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -58,7 +58,13 @@ const { id, name } = Astro.props
     const boxerCards = document.querySelectorAll(".boxer-card")
     let timeoutId: number | null = null
 
-    boxerCards.forEach((singleBoxerCard) => {
+    const pairings: Record<number, number> = {
+      0: 5, 1: 4, 2: 3, 6: 13, 7: 12, 8: 11, 9: 10,
+      5: 0, 4: 1, 3: 2, 13: 6, 12: 7, 11: 8, 10: 9
+    };
+
+
+    boxerCards.forEach((singleBoxerCard, index) => {
       singleBoxerCard.addEventListener("mouseenter", () => {
         if (timeoutId) {
           clearTimeout(timeoutId)
@@ -73,6 +79,16 @@ const { id, name } = Astro.props
           })
           document.dispatchEvent(event)
         }
+      // Aplicar la clase 'grayscale-100' a todas las tarjetas
+    boxerCards.forEach((card) => card.classList.add("grayscale-100"));
+
+    // Quitar la clase solo de la tarjeta sobre la que se está haciendo hover
+    singleBoxerCard.classList.remove("grayscale-100");
+    
+        // Quitar la clase también de su par si existe
+    if (pairings[index] !== undefined) {
+      boxerCards[pairings[index]].classList.remove("grayscale-100");
+    }
       })
 
       singleBoxerCard.addEventListener("mouseleave", () => {
@@ -80,6 +96,9 @@ const { id, name } = Astro.props
           const event = new CustomEvent("boxer-card-exit")
           document.dispatchEvent(event)
         }, 500)
+
+          // Restaurar la clase en todas las tarjetas cuando el mouse salga
+    boxerCards.forEach((card) => card.classList.remove("grayscale-100"));
       })
 
       singleBoxerCard.addEventListener("focus", () => {


### PR DESCRIPTION
Al hacer hover sobre un boxeador, los demás boxeadores pasan a escala de grises excepto su rival.

![lavelada](https://github.com/user-attachments/assets/7a5d4fe8-330f-4404-8931-9847e52faffd)

