### PR TITLE
Fix card text

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -35,7 +35,7 @@ interface Props {
     class="absolute inset-0 flex translate-y-2 flex-col items-center justify-end bg-gradient-to-t from-pink-950/90 via-pink-950/40 to-transparent p-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100"
   >
     <h3
-      class="text-theme-tickle-me-pink text-xs font-semibold tracking-wide drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)] uppercase"
+      class="text-theme-tickle-me-pink text-xs text-center font-semibold tracking-wide drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)] transform-[scale(0.9)] uppercase"
     >
       {name}
     </h3>

--- a/src/components/FighterSelector.astro
+++ b/src/components/FighterSelector.astro
@@ -5,10 +5,7 @@ const { id, name, boxerCardClass } = Astro.props;
 ---
 
 <div>
-  <BoxerCard id={id} name={name} class:list={[
-    'peer',
-    boxerCardClass,
-  ]} />
+  <BoxerCard id={id} name={name} class={`peer ${boxerCardClass}`} />
   <div
     id='fighter-container'
     class='pointer-events-none absolute inset-0 flex-col items-center hidden peer-hover:flex peer-focus:flex peer-focus-visible:flex'


### PR DESCRIPTION
## Problema con la estética y legibilidad del texto dentro de las tarjetas

Se ajustó el estilo del texto dentro de las tarjetas de algunos luchadores para evitar que se viera demasiado pegado a los bordes. Se añadieron las siguientes modificaciones al `<h3>`:

- Se agregó `text-center` para centrar el texto.
- Se añadió `transform-[scale(0.9)]` para reducir ligeramente el tamaño del texto y mejorar la distribución dentro de la tarjeta.


**Antes:**

![Captura de pantalla 2025-03-26 173345](https://github.com/user-attachments/assets/a8cb68a3-c17b-4e80-8c77-4c7f34a87246)
![Captura de pantalla 2025-03-26 173328](https://github.com/user-attachments/assets/405b4459-59b1-4a80-98d5-9fdf04bd33c4)
![Captura de pantalla 2025-03-26 173338](https://github.com/user-attachments/assets/a28ea7e3-c694-4884-88f8-04f1f119fa2c)

**Después:**

![Captura de pantalla 2025-03-27 002630](https://github.com/user-attachments/assets/a097e0e3-a4b2-466c-8c1b-bc84f7611208)
![Captura de pantalla 2025-03-27 002641](https://github.com/user-attachments/assets/5e6933b9-4bff-4753-a457-e8077b851e54)
![Captura de pantalla 2025-03-27 002647](https://github.com/user-attachments/assets/7adec10e-08f8-46f3-9444-a2e3eb25430c)

### **Tipo de cambio**

✅ Bug fix (non-breaking change which fixes an issue)

Este cambio no afecta la funcionalidad del código, solo mejora la estética y legibilidad del texto dentro de las tarjetas.

---

## Solución error de tipado en clases
Se corrige el error de tipo y se asegura que las clases se apliquen correctamente formateado en string
**Antes**:
![Captura de pantalla 2025-03-27 000815](https://github.com/user-attachments/assets/9dc6d620-2b9a-4ed3-8235-3baac88f4ad4)

**Después**:

![Captura de pantalla 2025-03-27 000909](https://github.com/user-attachments/assets/73cd42d9-8025-4c5c-af99-a1e41fe919d0)



