### PR TITLE
Feat/porra page

### DIFF
--- a/src/components/CombatPoll.astro
+++ b/src/components/CombatPoll.astro
@@ -1,11 +1,11 @@
 ---
 interface Props {
-  combatId: string;
-  leftFighter: string;
-  rightFighter: string;
-  title: string;
+  combatId: string
+  leftFighter: string
+  rightFighter: string
+  title: string
 }
-const { title, leftFighter, rightFighter } = Astro.props as Props;
+const { title, leftFighter, rightFighter } = Astro.props as Props
 ---
 
 <section class="flex flex-col items-center justify-center gap-4">
@@ -20,6 +20,10 @@ const { title, leftFighter, rightFighter } = Astro.props as Props;
         src={`/images/fighters/cards/${leftFighter}.webp`}
         alt={`Tarjeta del boxeador ${leftFighter}`}
       />
+      <div
+        class="absolute inset-0 flex translate-y-2 flex-col items-center justify-end rounded-lg bg-gradient-to-t from-theme-tickle-me-pink/70 via-theme-tickle-me-pink/40 to-transparent p-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100"
+      >
+      </div>
     </button>
     <div class="relative col-span-2">
       {/* TODO: detect who has more votes to show */}
@@ -27,7 +31,7 @@ const { title, leftFighter, rightFighter } = Astro.props as Props;
         src={`/images/fighters/big/${leftFighter}.webp`}
         alt={leftFighter}
         decoding="async"
-        class="h-[450px] w-auto object-cover lg:object-contain mx-auto"
+        class="mx-auto h-[450px] w-auto object-cover lg:object-contain"
         fetchpriority="low"
       />
       <div class="absolute top-50 left-0 h-10 w-full rounded-full">
@@ -63,6 +67,10 @@ const { title, leftFighter, rightFighter } = Astro.props as Props;
         src={`/images/fighters/cards/${rightFighter}.webp`}
         alt={`Tarjeta del boxeador ${rightFighter}`}
       />
+      <div
+        class="absolute inset-0 flex translate-y-2 flex-col items-center justify-end rounded-lg bg-gradient-to-t from-theme-turquoise/70 via-theme-turquoise/40 to-transparent p-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100"
+      >
+      </div>
     </button>
   </div>
 </section>

--- a/src/components/CombatPoll.astro
+++ b/src/components/CombatPoll.astro
@@ -27,7 +27,7 @@ const { title, leftFighter, rightFighter } = Astro.props as Props;
         src={`/images/fighters/big/${leftFighter}.webp`}
         alt={leftFighter}
         decoding="async"
-        class="h-full w-auto object-cover lg:object-contain"
+        class="h-[450px] w-auto object-cover lg:object-contain mx-auto"
         fetchpriority="low"
       />
       <div class="absolute top-50 left-0 h-10 w-full rounded-full">

