### PR TITLE
fix/Fix issue not displaying fighter image in fighter page. Fix issue hiding fighter image in fighter page after page loads

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -80,7 +80,7 @@ const secondRow = FIGHTERS.slice(6)
               src={`/images/fighters/big/${id}.webp`}
               alt={name}
               decoding="async"
-              class="absolute hidden h-full w-full object-cover lg:object-contain"
+              class="absolute hidden h-full w-full object-cover lg:object-contain fighter-hero-preview"
               fetchpriority="low"
             />
           ))
@@ -124,7 +124,7 @@ const secondRow = FIGHTERS.slice(6)
         document.querySelector(`[data-id="hero-text-${currentFighterId}"]`)?.classList.add('hidden')
 
         document
-          .querySelector(`[data-id="hero-image-${currentFighterId}"]`)
+          .querySelector(`.fighter-hero-preview[data-id="hero-image-${currentFighterId}"]`)
           ?.classList.add('hidden')
 
         currentFighterId = null

--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -18,10 +18,10 @@ export const prerender = false
     <img
       transition:name={`image-${id}`}
       data-id={`hero-image-${id}`}
-      src={`/images/fighters/big/${id}.png`}
+      src={`/images/fighters/big/${id}.webp`}
       alt={fighter?.name}
       decoding="async"
-      class="w-auto h-full z-10 mask-fade-bottom"
+      class="w-auto max-w-1/3 h-full z-10 mask-fade-bottom"
       fetchpriority="low"
     />
   </section>


### PR DESCRIPTION
## Describe your changes
* Fix issue not displaying fighter image in fighter page.
* Fix issue hiding fighter image in fighter page after page loads

## Include a screenshot/video where applicable
To reproduce the issue, click any fighter to open their page, and the image fighter will not appear.
Once the image type is changed to be loaded, the image is hidden after the page loads, this PR fixes both issues.
Sorry, video is too heavy to be uploaded.

Fighter page with bug present:
![Bug present](https://github.com/user-attachments/assets/4a68f683-e192-4a8c-a715-e34681e519b6)

Fighter page with bug fixed:
![Bug fixed](https://github.com/user-attachments/assets/e3736e33-1be6-47a2-887a-746291679280)



## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
