### PR TITLE
[bug] BoxerCard: ajustar el scroll a cero antes de animar la transición

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -15,7 +15,7 @@ interface Props {
 >
   <div class="relative overflow-hidden rounded-lg">
     <img
-      class="via-40 aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 to-transparent object-cover transition-transform duration-500 group-hover:scale-110"
+      class="aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 via-40 to-transparent object-cover transition-transform duration-500 group-hover:scale-110"
       src={`/images/fighters/cards/${id}.webp`}
       alt={`Tarjeta del boxeador ${name}`}
     />
@@ -69,32 +69,23 @@ interface Props {
   }
 
   @keyframes pulseBorder {
-    0% {
-      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0.7);
-    }
-    70% {
-      box-shadow: 0 0 0 10px rgba(255, 20, 147, 0);
-    }
-    100% {
-      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0);
-    }
+    0% { box-shadow: 0 0 0 0 rgba(255, 20, 147, 0.7); }
+    70% { box-shadow: 0 0 0 10px rgba(255, 20, 147, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(255, 20, 147, 0); }
   }
 
   @keyframes selectedPulse {
     0% {
-      box-shadow:
-        0 0 0 0 rgba(255, 20, 147, 0.7),
-        inset 0 0 0 2px rgba(255, 20, 147, 1);
+      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0.7),
+                  inset 0 0 0 2px rgba(255, 20, 147, 1);
     }
     70% {
-      box-shadow:
-        0 0 0 15px rgba(255, 20, 147, 0),
-        inset 0 0 0 2px rgba(255, 20, 147, 1);
+      box-shadow: 0 0 0 15px rgba(255, 20, 147, 0),
+                  inset 0 0 0 2px rgba(255, 20, 147, 1);
     }
     100% {
-      box-shadow:
-        0 0 0 0 rgba(255, 20, 147, 0),
-        inset 0 0 0 2px rgba(255, 20, 147, 1);
+      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0),
+                  inset 0 0 0 2px rgba(255, 20, 147, 1);
     }
   }
 