--- a/src/components/CombatPoll.astro
+++ b/src/components/CombatPoll.astro
@@ -1,0 +1,68 @@
+---
+interface Props {
+  combatId: string;
+  leftFighter: string;
+  rightFighter: string;
+  title: string;
+}
+const { title, leftFighter, rightFighter } = Astro.props as Props;
+---
+
+<section class="flex flex-col items-center justify-center gap-4">
+  <h3 class="text-center text-xl font-bold text-white">{title}</h3>
+  <div class="grid grid-cols-4 gap-4">
+    <button
+      class={`group relative inline-block rounded-lg transition-all duration-300 hover:z-20 hover:scale-110 hover:shadow-lg cursor-pointer`}
+      data-id={leftFighter}
+    >
+      <img
+        class="via-40 aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 to-transparent object-cover transition-transform duration-500"
+        src={`/images/fighters/cards/${leftFighter}.webp`}
+        alt={`Tarjeta del boxeador ${leftFighter}`}
+      />
+    </button>
+    <div class="relative col-span-2">
+      {/* TODO: detect who has more votes to show */}
+      <img
+        src={`/images/fighters/big/${leftFighter}.webp`}
+        alt={leftFighter}
+        decoding="async"
+        class="h-full w-auto object-cover lg:object-contain"
+        fetchpriority="low"
+      />
+      <div class="absolute top-50 left-0 h-10 w-full rounded-full">
+        <div class="flex h-full">
+          <div
+            id={`progress-${leftFighter}`}
+            class="bg-theme-tickle-me-pink shadow-theme-tickle-me-pink/80 h-full rounded-l-full shadow-lg"
+            style="width: 50%"
+          >
+          </div>
+          <div
+            id={`progress-${rightFighter}`}
+            class="bg-theme-turquoise shadow-theme-turquoise h-full rounded-r-full shadow-lg"
+            style="width: 50%"
+          >
+          </div>
+        </div>
+        <div
+          class="text-theme-raisin-black absolute top-0 left-0 flex h-full w-full items-center justify-center text-xl font-bold"
+        >
+          <span id={`votes-${leftFighter}`}>50%</span>
+          <span class="text-theme-tickle-me-pink mx-1 h-full">|</span>
+          <span id={`votes-${rightFighter}`}>50%</span>
+        </div>
+      </div>
+    </div>
+    <button
+      class={`group relative inline-block rounded-lg transition-all duration-300 hover:z-20 hover:scale-110 hover:shadow-lg cursor-pointer`}
+      data-id={rightFighter}
+    >
+      <img
+        class="via-40 aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 to-transparent object-cover transition-transform duration-500"
+        src={`/images/fighters/cards/${rightFighter}.webp`}
+        alt={`Tarjeta del boxeador ${rightFighter}`}
+      />
+    </button>
+  </div>
+</section>

--- a/src/pages/la-porra.astro
+++ b/src/pages/la-porra.astro
@@ -2,6 +2,8 @@
 import Layout from '@/layouts/Layout.astro'
 import { porra } from '@/consts/pageTitles'
 import BackgroundLayout from '@/layouts/BackgroundLayout.astro'
+import { COMBATS } from '@/consts/combats'
+import CombatPoll from '@/components/CombatPoll.astro'
 ---
 
 <Layout title={porra}>
@@ -15,5 +17,17 @@ import BackgroundLayout from '@/layouts/BackgroundLayout.astro'
         PARTICIPA EN LA PORRA
       </h2>
     </header>
+    <div class="mx-auto mt-40 w-full max-w-4xl">
+      {
+        COMBATS.map(({ id, fighters, title }) => (
+          <CombatPoll
+            combatId={id}
+            leftFighter={fighters[0]}
+            rightFighter={fighters[1]}
+            title={title}
+          />
+        ))
+      }
+    </div>
   </BackgroundLayout>
 </Layout>

--- a/src/pages/la-porra.astro
+++ b/src/pages/la-porra.astro
@@ -1,13 +1,11 @@
 ---
 import Layout from '@/layouts/Layout.astro'
 import { porra } from '@/consts/pageTitles'
-import BackgroundLayout from '@/layouts/BackgroundLayout.astro'
 import { COMBATS } from '@/consts/combats'
 import CombatPoll from '@/components/CombatPoll.astro'
 ---
 
 <Layout title={porra}>
-  <BackgroundLayout>
     <header
       class="absolute top-28 mx-auto flex min-h-screen w-full flex-col items-center justify-start gap-4"
     >
@@ -29,5 +27,4 @@ import CombatPoll from '@/components/CombatPoll.astro'
         ))
       }
     </div>
-  </BackgroundLayout>
 </Layout>


### PR DESCRIPTION
## Describe your changes
Actualice la página de la porra basandome en el diseño mencionado en la issue #1135 y la PR #1118.

Cree un componente CombatPoll.astro con el diseño para votar cada combate y mostrar la imagen del que va ganando, incluyendo la barra de progreso. 

Como mencione en la issue use los 2 colores principales de la página para la barra de progreso donde cada boxeador representa un color. Siguiendo ese concepto agregue un hover que cambia el fondo del peleador seleccionado según el color que le corresponde en la barra de progreso.

**Nota**: Quite el componente del fondo porque tiene una altura fija y cortaba los combates haciendo que los otros quedaran ocultos y hacer un cambio en dicho componente esta fuera del alcance de esta PR.

## Include a screenshot/video where applicable

![image](https://github.com/user-attachments/assets/3674d027-3ab8-4ee1-a99a-873e35568c00)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
