### PR TITLE
Add exit animation on hover for fighters

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -121,11 +121,12 @@ const secondRow = FIGHTERS.slice(6)
       $landing?.classList.remove('hidden')
 
       if (currentFighterId) {
-        document.querySelector(`[data-id="hero-text-${currentFighterId}"]`)?.classList.add('hidden')
+        // Uso de animación para ocultar a los peleadores
+        document.querySelector(`[data-id="hero-text-${currentFighterId}"]`)?.classList.add("animate-zoom-out")
 
-        document
-          .querySelector(`[data-id="hero-image-${currentFighterId}"]`)
-          ?.classList.add('hidden')
+        document.querySelector(`[data-id="hero-image-${currentFighterId}"]`)?.classList.remove('animate-slide-up-fade')
+
+        document.querySelector(`[data-id="hero-image-${currentFighterId}"]`)?.classList.add('animate-fade-out-down')
 
         currentFighterId = null
       }
@@ -159,6 +160,14 @@ const secondRow = FIGHTERS.slice(6)
       $landing?.classList.add('hidden')
 
       // mostramos el luchador que quiere ver el usuario
+      document.querySelector(`[data-id="hero-text-${id}"]`)?.classList.add('hidden')
+
+      document.querySelector(`[data-id="hero-text-${id}"]`)?.classList.remove("animate-zoom-out")
+
+      document.querySelector(`[data-id="hero-image-${id}"]`)?.classList.add('hidden')
+
+      document.querySelector(`[data-id="hero-image-${id}"]`)?.classList.remove('animate-fade-out-down')
+
       document.querySelector(`[data-id="hero-text-${id}"]`)?.classList.remove('hidden')
 
       document.querySelector(`[data-id="hero-image-${id}"]`)?.classList.remove('hidden')


### PR DESCRIPTION
## Animación al salir de los peleadores

He implementado animaciones de salida para las imágenes de los peleadores al salir del hover, utilizando las animaciones de @midudev/tailwind-animations que ya estaban importadas. Esto complementa la animación de entrada y mejora la experiencia de usuario al tener un comportamiento más fluido y completo en ambas acciones: al pasar el ratón (hover) y al retirarlo.

> ### Video
https://github.com/user-attachments/assets/ba79583a-c49d-4504-a6ed-0592355bb44d