@@ -113,7 +104,7 @@ interface Props {
 <script>
   document.addEventListener('astro:page-load', () => {
     const boxerCards = document.querySelectorAll('.boxer-card')
-    let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const pairings: Record<number, number> = {
       0: 5,
@@ -186,63 +177,57 @@ interface Props {
         }, 500)
       })
 
-      singleBoxerCard.addEventListener('click', (e) => {
-        e.preventDefault()
-
-        // Si el scroll está en otra posición no se verá el boxeador para luego animar la transición
-        window.scrollTo(0, 0)
-
+      singleBoxerCard.addEventListener("click", (e) => {
+        e.preventDefault();
+        
         // Remover la clase selected de todas las tarjetas
-        boxerCards.forEach((card) => card.classList.remove('selected'))
-
+        boxerCards.forEach(card => card.classList.remove('selected'));
+        
         // Añadir la clase selected SOLO a la tarjeta clickeada (removemos la parte de la pareja)
-        singleBoxerCard.classList.add('selected')
+        singleBoxerCard.classList.add('selected');
 
         // Crear partículas solo en la tarjeta clickeada
-        createParticles(singleBoxerCard as HTMLElement)
+        createParticles(singleBoxerCard as HTMLElement);
 
         // Navegar a la página del boxeador después de un pequeño delay
-        const href = singleBoxerCard.getAttribute('href')
+        const href = singleBoxerCard.getAttribute('href');
         if (href) {
           setTimeout(() => {
-            window.location.href = href
-          }, 600)
+            window.location.href = href;
+          }, 600);
         }
-      })
+      });
     })
 
     function createParticles(element: HTMLElement) {
       for (let i = 0; i < 10; i++) {
-        const particle = document.createElement('div')
-        particle.className = 'absolute w-1 h-1 bg-theme-tickle-me-pink rounded-full'
-
+        const particle = document.createElement('div');
+        particle.className = 'absolute w-1 h-1 bg-theme-tickle-me-pink rounded-full';
+        
         // Posición aleatoria alrededor de la tarjeta
-        const angle = Math.random() * Math.PI * 2
-        const radius = 50 + Math.random() * 20
-
-        particle.style.left = `${50 + Math.cos(angle) * radius}%`
-        particle.style.top = `${50 + Math.sin(angle) * radius}%`
-
-        element.appendChild(particle)
-
+        const angle = Math.random() * Math.PI * 2;
+        const radius = 50 + Math.random() * 20;
+        
+        particle.style.left = `${50 + Math.cos(angle) * radius}%`;
+        particle.style.top = `${50 + Math.sin(angle) * radius}%`;
+        
+        element.appendChild(particle);
+        
         // Animación
-        particle.animate(
-          [
-            { opacity: 1, transform: 'scale(1)' },
-            { opacity: 0, transform: 'scale(0)' },
-          ],
-          {
-            duration: 1000,
-            fill: 'forwards',
-          }
-        ).onfinish = () => particle.remove()
+        particle.animate([
+          { opacity: 1, transform: 'scale(1)' },
+          { opacity: 0, transform: 'scale(0)' }
+        ], {
+          duration: 1000,
+          fill: 'forwards'
+        }).onfinish = () => particle.remove();
       }
     }
 
     boxerCards.forEach((card) => {
       card.addEventListener('mouseenter', () => {
-        createParticles(card as HTMLElement)
-      })
-    })
+        createParticles(card as HTMLElement);
+      });
+    });
   })
 </script>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -15,7 +15,7 @@ interface Props {
 >
   <div class="relative overflow-hidden rounded-lg">
     <img
-      class="aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 via-40 to-transparent object-cover transition-transform duration-500 group-hover:scale-110"
+      class="via-40 aspect-[900/1200] h-full w-full bg-gradient-to-t from-gray-50/40 via-gray-50/20 to-transparent object-cover transition-transform duration-500 group-hover:scale-110"
       src={`/images/fighters/cards/${id}.webp`}
       alt={`Tarjeta del boxeador ${name}`}
     />
@@ -69,23 +69,32 @@ interface Props {
   }
 
   @keyframes pulseBorder {
-    0% { box-shadow: 0 0 0 0 rgba(255, 20, 147, 0.7); }
-    70% { box-shadow: 0 0 0 10px rgba(255, 20, 147, 0); }
-    100% { box-shadow: 0 0 0 0 rgba(255, 20, 147, 0); }
+    0% {
+      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0.7);
+    }
+    70% {
+      box-shadow: 0 0 0 10px rgba(255, 20, 147, 0);
+    }
+    100% {
+      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0);
+    }
   }
 
   @keyframes selectedPulse {
     0% {
-      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0.7),
-                  inset 0 0 0 2px rgba(255, 20, 147, 1);
+      box-shadow:
+        0 0 0 0 rgba(255, 20, 147, 0.7),
+        inset 0 0 0 2px rgba(255, 20, 147, 1);
     }
     70% {
-      box-shadow: 0 0 0 15px rgba(255, 20, 147, 0),
-                  inset 0 0 0 2px rgba(255, 20, 147, 1);
+      box-shadow:
+        0 0 0 15px rgba(255, 20, 147, 0),
+        inset 0 0 0 2px rgba(255, 20, 147, 1);
     }
     100% {
-      box-shadow: 0 0 0 0 rgba(255, 20, 147, 0),
-                  inset 0 0 0 2px rgba(255, 20, 147, 1);
+      box-shadow:
+        0 0 0 0 rgba(255, 20, 147, 0),
+        inset 0 0 0 2px rgba(255, 20, 147, 1);
     }
   }
 
