### PR TITLE
Agrega unas pocas clases de Tailwind CSS para corregir el orden en qu…

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -107,9 +107,9 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
       </div>
     </div>
 
-    <div class="relative flex h-full w-full max-w-6xl flex-col items-center justify-end gap-8 p-8">
-      <div class="flex w-full flex-wrap justify-between px-4">
-        <div class="flex flex-wrap justify-start gap-4">
+    <div class="relative flex h-full w-full max-w-6xl flex-col items-center justify-end gap-8 -md:p-2 md:p-8">
+      <div class="flex w-full -md:flex-row md:flex-wrap gap-x-3 justify-between md:px-4">
+        <div class="flex -md:flex-row flex-wrap justify-start gap-4">
           {
             leftRow.map(({ id, name, versus }, index) => (
               <div
@@ -121,7 +121,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
           }
         </div>
 
-        <div class="flex flex-wrap justify-end gap-4">
+        <div class="flex -md:flex-row flex-wrap justify-end gap-4">
           {
             rightRow.map(({ id, name, versus }, index) => (
               <div
@@ -134,7 +134,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
         </div>
       </div>
 
-      <div class="flex flex-wrap justify-between gap-4">
+      <div class="flex -md:flex-row md:flex-wrap justify-between gap-4">
         <div class="flex flex-wrap justify-start gap-4">
           {
             leftSecondRow.map(({ id, name, versus }, index) => (


### PR DESCRIPTION
Agrega unas pocas clases de Tailwind CSS para corregir el orden en que se muchos las cards de los boxeadores en dispositivos móviles.

Nota: Lo siento, por hacer lo en la rama main, cree una, pero no cambie 😅.

Nota: Hola, Midu, inicien como backend con C# así que Héctor D' León es unos de mis maestros, tengo un poco más de 2 años aprendiendo web y desde entonces te sigo, me causa mucha gracia cuando te tiras con Héctor en tono de chercha entonces veo Héctor sube un video y lo veo y el responde la 'joda' como dice el, es muy gracioso, siguan así, saludos desde República Dominicana, aquí tenemos un 'código Domini'.

## Antes

![Screenshot_2025-04-03-23-24-40-428_com foxdebug acode](https://github.com/user-attachments/assets/08af9e5c-d063-411d-8683-864647f95bc8)

![Screenshot_2025-04-03-23-23-38-034_com kiwibrowser browser](https://github.com/user-attachments/assets/8d587008-13d9-4641-a71b-cdec7781bf7f)

## Después

![Screenshot_2025-04-03-23-49-49-835_com foxdebug acodefree](https://github.com/user-attachments/assets/6bb0e794-b3a0-4a69-a19d-2bdab84590d2)

![Screenshot_2025-04-03-23-23-57-439_com kiwibrowser browser](https://github.com/user-attachments/assets/8b5be430-1f0c-4364-b048-2595421a13a9)

