### PR TITLE
fix(footer): improve responsiveness for larger screens

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,30 +1,26 @@
 ---
-import { SOCIAL } from "@/consts/social";
+import { SOCIAL } from '@/consts/social'
 ---
 
-<footer class="relative w-full h-[400px] pb-32">
+<footer class="relative min-h-[400px] w-full pb-32 2xl:mt-24 2xl:pb-96">
   <div
-    class="absolute inset-0 bg-cover bg-bottom bg-[url('/images/footer.webp')]
-    [mask-image:linear-gradient(transparent,black_50%)]"
+    class="absolute inset-0 bg-[url('/images/footer.webp')] bg-cover bg-bottom [mask-image:linear-gradient(transparent,black_50%)]"
   >
   </div>
 
-  <div
-    class="relative h-full flex flex-col justify-center items-center text-[#2a1f26]"
-  >
+  <div class="relative flex h-full flex-col items-center justify-center text-[#2a1f26]">
     <div class="footer-content">
       <p class="text-center lowercase">© 2025 La Velada del Año. Todos los derechos reservados.</p>
     </div>
 
-    <div class="flex flex-row gap-x-2 items-center justify-center mt-4">
-
+    <div class="mt-4 flex flex-row items-center justify-center gap-x-2">
       {
         SOCIAL.map(({ url, image, name, label }) => (
           <a
             href={url}
             target="_blank"
             aria-label={label ?? name}
-            class="hover:scale-125 transition flex items-center justify-center"
+            class="flex items-center justify-center transition hover:scale-125"
           >
             <image.logo />
           </a>


### PR DESCRIPTION
## Describe your changes
### Issue
When opening the page on bigger screens, the footer image disappeared as it grew. This issue was particularly evident on 2xl screens.

### Solution
To address this problem, the following changes were implemented:

1. Replaced `height` with `min-height` to allow the footer image to grow appropriately.
2. Added padding and margin specifically for 2xl screens where the issue was most noticeable.

### Impact
These changes ensure that the footer image remains visible and properly sized when scaling to bigger screens, improving the overall responsiveness of the footer component.

## Include a screenshot/video where applicable
![Before](https://github.com/user-attachments/assets/f2b4310b-49ee-447d-9149-3953f0b0ad2b)
![After](https://github.com/user-attachments/assets/dc49a0f7-8289-4c76-afcd-0c2e913ce681)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

