### PR TITLE
fix: missing prop in the BoxerCard component call

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -31,7 +31,7 @@ const opponent = FIGHTERS.find((f) => f.id === fighter.versus)
         opponent && (
           <div class="flex w-full items-center gap-4 justify-center">
             <img src="/images/versus.png" alt="Versus" class="h-12 w-auto" />
-            <BoxerCard id={opponent.id} name={opponent.name} class="group-hover:scale-110" />
+            <BoxerCard id={opponent.id} name={opponent.name} versus={opponent.versus} class="group-hover:scale-110" />
           </div>
         )
       }


### PR DESCRIPTION
## Prop faltante para el componente BoxerCard

El boxer card requiere de la prop versus en el tipo "{ id: fighterId; name: fighterName; versus: string; class: string; }", la cual es obligatoria en el tipo "Props".
```ts
<BoxerCard id={opponent.id} name={opponent.name} class="group-hover:scale-110" />
```

Añadido
```ts
<BoxerCard id={opponent.id} name={opponent.name} versus={opponent.versus} class="group-hover:scale-110" />
````
