### PR TITLE
use cards image in combat instead of big image

### DIFF
--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -27,7 +27,7 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
         class="w-full h-full flex items-center justify-center pb-8" 
         href={`/luchador/${fighter1?.id}`}>
           <img
-              src={`/images/fighters/big/${fighter1?.id}.webp`}
+              src={`/images/fighters/cards/${fighter1?.id}.webp`}
               alt={`Imagen de ${fighter1?.name}`}
               decoding="async"
               loading="eager"
@@ -52,7 +52,7 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
         class="w-full h-full flex items-center justify-center mt-8"
         href={`/luchador/${fighter2?.id}`}>
           <img
-            src={`/images/fighters/big/${fighter2?.id}.webp`}
+            src={`/images/fighters/cards/${fighter2?.id}.webp`}
             alt={`Imagen de ${fighter2?.name}`}
             decoding="async"
             loading="eager"


### PR DESCRIPTION
## Describe your changes
Aprovechando el encaramiento, usar las imagenes `card` en la página de los combates.

## Include a screenshot/video where applicable
| antes | despues |
| - | - | 
| ![image](https://github.com/user-attachments/assets/006223eb-7859-41df-9056-a2c2b3dd8d26) | ![image](https://github.com/user-attachments/assets/9abfbc83-eb4e-45fb-b63c-73362d447e17) |


## Type of change
- [x] Question
