### PR TITLE
Fix: Se muestra el logo en la pantalla de combates para mantener coherencia con el header

### DIFF
--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -2,7 +2,7 @@
 const { pathname } = Astro.url;
 
 // Lista de rutas donde NO debe aparecer el logo
-const hideLogoRoutes = ["/", "/combates"];
+const hideLogoRoutes = ["/"];
 const shouldShowLogo = !hideLogoRoutes.includes(pathname);
 ---
 

--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -13,25 +13,12 @@ import { combates } from '@/consts/pageTitles'
 
     <div class="flex w-full flex-col items-center text-center">
       <div id="landing" class="absolute top-0 flex w-full flex-col items-center py-30">
-        <figure class="animate-fade-in relative -mt-10">
-          <img
-            class="relative z-20 h-auto w-48"
-            src="/images/logo.png"
-            fetchpriority="high"
-            alt="La Velada del Año V"
-            decoding="async"
-          />
-          <div class="absolute top-0 z-0 size-64 bg-pink-400/80 blur-2xl"></div>
-        </figure>
-
-        <div>
-          <h3
-            class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_40%)]"
-          >
-            <strong>LISTA DE LOS</strong>
-            <br /><strong>COMBATES</strong>
-          </h3>
-        </div>
+        <h3
+          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_40%)]"
+        >
+          <strong>LISTA DE LOS</strong>
+          <br /><strong>COMBATES</strong>
+        </h3>
       </div>
 
       <div


### PR DESCRIPTION
Se actualizó el header para que el logo sea visible en la pantalla de combates, manteniendo una navegación consistente a la página principal.

- Se eliminó la imagen del logo en combates/index.astro para evitar que apareciera repetida.
- Ahora el header mantiene la misma estructura en todas las páginas.

Antes:
![Screenshot 2025-03-27 234949](https://github.com/user-attachments/assets/36f8af1e-b8e1-4454-970c-60d3deac7fd1)

Despues:
![Screenshot 2025-03-27 235829](https://github.com/user-attachments/assets/1010cd92-2838-4031-908a-082e2383acf7)
