### PR TITLE
Mostrar los combates con Flex centrando el último

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -23,12 +23,12 @@ import { combates } from '@/consts/pageTitles'
 
       <div
         id="combats-container"
-        class="relative top-96 mx-auto mt-10 mb-72 grid max-w-7xl grid-cols-1 gap-4 p-6 md:grid-cols-2 md:gap-8"
+        class="relative top-96 mx-auto max-w-7xl mt-10 mb-72 flex flex-wrap justify-center gap-4 p-6 md:gap-8"
       >
         {
           COMBATS.map(({ id, number, fighters, title }) => (
             <a
-              class="inline-block"
+              class="inline-block w-full md:w-[calc(50%-1rem)]"
               href={`combates/${id}`}
               title={`Ir al combate ${number} de ${title}`}
             >


### PR DESCRIPTION
Se cambio grid por flex para mostrar el último combate centrado, creo es más estético, se comprobó en Desktop

![Xnip2025-04-02_10-47-12](https://github.com/user-attachments/assets/81b9db9a-9609-4996-be13-c31ec1884297)
