### PR TITLE
Feat: Agregar efecto de fondo para combates [id] & Refactor: Simplificar con componente

### DIFF
--- a/src/components/CombatFighterCard.astro
+++ b/src/components/CombatFighterCard.astro
@@ -1,0 +1,79 @@
+---
+const { fighter, isFirst } = Astro.props
+---
+<div class=`relative  w-1/2 h-auto bg-gradient-to-b from-black/50  to-pink-900/50 custom-clip animate-crash overflow-hidden hover:scale-[1.02] transition-transform duration-200 ${isFirst ? 'rotate-180': ''}`>
+        
+  <h3 class=`absolute right-0 end-0 text-2xl md:text-6xl z-20 font-medium leading-[100%] text-theme-seashell vertical-text ${isFirst ? 'animate-slide-in-bottom':'animate-slide-in-top'} animate-delay-1000 transition-all delay-300 ${isFirst ? 'rotate-180': ''}`>
+    {fighter?.name.toLocaleLowerCase()}
+  </h3>
+
+  <a class="flex justify-center items-center" href={`/luchador/${fighter?.id}`}>
+    <img
+      src={`/images/fighters/big/${fighter?.id}.webp`}
+      alt={`Imagen de ${fighter?.name}`}
+      decoding="async"
+      loading="eager"
+      class=`h-[85vh] w-auto object-cover  mask-fade-bottom z-10 ${isFirst ? 'rotate-180': ''}`
+    />
+  </a>
+  <!-- shimmer -->
+  <div class="absolute inset-0 z-0 animate-shimmer"></div>
+
+</div> 
+
+<style>
+  .custom-clip {
+    clip-path: polygon(15% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
+
+  .vertical-text {
+    writing-mode: vertical-lr;
+    text-orientation: upright;
+  }
+
+  .animate-crash{
+    animation: crash 1s linear forwards;
+  }
+
+  @keyframes crash {
+  0% {
+    transform: translateX(100px);
+    box-shadow: 0 0 0 rgba(255, 255, 255, 0); /* Sin sombra */
+    opacity: 0;
+  }
+  40% {
+    transform: translateX(-10px);
+    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Sombra visible más intensa */
+    opacity: 1;
+  }
+  60% {
+    transform: translateX(50px);
+    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
+  }
+  80% {
+    transform: translateX(0);
+    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
+  }
+  100% {
+    transform: translateX(-10px); 
+    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
+  }
+  }
+
+  .animate-shimmer {
+    background: linear-gradient(120deg, transparent 40%, rgba(255, 255, 255, 0.25) 50%, transparent 60%);
+    background-size: 200% 100%;
+    animation: shimmer 10s linear infinite ;
+    animation-delay: 1s;
+    
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: -200% -200%;
+    }
+    100% {
+      background-position: 200% 200%;
+    }
+  }
+</style>

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -21,40 +21,41 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
     <!-- Cartelera -->
     <div class="relative h-full w-full  p-2 flex">
       <!-- Primer Combatiente -->
-      <div class="relative w-1/2 h-auto bg-gradient-to-b from-black/50 to-pink-900/50 custom-clip  animate-crash overflow-hidden hover:scale-105 transition-transform duration-200 rotate-180 ">
-        <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-10 rotate-180 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-bottom animate-delay-800">{fighter1?.name.toLocaleLowerCase()}</h3>
-        <a href={`/luchador/${fighter1?.id}`}>
+      <div class="relative w-1/2 h-auto bg-gradient-to-b from-black/50 to-pink-900/50 custom-clip  animate-crash overflow-hidden hover:scale-[1.02] transition-transform duration-200 rotate-180 ">
+        
+        <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-20 rotate-180 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-bottom animate-delay-1000 transition-all delay-300">
+          {fighter1?.name.toLocaleLowerCase()}
+        </h3>
+
+        <a class="flex justify-center items-center" href={`/luchador/${fighter1?.id}`}>
           <img
               src={`/images/fighters/big/${fighter1?.id}.webp`}
               alt={`Imagen de ${fighter1?.name}`}
               decoding="async"
               loading="eager"
-              class="object-cover  mask-fade-bottom rotate-180"
+              class="h-[85vh] w-auto object-cover mask-fade-bottom rotate-180 z-10"
             />
-            <!-- <img
-              src={fighter1Country?.image.src}
-              alt={`Bandera de ${fighter1Country?.name ?? 'Desconocido'}`}
-              class="absolute top-8 md:top-20 left-1/2 transform -translate-x-1/2 -translate-y-1/2 h-auto w-16 md:w-52 rotate-180 inline-flex"
-            /> -->
         </a>
+        <div class="absolute inset-0 z-0 animate-shimmer"></div>
       </div>
 
       <!-- Versus Letra o Imagen -->
-      <img src="/images/versus.png" class="size-24 md:size-50 z-20 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 animate-slide-out-bottom delay-1000" alt="Imagen de Versus">
+      <img src="/images/versus.png" class="size-28 md:size-56 z-30 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 animate-slide-out-bottom  transition-all delay-200" alt="Imagen de Versus">
       
       <!-- Segundo Combatiente -->
-      <div class="relative w-1/2 h-auto bg-gradient-to-b from-black/50  to-pink-900/50 custom-clip animate-crash overflow-hidden hover:scale-105 transition-transform duration-200">
+      <div class="relative  w-1/2 h-auto bg-gradient-to-b from-black/50  to-pink-900/50 custom-clip animate-crash overflow-hidden hover:scale-[1.02] transition-transform duration-200">
         <!-- Esquina Derecha -->
-        <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-10 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-top animate-delay-800">{fighter2?.name.toLocaleLowerCase()}</h3>
-        <a href={`/luchador/${fighter2?.id}`}>
+        <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-20 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-top animate-delay-1000 transition-all delay-300">{fighter2?.name.toLocaleLowerCase()}</h3>
+        <a class="flex justify-center items-center" href={`/luchador/${fighter2?.id}`}>
           <img
             src={`/images/fighters/big/${fighter2?.id}.webp`}
             alt={`Imagen de ${fighter2?.name}`}
             decoding="async"
             loading="eager"
-            class="object-cover mask-fade-bottom"
+            class="h-[85vh] w-auto object-cover  mask-fade-bottom z-10"
           />
         </a>
+        <div class="absolute inset-0 z-0 animate-shimmer"></div>
       </div>
     </div>
 
@@ -80,8 +81,10 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
             <p>{fighter1Country?.name.toLocaleLowerCase()}</p>
             <img
               src={fighter1Country?.image.src}
+              loading="lazy"
+              decoding="async"
               alt={`Bandera de ${fighter1Country?.name ?? 'Desconocido'}`}
-              class="h-auto w-16 md:w-25 inline-flex"
+              class="h-10 md:h-16 w-16 md:w-25 inline-flex"
             />
           </div>
           <div class="space-y-2 text-center text-theme-seashell font-bold text-sm md:text-2xl">
@@ -99,15 +102,17 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
             <p>{fighter2Country?.name.toLocaleLowerCase()}</p>
             <img
               src={fighter2Country?.image.src}
+              loading="lazy"
+              decoding="async"
               alt={`Bandera de ${fighter2Country?.name ?? 'Desconocido'}`}
-              class="h-auto w-16 md:w-25 inline-flex"
+              class="h-10 md:h-16 w-16 md:w-25 inline-flex"
             />
           </div>
         </div>
       </div>
 
+      <!-- Pronostico -->
       <div class="bg-black/70 ">
-        <!-- Pronostico -->
           <h2 class="text-md md:text-2xl font-bold my-4 uppercase text-theme-seashell text-center"> 
             pronóstico
           </h2>
@@ -119,26 +124,27 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
             <span class="text-center text-3xl md:text-6xl text-white my-10">próximamente..</span>
           </div>
       </div>
+
     </div>
   </section>
 
 </Layout>
 
 <style>
- .custom-clip {
-  clip-path: polygon(15% 0%, 100% 0%, 100% 100%, 0% 100%);
- }
+  .custom-clip {
+    clip-path: polygon(15% 0%, 100% 0%, 100% 100%, 0% 100%);
+  }
 
- .vertical-text {
-  writing-mode: vertical-lr;
-  text-orientation: upright;
- }
+  .vertical-text {
+    writing-mode: vertical-lr;
+    text-orientation: upright;
+  }
 
- .animate-crash{
-  animation: crash 1s linear forwards;
- }
+  .animate-crash{
+    animation: crash 1s linear forwards;
+  }
 
- @keyframes crash {
+  @keyframes crash {
   0% {
     transform: translateX(100px);
     box-shadow: 0 0 0 rgba(255, 255, 255, 0); /* Sin sombra */
@@ -161,5 +167,22 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
     transform: translateX(-10px); 
     box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
   }
-}
+  }
+
+  .animate-shimmer {
+    background: linear-gradient(120deg, transparent 40%, rgba(255, 255, 255, 0.25) 50%, transparent 60%);
+    background-size: 200% 100%;
+    animation: shimmer 10s linear infinite ;
+    animation-delay: 1s;
+    
+  }
+
+  @keyframes shimmer {
+    0% {
+      background-position: -200% -200%;
+    }
+    100% {
+      background-position: 200% 200%;
+    }
+  }
 </style>

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -4,6 +4,7 @@ import { COMBATS } from '@/consts/combats'
 import { FIGHTERS } from '@/consts/fighters'
 import { countries } from '@/consts/countries'
 import { combate } from '@/consts/pageTitles'
+import CombatFighterCard from '@/components/CombatFighterCard.astro'
 
 const { id } = Astro.params
 const combat = COMBATS.find((c) => c.id === id)
@@ -21,42 +22,14 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
     <!-- Cartelera -->
     <div class="relative h-full w-full  p-2 flex">
       <!-- Primer Combatiente -->
-      <div class="relative w-1/2 h-auto bg-gradient-to-b from-black/50 to-pink-900/50 custom-clip  animate-crash overflow-hidden hover:scale-[1.02] transition-transform duration-200 rotate-180 ">
-        
-        <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-20 rotate-180 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-bottom animate-delay-1000 transition-all delay-300">
-          {fighter1?.name.toLocaleLowerCase()}
-        </h3>
-
-        <a class="flex justify-center items-center" href={`/luchador/${fighter1?.id}`}>
-          <img
-              src={`/images/fighters/big/${fighter1?.id}.webp`}
-              alt={`Imagen de ${fighter1?.name}`}
-              decoding="async"
-              loading="eager"
-              class="h-[85vh] w-auto object-cover mask-fade-bottom rotate-180 z-10"
-            />
-        </a>
-        <div class="absolute inset-0 z-0 animate-shimmer"></div>
-      </div>
+      <CombatFighterCard fighter={fighter1} isFirst={true}/> 
 
       <!-- Versus Letra o Imagen -->
       <img src="/images/versus.png" class="size-28 md:size-56 z-30 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 animate-slide-out-bottom  transition-all delay-200" alt="Imagen de Versus">
+      <!--<h3 class="text-9xl  font-bold text-theme-seashell z-30 absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 animate-slide-out-bottom  transition-all delay-200 ">vs</h3>-->
       
       <!-- Segundo Combatiente -->
-      <div class="relative  w-1/2 h-auto bg-gradient-to-b from-black/50  to-pink-900/50 custom-clip animate-crash overflow-hidden hover:scale-[1.02] transition-transform duration-200">
-        <!-- Esquina Derecha -->
-        <h3 class="absolute right-0 end-0 text-2xl md:text-6xl z-20 font-medium leading-[100%] text-theme-seashell  vertical-text animate-slide-in-top animate-delay-1000 transition-all delay-300">{fighter2?.name.toLocaleLowerCase()}</h3>
-        <a class="flex justify-center items-center" href={`/luchador/${fighter2?.id}`}>
-          <img
-            src={`/images/fighters/big/${fighter2?.id}.webp`}
-            alt={`Imagen de ${fighter2?.name}`}
-            decoding="async"
-            loading="eager"
-            class="h-[85vh] w-auto object-cover  mask-fade-bottom z-10"
-          />
-        </a>
-        <div class="absolute inset-0 z-0 animate-shimmer"></div>
-      </div>
+      <CombatFighterCard fighter={fighter2} isFirst={false}/>   
     </div>
 
     <!-- Informacion -->
@@ -129,60 +102,3 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
   </section>
 
 </Layout>
-
-<style>
-  .custom-clip {
-    clip-path: polygon(15% 0%, 100% 0%, 100% 100%, 0% 100%);
-  }
-
-  .vertical-text {
-    writing-mode: vertical-lr;
-    text-orientation: upright;
-  }
-
-  .animate-crash{
-    animation: crash 1s linear forwards;
-  }
-
-  @keyframes crash {
-  0% {
-    transform: translateX(100px);
-    box-shadow: 0 0 0 rgba(255, 255, 255, 0); /* Sin sombra */
-    opacity: 0;
-  }
-  40% {
-    transform: translateX(-10px);
-    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Sombra visible más intensa */
-    opacity: 1;
-  }
-  60% {
-    transform: translateX(50px);
-    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
-  }
-  80% {
-    transform: translateX(0);
-    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
-  }
-  100% {
-    transform: translateX(-10px); 
-    box-shadow: 10px 0 20px rgba(255, 255, 255, 0.6); /* Mantener sombra */
-  }
-  }
-
-  .animate-shimmer {
-    background: linear-gradient(120deg, transparent 40%, rgba(255, 255, 255, 0.25) 50%, transparent 60%);
-    background-size: 200% 100%;
-    animation: shimmer 10s linear infinite ;
-    animation-delay: 1s;
-    
-  }
-
-  @keyframes shimmer {
-    0% {
-      background-position: -200% -200%;
-    }
-    100% {
-      background-position: 200% 200%;
-    }
-  }
-</style>


### PR DESCRIPTION
## Describe your changes
Se añade un fondo tipo shimmer para resaltar a los combatientes, se ajusta el tamaño de la imagen y el efecto hover, y se suaviza la transición de la imagen de 'Versus'. Además, se crea el componente CombatFighterCard para reutilizar código y facilitar futuras ediciones.

Cambios presentados:

1. Se suaviza el efecto hover (scale) para evitar cambios bruscos.
2. Las imágenes ahora ocupan siempre el 80 del vh.
3. Se agrega un efecto de movimiento detrás del combatiente para resaltarlo.
4. Se desglosa y simplifica el código con el nuevo componente CombatFighterCard.
5. Se añade delay y transición a los nombres y al "Versus" para un cambio de pantalla más fluido.

## Include a screenshot/video where applicable
**Aquí una vista de la versión anterior sin el fondo y transición de textos:** 
https://github.com/user-attachments/assets/b418a8fc-cefd-499c-8373-5a517c9f3526

**A continuación una visualización con el componente con los suavizados y fondo integrados:**
https://github.com/user-attachments/assets/9d580cff-b263-426b-bc83-54f2e2376dc4


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
