### PR TITLE
Fix: La imagen ya no desaparece al navegar a la página del luchador

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -17,8 +17,8 @@ export const prerender = false
     </div>
     <img
       transition:name={`image-${id}`}
-      data-id={`hero-image-${id}`}
-      src={`/images/fighters/big/${id}.png`}
+      data-id={`detail-hero-image-${id}`}
+      src={`/images/fighters/big/${id}.webp`}
       alt={fighter?.name}
       decoding="async"
       class="w-auto h-full z-10 mask-fade-bottom"


### PR DESCRIPTION
## Describe your changes
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
La página del luchador contiene un bug debido al evento **boxer-card-exit** en Hero.astro. En este evento se añade la clase **hidden** a todas las etiquetas que tengan la propiedad **data-id** con valor **hero-image-[id]**, que es justo el mismo valor que tendrá la propiedad data-id de la etiqueta img en la páginad el luchador.

Para solucionarlo he añadido detail- al valor del data-id para que que no afecte lo realizado en el evento **boxer-card-exit**.

También he cambiado el formato de la imagen del **src** de **_png_** a _**webp**_ que son las que hay actualmente en /images/fighters/big.

**AVISO**: Este problema solo ocurría al acceder a la página del luchador desde index. Si se navega directamente a /luchador/[id] este problema no ocurre ya que el evento boxer-card-exit no se lanzaría.

## Include a screenshot/video where applicable
<!-- Please add screenshots to help explain your changes. Delete this section if not needed. -->
![preuba0](https://github.com/user-attachments/assets/153976ec-db52-4770-9e5d-1da08cbe7f17)
![prueba1](https://github.com/user-attachments/assets/14796b56-9932-4bca-8df0-2966ed1ccd53)


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
