### PR TITLE
chore: add rel='noopener noreferrer' to sponsor links

### DIFF
--- a/src/components/Sponsors.astro
+++ b/src/components/Sponsors.astro
@@ -18,6 +18,7 @@ const secondRow = SPONSORS.slice(5)
         <a
           href={url}
           target="_blank"
+          rel="noopener noreferrer"
           aria-label={label ?? name}
           class="size-14 hover:scale-125 transition text-dark-magenta flex justify-center items-center"
         >
@@ -36,6 +37,7 @@ const secondRow = SPONSORS.slice(5)
         <a
           href={url}
           target="_blank"
+          rel="noopener noreferrer"
           aria-label={label ?? name}
           class="size-14 hover:scale-125 transition text-dark-magenta flex justify-center items-center"
         >


### PR DESCRIPTION
## Describe your changes
Se agregó `rel="noopener noreferrer"` a los enlaces externos en la sección de patrocinadores para mejorar la seguridad y evitar posibles vulnerabilidades al usar `target="_blank"`.  
Esto previene que la página enlazada tenga acceso al `window.opener`, mejorando la privacidad y el rendimiento.  

## Include a screenshot/video where applicable
_No aplica (es un cambio interno en los enlaces)._  

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
