### PR TITLE
corrige la mayúscula del texto en la página 404

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -18,7 +18,7 @@ import Layout from '@/layouts/Layout.astro'
         <span class="mb-2 block text-4xl font-bold tracking-wider">¡FUERA DE COMBATE!</span>
       </h1>
       <p class="text-theme-raisin-black mb-6 text-xl tracking-wide">
-        Vaya, parece que te han noqueado...
+        vaya, parece que te han noqueado...
       </p>
       <div class="flex min-h-4 items-center justify-center">
         <a


### PR DESCRIPTION
## Descripción de cambios
Se ha modificado la Mayúscula del "Vaya" ya que quedaba un poco rara a la vista por el tema de la fuente.
La he puesto en minúscula y para mi gusto queda mejor, no sé que opinas.

## Imagen antes del cambio
![image](https://github.com/user-attachments/assets/7a01c97a-8d71-43b3-b6e8-a8c6c085d3fa)

## Immmagen después del cambio
![image](https://github.com/user-attachments/assets/fb4551b9-a079-4831-b971-b0ecace24471)
