### PR TITLE
UX: Mejora la legibilidad de la selección de boxeadores

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -15,7 +15,7 @@ interface Props {
 >
   <div class="relative overflow-hidden rounded-lg">
     <img
-      class="aspect-[900/1200] h-full w-full object-cover transition-transform duration-500 group-hover:scale-110"
+      class="aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 via-40 to-transparent object-cover transition-transform duration-500 group-hover:scale-110"
       src={`/images/fighters/cards/${id}.webp`}
       alt={`Tarjeta del boxeador ${name}`}
     />
@@ -139,14 +139,14 @@ interface Props {
           document.dispatchEvent(event)
         }
         // Aplicar la clase 'grayscale-100' a todas las tarjetas
-        boxerCards.forEach((card) => card.classList.add('grayscale-100'))
+        boxerCards.forEach((card) => card.classList.add('grayscale-100', 'opacity-40'))
 
         // Quitar la clase solo de la tarjeta sobre la que se está haciendo hover
-        singleBoxerCard.classList.remove('grayscale-100')
+        singleBoxerCard.classList.remove('grayscale-100', 'opacity-40')
 
         // Quitar la clase también de su par si existe
         if (pairings[index] !== undefined) {
-          boxerCards[pairings[index]].classList.remove('grayscale-100')
+          boxerCards[pairings[index]].classList.remove('grayscale-100', 'opacity-40')
         }
       })
 
@@ -157,7 +157,7 @@ interface Props {
         }, 500)
 
         // Restaurar la clase en todas las tarjetas cuando el mouse salga
-        boxerCards.forEach((card) => card.classList.remove('grayscale-100'))
+        boxerCards.forEach((card) => card.classList.remove('grayscale-100', 'opacity-40'))
       })
 
       singleBoxerCard.addEventListener('focus', () => {


### PR DESCRIPTION
## Cambios:
- Agrega un background de base en las imágenes de los boxeadores.
- Reduce la opacidad de los boxeadores que no están en hover, excluyendo a la pareja del boxeador seleccionado

### Antes

https://github.com/user-attachments/assets/2664567a-d24f-4826-8035-811304931536

### Después

https://github.com/user-attachments/assets/87b99872-5e37-4cb9-ad96-970b59c6bd9d


