### PR TITLE
Ajuste del margen inferior en el banner informativo de twitch

### DIFF
--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -2,9 +2,7 @@
 import { SPONSORS } from "@/consts/sponsors"
 ---
 
-<section
-	class="relative h-screen w-full overflow-hidden bg-[var(--background-color)] pt-10 pb-20"
->
+<section class="relative h-screen w-full overflow-hidden bg-[var(--background-color)] pt-10 pb-20">
 	<img
 		src="/img/background-la-velada.webp"
 		class="animate-fade-in pointer-events-none fixed top-0 z-0 h-screen w-screen object-cover select-none"
@@ -68,7 +66,7 @@ import { SPONSORS } from "@/consts/sponsors"
 		</div>
 
 		<div
-			class="animate-fade-in-up animate-delay-700 my-20 flex w-full items-center justify-center md:my-40"
+			class="animate-fade-in-up animate-delay-700 my-20 flex w-full items-center justify-center md:mb-30"
 		>
 			<p
 				class="text-navy bg-cream/90 max-w-[64ch] -skew-x-6 rounded px-4 py-2 text-center text-base text-balance uppercase shadow-md backdrop-grayscale md:px-8 md:py-4 md:text-xl"


### PR DESCRIPTION
## Descripción
Se arreglo el margen inferior del banner informativo de Twitch. En algunas pantallas (incluida la mía) la mitad del banner esta oculto y no se logra ver todo el texto a menos de que se haga un "zoom out"

## Antes y Despues
![antes](https://github.com/user-attachments/assets/00a3157e-2184-46c4-a737-0d01d16ca28d)
![despues](https://github.com/user-attachments/assets/343eaaa5-d328-4561-87bb-67509a3c36f2)

## Categoría de los cambios realizados.

- [x] Bug fix (non-breaking change which fixes an issue)