### PR TITLE
Fix selector fighter type class

### DIFF
--- a/src/components/FighterSelector.astro
+++ b/src/components/FighterSelector.astro
@@ -5,10 +5,7 @@ const { id, name, boxerCardClass } = Astro.props;
 ---
 
 <div>
-  <BoxerCard id={id} name={name} class:list={[
-    'peer',
-    boxerCardClass,
-  ]} />
+  <BoxerCard id={id} name={name} class={`peer ${boxerCardClass}`} />
   <div
     id='fighter-container'
     class='pointer-events-none absolute inset-0 flex-col items-center hidden peer-hover:flex peer-focus:flex peer-focus-visible:flex'


### PR DESCRIPTION
## Solución error de tipado en clases

Se corrige el error de tipo y se asegura que las clases se apliquen correctamente formateado en string

**Antes**:

![Captura de pantalla 2025-03-27 000815](https://github.com/user-attachments/assets/3eafb28d-4f08-4a28-9d39-1ff4bf78a48a)


**Después:**

![Captura de pantalla 2025-03-27 000909](https://github.com/user-attachments/assets/e0d3c088-c31c-4c08-9a23-50964f6f90e0)

