### PR TITLE
Styled transparent fade-out to bottom of fighter image at [id].astro

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -30,7 +30,7 @@ const opponent = FIGHTERS.find(f => f.id === fighter.versus)
         <img
             src={`/images/fighters/big/${id}.webp`}
             alt={fighter.name}
-            class="h-full w-full object-contain transition-all duration-700 hover:scale-105 animate-fade-in"
+            class="h-full w-full object-contain transition-all duration-700 hover:scale-105 animate-fade-in [mask-image:linear-gradient(to_bottom,black_70%,transparent)]"
             transition:name={`image-${id}`}
         />
       </div>


### PR DESCRIPTION
## Fade-out hacia transparente en luchador/[id]
Ahora los luchadores tienen un fade-out hacia transparente para difuminar la parte de abajo y que no quede un corte tan agresivo

## Vídeo de los cambios
Muestro el antes y el después de los cambios

https://github.com/user-attachments/assets/229b1457-c922-4f23-be10-fa38e050a6fa

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
