### PR TITLE
feat:Title in 'combates' updated with dynamic fighters

### DIFF
--- a/src/consts/pageTitles.ts
+++ b/src/consts/pageTitles.ts
@@ -4,4 +4,6 @@ export const porra: string = `La Porra - ${fixedTitle}`
 
 export const combates: string = `Combates - ${fixedTitle}`
 
+export const combate = (fighter1: string | undefined, fighter2: string | undefined): string => `${fighter1} vs ${fighter2} - ${fixedTitle}`
+
 export const entradas: string = `Entradas - ${fixedTitle}`

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -3,6 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import { COMBATS } from '@/consts/combats'
 import { FIGHTERS } from '@/consts/fighters'
 import { countries } from '@/consts/countries'
+import { combate } from '@/consts/pageTitles'
 
 const { id } = Astro.params
 const combat = COMBATS.find((c) => c.id === id)
@@ -13,7 +14,7 @@ const fighter1Country = countries.find(c => c.id === fighter1?.country)
 const fighter2Country = countries.find(c => c.id === fighter2?.country)
 ---
 
-<Layout>
+<Layout title={combate(fighter1?.name, fighter2?.name)}> 
   <section class="relative flex min-h-screen w-full items-center justify-center p-6 text-white">
     <div class="mask-fade-bottom absolute inset-0 w-full bg-[url('/images/hero.avif')] bg-cover bg-center"></div>
     <div class="z-10 flex w-full max-w-5xl flex-col items-center">


### PR DESCRIPTION
## Describe your changes
In the `combates` page, I updated the Title adding the name of the two selected fighters and following the structure of the project.

## Include a screenshot/video where applicable
![Captura de pantalla 2025-03-26 183837](https://github.com/user-attachments/assets/f069343b-6a55-45f1-8468-766213d16b62)
![image](https://github.com/user-attachments/assets/ca509075-cef2-47a1-8286-11f372348eb2)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
