### PR TITLE
chore: add rel='noopener noreferrer' to social links in footer

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -19,6 +19,7 @@ import { SOCIAL } from '@/consts/social'
           <a
             href={url}
             target="_blank"
+            rel="noopener noreferrer"
             aria-label={label ?? name}
             class="flex items-center justify-center transition hover:scale-125"
           >


### PR DESCRIPTION
## Describe your changes
Se agregó `rel="noopener noreferrer"` a los enlaces externos en el footer para mejorar la seguridad y evitar posibles vulnerabilidades al usar `target="_blank"`.  
Esto previene que la página enlazada tenga acceso al `window.opener`, mejorando la privacidad y el rendimiento.  

## Include a screenshot/video where applicable
_No aplica (es un cambio interno en los enlaces)._  

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

