### PR TITLE
Feat/improve combates UI

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -36,7 +36,7 @@ import { combates } from '@/consts/pageTitles'
                 {fighters.map((fighter, index) => (
                   <img
                     src={`/images/fighters/big/${fighter}.webp`}
-                    class={`z-20 h-full w-1/2 object-contain drop-shadow-[0_0_10px_var(--color-theme-turquoise)] ${index === 0 ? 'ml-5 lg:ml-10' : '-ml-10 lg:-ml-20'} mask-fade-boxer size-96 transition-transform duration-300 group-hover:scale-110`}
+                    class={`z-20 h-full w-1/2 object-contain p-4 drop-shadow-[0_0_10px_var(--color-theme-turquoise)] ${index === 0 ? 'ml-5 lg:ml-10' : '-ml-10 lg:-ml-20'} mask-fade-boxer size-96 transition-transform duration-300 group-hover:scale-110`}
                     alt={`Imagen de ${fighter}`}
                     loading="lazy"
                     decoding="async"

--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -14,7 +14,7 @@ import { combates } from '@/consts/pageTitles'
     <div class="flex w-full flex-col items-center text-center">
       <div id="landing" class="absolute top-0 flex w-full flex-col items-center py-30">
         <h3
-          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_50%)] tracking-wider brightness-125 transition-all duration-300"
+          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-6xl leading-[100%] font-medium tracking-wider brightness-125 transition-all duration-300 [text-shadow:_5px_5px_10px_rgb(0_0_0_/_50%)]"
         >
           <strong>LISTA DE LOS</strong>
           <br /><strong>COMBATES</strong>
@@ -23,12 +23,12 @@ import { combates } from '@/consts/pageTitles'
 
       <div
         id="combats-container"
-        class="relative top-96 mx-auto mt-10 mb-72 grid max-w-7xl grid-cols-1 gap-4 p-6 md:grid-cols-2 md:gap-8"
+        class="relative top-96 mx-auto mt-10 mb-72 flex max-w-7xl flex-wrap justify-center gap-4 p-6 md:gap-8"
       >
         {
           COMBATS.map(({ id, number, fighters, title }) => (
             <a
-              class="inline-block"
+              class="flex-[0_1_calc(100%)] md:flex-[0_1_calc(50%-1rem)]"
               href={`combates/${id}`}
               title={`Ir al combate ${number} de ${title}`}
             >

--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -36,7 +36,7 @@ import { combates } from '@/consts/pageTitles'
                 {fighters.map((fighter, index) => (
                   <img
                     src={`/images/fighters/big/${fighter}.webp`}
-                    class={`z-20 h-full w-1/2 object-contain ${index === 0 ? 'ml-5 lg:ml-10' : '-ml-10 lg:-ml-20'} mask-fade-boxer size-96 transition-transform duration-300 group-hover:scale-110`}
+                    class={`z-20 h-full w-1/2 object-contain drop-shadow-[0_0_10px_var(--color-theme-turquoise)] ${index === 0 ? 'ml-5 lg:ml-10' : '-ml-10 lg:-ml-20'} mask-fade-boxer size-96 transition-transform duration-300 group-hover:scale-110`}
                     alt={`Imagen de ${fighter}`}
                     loading="lazy"
                     decoding="async"

--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -36,7 +36,7 @@ import { combates } from '@/consts/pageTitles'
                 {fighters.map((fighter, index) => (
                   <img
                     src={`/images/fighters/big/${fighter}.webp`}
-                    class={`z-20 h-full w-1/2 object-contain ${index === 0 ? 'ml-5 lg:ml-10' : '-ml-10 lg:-ml-20'} mask-fade-bottom size-96 transition-transform duration-300 group-hover:scale-110`}
+                    class={`z-20 h-full w-1/2 object-contain ${index === 0 ? 'ml-5 lg:ml-10' : '-ml-10 lg:-ml-20'} mask-fade-boxer size-96 transition-transform duration-300 group-hover:scale-110`}
                     alt={`Imagen de ${fighter}`}
                     loading="lazy"
                     decoding="async"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -77,3 +77,7 @@ html {
 @utility mask-fade-bottom {
   mask-image: linear-gradient(to bottom, black 80%, transparent 100%);
 }
+
+@utility mask-fade-boxer {
+  mask-image: linear-gradient(to bottom, black 50%, transparent 80%);
+}


### PR DESCRIPTION
## Describe your changes
Retoques en la página de combates

## Include a screenshot/video where applicable

- Se ha añadido (y aplicado) una máscara que haga fade más agresivo para aplicarlo a los boxeadores.

| antes | después |
| -  | - |
| ![image](https://github.com/user-attachments/assets/6c478f5b-e142-449d-acb5-940f62704dc2) | ![image](https://github.com/user-attachments/assets/9b89410c-8fc0-4764-abb3-002078fe6487) |

- Se ha añadido un drop-shadow a las imagenes de combates

| antes | después |
| -  | - |
|  ![image](https://github.com/user-attachments/assets/d7b2d391-c2ff-4b10-af50-3a0f2cb79af5) |  ![image](https://github.com/user-attachments/assets/29366b4a-1d0d-48e8-8c6e-e031bd47c5fd) |

- Se ha utilizado flex en lugar de grid para mostrar los combates (de este modo el último combate se puede centrar).

| antes | después |
| -  | - |
| ![image](https://github.com/user-attachments/assets/3dcc0a2b-0176-4872-8079-0b3465d64e78) | ![image](https://github.com/user-attachments/assets/75d20509-6cfb-42c4-93e0-5d7e9314e3b9) |

## Type of change
- [x] New feature (non-breaking change which adds functionality)

