### PR TITLE
Feat/fighters text image in combat

### DIFF
--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -64,11 +64,13 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
 
     <div class="grid grid-cols-2 items-center justify-items-center gap-4 py-4">
       <img
+        transition:name={`text-${fighter1?.id}`}
         src={`/images/fighters/text/${fighter1?.id}.webp`}
         alt={`${fighter2Country?.name ?? 'Desconocido'}`}
         class="h-auto max-h-12 w-auto max-w-[70%]"
       />
       <img
+        transition:name={`text-${fighter2?.id}`}
         src={`/images/fighters/text/${fighter2?.id}.webp`}
         alt={`${fighter2Country?.name ?? 'Desconocido'}`}
         class="h-auto max-h-12 w-auto max-w-[70%]"

--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -62,6 +62,19 @@ const fighter2Country = countries.find(c => c.id === fighter2?.country)
       </div>
     </div>
 
+    <div class="grid grid-cols-2 items-center justify-items-center gap-4 py-4">
+      <img
+        src={`/images/fighters/text/${fighter1?.id}.webp`}
+        alt={`${fighter2Country?.name ?? 'Desconocido'}`}
+        class="h-auto max-h-12 w-auto max-w-[70%]"
+      />
+      <img
+        src={`/images/fighters/text/${fighter2?.id}.webp`}
+        alt={`${fighter2Country?.name ?? 'Desconocido'}`}
+        class="h-auto max-h-12 w-auto max-w-[70%]"
+      />
+    </div>
+
     <!-- Informacion -->
     <div class="flex flex-col p-3 gap-8 mt-16 ">
       

--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -45,6 +45,7 @@ import { combates } from '@/consts/pageTitles'
 
                 <div class="absolute bottom-0 z-30 flex h-auto w-full -skew-4 flex-col items-center justify-center p-8 transition-transform duration-300 group-hover:scale-90">
                   <img
+                    transition:name={`text-${fighters[0]}`}
                     src={`/images/fighters/text/${fighters[0]}.webp`}
                     loading="lazy"
                     decoding="async"
@@ -59,6 +60,7 @@ import { combates } from '@/consts/pageTitles'
                     alt=""
                   />
                   <img
+                    transition:name={`text-${fighters[1]}`}
                     src={`/images/fighters/text/${fighters[1]}.png`}
                     loading="lazy"
                     decoding="async"


### PR DESCRIPTION
## Describe your changes
Se añade una grid con las imagenes del nombre del boxeador y se añaden `view transitions`

## Include a screenshot/video where applicable
|antes|después|
| - | - |
|  ![image](https://github.com/user-attachments/assets/70cd5022-e9fc-4ecb-b81f-06359f38dfc9) | ![image](https://github.com/user-attachments/assets/0265bf41-93d2-4a80-b81b-74b93185b5d0) |

## Type of change
- [x] New feature (non-breaking change which adds functionality)
