### PR TITLE
fix: texts on Hero z index decreased

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -43,7 +43,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
         <div class="absolute top-0 z-0 size-64 bg-pink-400/80 blur-2xl"></div>
       </figure>
 
-      <div class="relative z-50">
+      <div class="relative z-10">
         <h3
           class="text-theme-seashell animate-fade-in animate-delay-500 z-0 mt-4 leading-relaxed font-medium tracking-wider uppercase"
         >
@@ -54,7 +54,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
           href="https://twitch.tv/ibai"
           rel="noopener noreferrer"
           target="_blank"
-          class="animate-fade-in animate-delay-700 z-50 mt-4 inline-block leading-relaxed font-medium tracking-wider uppercase transition hover:scale-125"
+          class="animate-fade-in animate-delay-700 z-10 mt-4 inline-block leading-relaxed font-medium tracking-wider uppercase transition hover:scale-125"
         >
           twitch.tv<br />Ibai
         </a>


### PR DESCRIPTION
## Describe your changes

Se ha cambiado el z index de algunos textos del hero para que no queden por encima del header,

## Include a screenshot/video where applicable

Antes:
![Screenshot 2025-03-28 183400](https://github.com/user-attachments/assets/93902ea9-953a-4ab6-8fb2-46efd5bbfebc)

Después:
![Screenshot 2025-03-28 183726](https://github.com/user-attachments/assets/d7a36d0c-b225-48e5-a177-15e7aed00f98)


## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
