### PR TITLE
refactor: adjust layout and styling for fighter images in combate page

### DIFF
--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -19,7 +19,7 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
 
   <section class="relative min-h-screen max-w-6xl mx-auto p-6 mt-24">
     <!-- Cartelera -->
-    <div class="relative h-full w-full  p-2 flex">
+    <div class="relative h-full max-h-[80vh] w-full  p-2 flex">
       <!-- Primer Combatiente -->
       <div class="relative w-1/2 h-auto bg-gradient-to-b from-black/50 to-pink-900/50 custom-clip  animate-crash overflow-hidden hover:scale-105 transition-transform duration-200 rotate-180 ">
         <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-10 rotate-180 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-bottom animate-delay-800">{fighter1?.name.toLocaleLowerCase()}</h3>
@@ -29,7 +29,7 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
               alt={`Imagen de ${fighter1?.name}`}
               decoding="async"
               loading="eager"
-              class="object-cover  mask-fade-bottom rotate-180"
+              class="object-cover mx-auto h-[calc(100%-10px)] mask-fade-bottom rotate-180"
             />
             <!-- <img
               src={fighter1Country?.image.src}
@@ -52,7 +52,7 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
             alt={`Imagen de ${fighter2?.name}`}
             decoding="async"
             loading="eager"
-            class="object-cover mask-fade-bottom"
+            class="object-cover mx-auto h-[calc(100%-10px)] mask-fade-bottom"
           />
         </a>
       </div>


### PR DESCRIPTION
Se arreglan las alturas en las imágenes de los combatientes en la pagina de "/combates", para que no se salgan de los bordes de su contenedor.

Antes:
![imagen](https://github.com/user-attachments/assets/eeb620a0-c070-438b-99f7-7181189df5d6)
![imagen](https://github.com/user-attachments/assets/98c5afaa-2f47-4c54-b10b-7689d4ce8592)
Despues:
![imagen](https://github.com/user-attachments/assets/d13fd1e2-3521-450c-b369-01af31da8b6b)
![imagen](https://github.com/user-attachments/assets/802c1bf0-8b8c-437c-816f-6de800055458)

Estilos

- [x] Arreglo del tamaño de las imágenes de los luchadores

Seria bueno, agregarlos a un solo componente, pero por consejos de midu las pull requests tienen que ser pequeñas :)
