### PR TITLE
Fix timeout id card type

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -104,7 +104,7 @@ interface Props {
 <script>
   document.addEventListener('astro:page-load', () => {
     const boxerCards = document.querySelectorAll('.boxer-card')
-    let timeoutId: number | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const pairings: Record<number, number> = {
       0: 5,


### PR DESCRIPTION
## Corrección de tipo en timeoutId para compatibilidad con setTimeout
Se corrigió un error de tipado en la variable timeoutId, ya que setTimeout en entornos como Node.js devuelve un objeto Timeout, mientras que en navegadores devuelve un number. 
![image](https://github.com/user-attachments/assets/287bfeda-bc99-4f21-9a59-21e0e01c4c00)
La solución fue cambiar:

**Antes:**
```ts
let timeoutId: number | null = null;
```
Esto generaba el error:
> El tipo 'Timeout' no se puede asignar al tipo 'number'.

**Después:**
```ts
let timeoutId: ReturnType<typeof setTimeout> | null = null;
```
Este cambio asegura que `timeoutId` tenga el tipo correcto en cualquier entorno, evitando errores de asignación.
