### PR TITLE
[FEATURE] Optimization of the play button in lite-youtube

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -363,7 +363,9 @@ const { videoId, title, backgroundImage } = Astro.props
     /* …but visually it's still the same size */
     background: no-repeat center/100px 100px;
     /* YT's actual play button svg */
-    background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="white" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
+    background-color: white;
+    -webkit-mask: url('data:image/svg+xml;utf8,<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>') no-repeat center/100px 100px;
+    mask: url('data:image/svg+xml;utf8,<svg viewBox="0 0 1024 1024" xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>') no-repeat center/100px 100px;
     position: absolute;
     cursor: pointer;
     z-index: 1;
@@ -377,7 +379,7 @@ const { videoId, title, backgroundImage } = Astro.props
 
   lite-youtube:hover > .lty-playbtn,
   lite-youtube .lty-playbtn:focus {
-    background-image: url('data:image/svg+xml;utf8,<svg stroke="white" fill="pink" stroke-width="0" viewBox="0 0 1024 1024"  xmlns="http://www.w3.org/2000/svg"><path d="M512 64C264.6 64 64 264.6 64 512s200.6 448 448 448 448-200.6 448-448S759.4 64 512 64zm0 820c-205.4 0-372-166.6-372-372s166.6-372 372-372 372 166.6 372 372-166.6 372-372 372z"></path><path d="M719.4 499.1l-296.1-215A15.9 15.9 0 0 0 398 297v430c0 13.1 14.8 20.5 25.3 12.9l296.1-215a15.9 15.9 0 0 0 0-25.8zm-257.6 134V390.9L628.5 512 461.8 633.1z"></path></svg>');
+    background-color: pink;
     filter: none;
     transform: scale(1.23);
   }


### PR DESCRIPTION
## Describe your changes
Se Implementó una mejora en la gestión del botón de reproducción para lite-youtube que elimina la necesidad de cargar dos versiones del mismo SVG, reduciendo así el tamaño del CSS y mejorando el rendimiento.

## Include a screenshot/video where applicable
<img width="1412" alt="Captura de pantalla 2025-04-01 a las 12 12 56 p  m" src="https://github.com/user-attachments/assets/0774f383-776d-4c31-be45-46fe029c7829" />

<img width="1434" alt="Captura de pantalla 2025-04-01 a las 12 13 04 p  m" src="https://github.com/user-attachments/assets/a3899676-fed0-40e4-a859-a302ea794106" />


## Type of change
- [x] New feature (non-breaking change which adds functionality)


