### PR TITLE
feat: Elimina el enlace <a> innecesario en luchador/[id].astro

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -32,14 +32,9 @@ const opponent = FIGHTERS.find((f) => f.id === fighter.versus)
 
       {
         opponent && (
-          <div class="flex w-full items-center justify-center">
+          <div class="flex w-full items-center gap-4 justify-center">
             <img src="/images/versus.png" alt="Versus" class="h-12 w-auto" />
-            <a
-              href={`/luchador/${opponent.id}`}
-              class="group transform rounded-lg bg-white/10 px-4 py-2 transition-all hover:scale-105 hover:bg-white/20"
-            >
-              <BoxerCard id={opponent.id} name={opponent.name} class="group-hover:scale-110" />
-            </a>
+            <BoxerCard id={opponent.id} name={opponent.name} class="group-hover:scale-110" />
           </div>
         )
       }


### PR DESCRIPTION
## Describe your changes
Se ha eliminado el componente `<a>` innecesario que envolvía el componente `BoxerCard` en la página `luchador/[id].astro`, ya que no se utiliza más. Ahora, `BoxerCard` se renderiza directamente sin el enlace.

## Include a screenshot/video where applicable
Antes
![Screenshot 2025-04-01 184131](https://github.com/user-attachments/assets/6b434568-a312-448d-b1c4-cf0de9a4e84b)

Despues
![Screenshot 2025-04-01 184620](https://github.com/user-attachments/assets/b8aa1dcd-dd5f-43b0-aaf4-f7d3d2dc75af)


## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
