### PR TITLE
Añadir redirección a la página 404 si no se encuentra el combate

### DIFF
--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -7,6 +7,7 @@ import { combate } from '@/consts/pageTitles'
 
 const { id } = Astro.params
 const combat = COMBATS.find((c) => c.id === id)
+if (!combat) return Astro.redirect('/404')
 const fighter1 = FIGHTERS.find((f) => f.id === combat?.fighters[0])
 const fighter2 = FIGHTERS.find((f) => f.id === combat?.fighters[1])
 


### PR DESCRIPTION
## Descripción de cambios
Se ha corregido el comportamiento al acceder a combates inexistentes. Antes, si el nombre del combate no coincidía, se mostraban datos sin sentido. Ahora, si el combate no existe, se redirige automáticamente a la página 404.

## Antes del cambio
![image](https://github.com/user-attachments/assets/c792395e-56ca-4914-b868-88b4a0c656e7)


## Después del cambio
![image](https://github.com/user-attachments/assets/75cc8d48-1d36-4f3a-89be-5c02e63fdc9f)

## Cambios realizados
 - Se valida si el nombre del combate existe.
 - Si no existe, se redirige a la página 404.
Es la misma validación que se realiza en luchadores, pero en combates no estaba implementado.

## Cómo probarlo

Accede a un combate válido: http://localhost:4321/combates/1-peereira-vs-rivaldios

Accede a un combate inexistente: http://localhost:4321/combates/1-peereira-vs-rivaldiossbhdbsj





Resultado esperado: Debe redirigir a la página 404.