@@ -104,7 +113,7 @@ interface Props {
 <script>
   document.addEventListener('astro:page-load', () => {
     const boxerCards = document.querySelectorAll('.boxer-card')
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null
 
     const pairings: Record<number, number> = {
       0: 5,
@@ -177,57 +186,63 @@ interface Props {
         }, 500)
       })
 
-      singleBoxerCard.addEventListener("click", (e) => {
-        e.preventDefault();
-        
+      singleBoxerCard.addEventListener('click', (e) => {
+        e.preventDefault()
+
+        // Si el scroll está en otra posición no se verá el boxeador para luego animar la transición
+        window.scrollTo(0, 0)
+
         // Remover la clase selected de todas las tarjetas
-        boxerCards.forEach(card => card.classList.remove('selected'));
-        
+        boxerCards.forEach((card) => card.classList.remove('selected'))
+
         // Añadir la clase selected SOLO a la tarjeta clickeada (removemos la parte de la pareja)
-        singleBoxerCard.classList.add('selected');
+        singleBoxerCard.classList.add('selected')
 
         // Crear partículas solo en la tarjeta clickeada
-        createParticles(singleBoxerCard as HTMLElement);
+        createParticles(singleBoxerCard as HTMLElement)
 
         // Navegar a la página del boxeador después de un pequeño delay
-        const href = singleBoxerCard.getAttribute('href');
+        const href = singleBoxerCard.getAttribute('href')
         if (href) {
           setTimeout(() => {
-            window.location.href = href;
-          }, 600);
+            window.location.href = href
+          }, 600)
         }
-      });
+      })
     })
 
     function createParticles(element: HTMLElement) {
       for (let i = 0; i < 10; i++) {
-        const particle = document.createElement('div');
-        particle.className = 'absolute w-1 h-1 bg-theme-tickle-me-pink rounded-full';
-        
+        const particle = document.createElement('div')
+        particle.className = 'absolute w-1 h-1 bg-theme-tickle-me-pink rounded-full'
+
         // Posición aleatoria alrededor de la tarjeta
-        const angle = Math.random() * Math.PI * 2;
-        const radius = 50 + Math.random() * 20;
-        
-        particle.style.left = `${50 + Math.cos(angle) * radius}%`;
-        particle.style.top = `${50 + Math.sin(angle) * radius}%`;
-        
-        element.appendChild(particle);
-        
+        const angle = Math.random() * Math.PI * 2
+        const radius = 50 + Math.random() * 20
+
+        particle.style.left = `${50 + Math.cos(angle) * radius}%`
+        particle.style.top = `${50 + Math.sin(angle) * radius}%`
+
+        element.appendChild(particle)
+
         // Animación
-        particle.animate([
-          { opacity: 1, transform: 'scale(1)' },
-          { opacity: 0, transform: 'scale(0)' }
-        ], {
-          duration: 1000,
-          fill: 'forwards'
-        }).onfinish = () => particle.remove();
+        particle.animate(
+          [
+            { opacity: 1, transform: 'scale(1)' },
+            { opacity: 0, transform: 'scale(0)' },
+          ],
+          {
+            duration: 1000,
+            fill: 'forwards',
+          }
+        ).onfinish = () => particle.remove()
       }
     }
 
     boxerCards.forEach((card) => {
       card.addEventListener('mouseenter', () => {
-        createParticles(card as HTMLElement);
-      });
-    });
+        createParticles(card as HTMLElement)
+      })
+    })
   })
 </script>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -180,6 +180,9 @@ interface Props {
       singleBoxerCard.addEventListener("click", (e) => {
         e.preventDefault();
         
+        // Para ver adecuadamente la animación el scroll debe estar en cero
+        window.scrollTo(0,0)
+
         // Remover la clase selected de todas las tarjetas
         boxerCards.forEach(card => card.classList.remove('selected'));
         


### PR DESCRIPTION
## Describe your changes
Agregué un ajuste del scroll en caso de hacer clic en un boxeador, para evitar un mal aspecto de la animación, sobre todo en móvil

## Include a screenshot/video where applicable

Antes:

https://github.com/user-attachments/assets/37848c7d-15a2-46da-9da6-3782c16a0656


Después:

https://github.com/user-attachments/assets/1ef1577e-1a8e-441b-9858-5d561437b608





## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
