### PR TITLE
Feature Mobile Hover

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -1,9 +1,9 @@
 ---
-const { id, name } = Astro.props
+const { id, name } = Astro.props;
 ---
 
 <a
-  class="boxer-card inline-block transition hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
+  class="boxer-card inline-block transition focus:-translate-y-3 hover:-translate-y-3 w-10 sm:w-14 md:w-16 lg:w-24 xl:w-26 group relative rounded overflow-hidden"
   href={`/luchador/${id}`}
   data-id={id}
 >
@@ -14,7 +14,7 @@ const { id, name } = Astro.props
   />
 
   <div
-    class="absolute inset-0 flex flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-transparent to-transparent p-1 opacity-0 group-hover:opacity-100 transition-opacity duration-300"
+    class="absolute inset-0 flex flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-transparent to-transparent p-1 opacity-0 group-focus:opacity-100 group-hover:opacity-100 transition-opacity duration-300"
   >
     <h3 class="text-theme-tickle-me-pink text-sm">{name}</h3>
   </div>
@@ -22,31 +22,78 @@ const { id, name } = Astro.props
 
 <script>
   document.addEventListener("astro:page-load", () => {
-    const boxerCards = document.querySelectorAll(".boxer-card")
-    let timeoutId: number | null = null
+    const boxerCards = document.querySelectorAll(".boxer-card");
+    let timeoutId: number | null = null;
 
+    function exitCardHover() {
+      timeoutId = setTimeout(() => {
+        const event = new CustomEvent("boxer-card-exit");
+        document.dispatchEvent(event);
+
+        if (document.activeElement instanceof HTMLElement) {
+          document.activeElement.blur();
+        }
+      }, 500);
+    }
     boxerCards.forEach((singleBoxerCard) => {
+      const id = singleBoxerCard.getAttribute("data-id");
+
       singleBoxerCard.addEventListener("mouseenter", () => {
         if (timeoutId) {
-          clearTimeout(timeoutId)
+          clearTimeout(timeoutId);
         }
 
-        const id = singleBoxerCard.getAttribute("data-id")
         if (id) {
           // Dispatch a custom event to notify a boxer card id is hovered
           const event = new CustomEvent("boxer-card-hovered", {
             detail: { id },
-          })
-          document.dispatchEvent(event)
+          });
+          document.dispatchEvent(event);
         }
-      })
+      });
 
       singleBoxerCard.addEventListener("mouseleave", () => {
-        timeoutId = setTimeout(() => {
-          const event = new CustomEvent("boxer-card-exit")
-          document.dispatchEvent(event)
-        }, 500)
-      })
-    })
-  })
+        exitCardHover();
+      });
+
+      // Funcion para simular el hover en mobile
+      function handleTouch(event: TouchEvent) {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+        const touch = event.touches[0];
+
+        const element = document.elementFromPoint(touch.clientX, touch.clientY);
+        const anchor = element?.closest("a");
+
+        const anchorId = anchor?.getAttribute("data-id");
+        if (!anchorId) {
+          exitCardHover();
+          return;
+        }
+
+        const customEvent = new CustomEvent("boxer-card-hovered", {
+          detail: { id: anchorId },
+        });
+        document.dispatchEvent(customEvent);
+        anchor?.focus();
+      }
+
+      singleBoxerCard.addEventListener("touchstart", function (event) {
+        handleTouch(event as TouchEvent);
+      });
+
+      singleBoxerCard.addEventListener("touchmove", function (event) {
+        handleTouch(event as TouchEvent);
+      });
+
+      singleBoxerCard.addEventListener("touchcancel", function (event) {
+        exitCardHover();
+      });
+
+      singleBoxerCard.addEventListener("touchend", function (event) {
+        exitCardHover();
+      });
+    });
+  });
 </script>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -25,6 +25,7 @@ const { id, name } = Astro.props;
     const boxerCards = document.querySelectorAll(".boxer-card");
     let timeoutId: number | null = null;
 
+    // funcion de salida del hover
     function exitCardHover() {
       timeoutId = setTimeout(() => {
         const event = new CustomEvent("boxer-card-exit");
@@ -56,41 +57,49 @@ const { id, name } = Astro.props;
         exitCardHover();
       });
 
-      // Funcion para simular el hover en mobile
+      // Funcion para simular el hover en mobile: MobileHover
       function handleTouch(event: TouchEvent) {
+        // eliminamos el timeout en cada movimiento
         if (timeoutId) {
           clearTimeout(timeoutId);
         }
         const touch = event.touches[0];
 
         const element = document.elementFromPoint(touch.clientX, touch.clientY);
+        // el elemento detectado es el div dentro del a por lo que buscamos su a correspondiente
         const anchor = element?.closest("a");
 
         const anchorId = anchor?.getAttribute("data-id");
         if (!anchorId) {
+          // si no se detecta id entonce eliminar el MobileHover
           exitCardHover();
           return;
         }
 
         const customEvent = new CustomEvent("boxer-card-hovered", {
+          // usamos el id dentro del a
           detail: { id: anchorId },
         });
         document.dispatchEvent(customEvent);
         anchor?.focus();
       }
 
+      // iniciamos el touch del MobileHover
       singleBoxerCard.addEventListener("touchstart", function (event) {
         handleTouch(event as TouchEvent);
       });
 
+      // movimiento mientras se toca para el MobileHover
       singleBoxerCard.addEventListener("touchmove", function (event) {
         handleTouch(event as TouchEvent);
       });
 
+      // cancelar el MobileHover en caso de que se cancele el touch
       singleBoxerCard.addEventListener("touchcancel", function (event) {
         exitCardHover();
       });
 
+      // finalizar el MobileHover cuando se levanta el dedo
       singleBoxerCard.addEventListener("touchend", function (event) {
         exitCardHover();
       });


### PR DESCRIPTION
Ya que para ver los luchadores usamos el hover, y además de que el click dirige a otra pagina, decidí implementar el manejo del del hover para dispositivos móviles incluyendo el focus. Se implementó gracias a los eventos táctiles (touchstart, touchmove y touchend) que simulan el efecto hover. Se añadió lógica para asegurar que el elemento actualmente enfocado se desenfoque correctamente al levantar el dedo o porque se canceló el touch por alguna razon.