### PR TITLE
Feature/mobile ux boton info boxeador

### DIFF
--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -37,7 +37,7 @@ interface Props {
     class="absolute inset-0 flex translate-y-2 flex-col items-center justify-end rounded-lg bg-gradient-to-t from-pink-950/90 via-pink-950/40 to-transparent p-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100"
   >
     <h3
-      class="text-theme-tickle-me-pink text-white text-xs font-semibold tracking-wide uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
+      class="text-theme-tickle-me-pink select-none text-white text-xs font-semibold tracking-wide uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
     >
       {name}
     </h3>

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -37,7 +37,7 @@ interface Props {
     class="absolute inset-0 flex translate-y-2 flex-col items-center justify-end rounded-lg bg-gradient-to-t from-pink-950/90 via-pink-950/40 to-transparent p-2 opacity-0 transition-all duration-300 group-hover:translate-y-0 group-hover:opacity-100"
   >
     <h3
-      class="text-theme-tickle-me-pink text-xs font-semibold tracking-wide uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
+      class="text-theme-tickle-me-pink text-white text-xs font-semibold tracking-wide uppercase drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]"
     >
       {name}
     </h3>
@@ -116,7 +116,37 @@ interface Props {
   document.addEventListener('astro:page-load', () => {
     const boxerCards = document.querySelectorAll('.boxer-card')
     let timeoutId: ReturnType<typeof setTimeout> | null = null
+    let hideBtnFighterTimer: ReturnType<typeof setTimeout>
+    
+    function removeHrefInMovil() {
+      boxerCards.forEach((singleBoxerCard, index) => {
+        const hasHref = singleBoxerCard.hasAttribute('href');
 
+        if (hasHref && window.innerWidth < 768) {
+          singleBoxerCard.removeAttribute('href')
+
+          if (singleBoxerCard.href) {
+            singleBoxerCard.removeAttribute('href');
+          } 
+        }
+
+        if (!hasHref) { 
+          const id = singleBoxerCard.getAttribute('data-id')
+          singleBoxerCard.setAttribute("href",`/luchador/${id}`)
+        }
+      })
+    }
+
+    function isDiviceMovil() {
+      return /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
+    }
+
+    if (isDiviceMovil()) {
+      removeHrefInMovil();
+    }
+
+    window.addEventListener('resize', removeHrefInMovil);
+    
     boxerCards.forEach((singleBoxerCard, index) => {
       singleBoxerCard.addEventListener('mouseenter', () => {
         if (timeoutId) {

--- a/src/consts/fighters.ts
+++ b/src/consts/fighters.ts
@@ -86,15 +86,15 @@ export const FIGHTERS: Fighters[] = [
       {
         text: 'En seis meses va a caer, lo voy a noquear 100% y le voy a arrancar la p*** cabeza.',
         url: 'https://www.youtube.com/embed/OjOItlQQHNM?si=GIR26FtonnzIbZZL&amp;clip=UgkxLQNqwPqlJLU97lVJkD2lEWrJXswPfHOU&amp;clipt=ENGYChjaywo'
-        },
+      },
       {
         text: 'Vengo aquí para ser el mejor boxeador posible, estoy con el mejor equipo posible y lo único que te pido es que entrenes lo suficientemente bien para que toda esta gente vea el show que se merece.',
         url: 'https://www.youtube.com/embed/OjOItlQQHNM?si=OQAXdqDuQ33flPQg&amp;clip=UgkxtAMxt3Q-BIOC7G6PqfRTs8qkUZgaXwWP&amp;clipt=ENS2KBjkiik'
-        },
+      },
       {
         text: 'Entreno literalmente para noquearlo, no vengo a otra cosa.',
         url: 'https://www.youtube.com/embed/OjOItlQQHNM?si=AOlsjKIAacuwz_NZ&amp;clip=Ugkx2wfrvLVecdcny4Aw7hy0wu44LEZ8p3Ua&amp;clipt=EI2IQhiVr0I'
-        },
+      },
     ],
   },
   {
@@ -432,10 +432,10 @@ export const FIGHTERS: Fighters[] = [
     clips: [
       {
         text: 'Pereira, ponte trucha, amigo. Te voy a enseñar que la cuna del boxeo está en México.',
-        url: 'https://www.youtube.com/embed/OjOItlQQHNM?si=2yNcYbYAnGXc4jRD&amp;clip=UgkxuVSmgfc49HRArsmT522Vf42fmDo_W1WA&amp;clipt=EKOABBj8rgQ'  
+        url: 'https://www.youtube.com/embed/OjOItlQQHNM?si=2yNcYbYAnGXc4jRD&amp;clip=UgkxuVSmgfc49HRArsmT522Vf42fmDo_W1WA&amp;clipt=EKOABBj8rgQ'
       },
       {
-        text:'Voy a llegar al punto en que este v**** me va a tener miedo después de la pelea.',
+        text: 'Voy a llegar al punto en que este v**** me va a tener miedo después de la pelea.',
         url: 'https://www.youtube.com/embed/OjOItlQQHNM?si=qXDaC9BtQVT2Lw3r&amp;clip=Ugkxyvlpe6cGZqC2A2tU6B_-kgYlAqHuWn90&amp;clipt=EJC-LxiY5S8'
       },
       {
@@ -743,83 +743,6 @@ export const FIGHTERS: Fighters[] = [
     }
   },
   {
-    // https://www.biografia.de/westcol/
-    id: 'westcol',
-    name: 'Westcol',
-    realName: 'Luis Fernando Villa Álvarez',
-    gender: 'masculino',
-    birthDate: new Date(2001, 1, 2),
-    height: 1.65,
-    age: 24,
-    weight: 63,
-    country: 'co',
-    city: 'Medellín',
-    versus: 'grefg',
-    socials: [
-      {
-        id: 'instagram',
-        name: 'Instagram',
-        url: 'https://www.instagram.com/westcol/',
-        label: 'Visitar perfil de Westcol en Instagram',
-        followers: '4.3M',
-        image: {
-          logo: Instagram,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'x',
-        name: 'X',
-        url: 'https://x.com/WestCOL',
-        label: 'Visitar perfil de Westcol en X',
-        followers: '413.3k',
-        image: {
-          logo: X,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'youtube',
-        name: 'Youtube',
-        url: 'https://www.youtube.com/channel/UCEg_iK8FKwZfpRMn4-AnnnQ',
-        label: 'Visitar canal de Westcol en Youtube',
-        followers: '1.32M',
-        image: {
-          logo: Youtube,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'tiktok',
-        name: 'TikTok',
-        url: 'https://www.tiktok.com/@westcol',
-        label: 'Visitar perfil de Westcol en TikTok',
-        followers: '993.4k',
-        image: {
-          logo: TikTok,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'kick',
-        name: 'Kick',
-        url: 'https://www.kick.com/westcol',
-        label: 'Visitar perfil de Westcol en Kick',
-        followers: '1.9M',
-        image: {
-          logo: Kick,
-          width: 200,
-          height: 200,
-        }
-      }
-    ],
-    clips: [],
-  },
-  {
     // https://www.biografia.de/ari-geli/
     id: 'arigeli',
     name: 'Arigeli',
@@ -878,180 +801,4 @@ export const FIGHTERS: Fighters[] = [
         image: {
           logo: Youtube,
           width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'twitch',
-        name: 'Twitch',
-        url: 'https://www.twitch.tv/arigeli_',
-        label: 'Visitar perfil de Arigeli en Twitch',
-        followers: '32.5k',
-        image: {
-          logo: Twitch,
-          width: 200,
-          height: 200,
-        }
-      }
-    ],
-    clips: [],
-    workout: {
-      videoID: 'rugHsv9JCSU',
-      thumbnail: '/images/fighters/workoutThumbnails/arigeli-thumbnail.webp'
-    }
-  },
-  {
-    // https://www.biografia.de/tomas-mazza/
-    id: 'tomas',
-    name: 'Tomás',
-    realName: 'Tomás Francisco Pérez Mazza',
-    gender: 'masculino',
-    birthDate: new Date(2000, 3, 16),
-    height: 1.76,
-    age: 25,
-    weight: 80,
-    country: 'ar',
-    city: 'Buenos Aires',
-    versus: 'viruzz',
-    socials: [
-      {
-        id: 'x',
-        name: 'X',
-        url: 'https://x.com/MazzaTomas',
-        label: 'Visitar perfil de Tomás en X',
-        followers: '259.9k',
-        image: {
-          logo: X,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'instagram',
-        name: 'Instagram',
-        url: 'https://www.instagram.com/mazzatomas',
-        label: 'Visitar perfil de Tomás en Instagram',
-        followers: '2.9M',
-        image: {
-          logo: Instagram,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'youtube',
-        name: 'Youtube',
-        url: 'https://www.youtube.com/@tomasmazza',
-        label: 'Visitar canal de Tomás en Youtube',
-        followers: '855k',
-        image: {
-          logo: Youtube,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'tiktok',
-        name: 'TikTok',
-        url: 'https://www.tiktok.com/@mazzatomas',
-        label: 'Visitar perfil de Tomás en TikTok',
-        followers: '2.5M',
-        image: {
-          logo: TikTok,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'twitch',
-        name: 'Twitch',
-        url: 'https://www.twitch.tv/mazzatomas',
-        label: 'Visitar perfil de Tomás en Twitch',
-        followers: '629k',
-        image: {
-          logo: Twitch,
-          width: 200,
-          height: 200,
-        }
-      }
-    ],
-    clips: [],
-  },
-  {
-    // https://laletrade.com/biografias/youtuber/19752-carlos-belcast
-    id: 'carlos',
-    name: 'Carlos',
-    realName: 'Carlos Belcast',
-    gender: 'masculino',
-    birthDate: new Date(1998, 9, 5),
-    height: 1.77,
-    age: 26,
-    weight: 85,
-    country: 'mx',
-    city: 'Monterrey',
-    versus: 'andoni',
-    socials: [
-      {
-        id: 'x',
-        name: 'X',
-        url: 'https://x.com/CarlosBelcast',
-        label: 'Visitar perfil de Carlos en X',
-        followers: '22.1k',
-        image: {
-          logo: X,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'instagram',
-        name: 'Instagram',
-        url: 'https://www.instagram.com/carlosbelcast/',
-        label: 'Visitar perfil de Carlos en Instagram',
-        followers: '5.1M',
-        image: {
-          logo: Instagram,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'tiktok',
-        name: 'TikTok',
-        url: 'https://www.tiktok.com/@carlosbelcast',
-        label: 'Visitar perfil de Carlos en TikTok',
-        followers: '6.5M',
-        image: {
-          logo: TikTok,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'youtube',
-        name: 'Youtube',
-        url: 'https://www.youtube.com/@carlosbelcast',
-        label: 'Visitar canal de Carlos en Youtube',
-        followers: '1.42M',
-        image: {
-          logo: Youtube,
-          width: 200,
-          height: 200,
-        }
-      },
-      {
-        id: 'twitch',
-        name: 'Twitch',
-        url: 'https://www.twitch.tv/carlosbelcastt',
-        label: 'Visitar perfil de Carlos en Twitch',
-        followers: '50.3k',
-        image: {
-          logo: Twitch,
-          width: 200,
-          height: 200,
-        }
-      }
-    ],
-    clips: [],
-  },
-] as const
+  

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -72,7 +72,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
       id="fighter-container"
       class="pointer-events-none absolute inset-0 flex flex-col items-center"
     >
-      <div class="relative top-96 z-1 mx-auto flex h-[4.5rem] w-full items-center justify-center">
+      <div class="relative top-96 z-10 mx-auto flex h-[4.5rem] w-full items-center justify-center">
         {
           FIGHTERS.map(({ id, name }) => (
             <img
@@ -154,6 +154,11 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
           }
         </div>
       </div>
+      
+      <a class="absolute hidden md:hidden btn-details animate-fade-in-up animate-delay-200 font-extrabold w-20 h-10 rounded-xl border-2 border-rose-700 shadow-lg flex items-center justify-center">
+        Details
+      </a>
+      
     </div>
   </div>
 </section>
@@ -161,6 +166,30 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
 <style>
   .mask-fade-text {
     mask-image: linear-gradient(to bottom, transparent 5%, black 6%, black 95%, transparent 100%);
+  }
+  
+  @keyframes selectedPulse {
+    0% {
+      box-shadow:
+        0 0 0 0 rgba(255, 20, 147, 0.7),
+        inset 0 0 0 2px rgba(255, 20, 147, 1);
+    }
+    
+    70% {
+      box-shadow:
+        0 0 0 15px rgba(255, 20, 147, 0),
+        inset 0 0 0 2px rgba(255, 20, 147, 1);
+    }
+    
+    100% {
+      box-shadow:
+        0 0 0 0 rgba(255, 20, 147, 0),
+        inset 0 0 0 2px rgba(255, 20, 147, 1);
+    }
+  }
+  
+  .btn-details {
+    animation: selectedPulse 2s infinite cubic-bezier(0.66, 0, 0, 1);
   }
 </style>
 
@@ -172,6 +201,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
 
     let currentFighterId: string | null = null
     let hideFighterTimer: ReturnType<typeof setTimeout>
+    let hideBtnFighterTimer: ReturnType<typeof setTimeout>
 
     document.addEventListener('boxer-card-exit', () => {
       $landing?.classList.remove('hidden')
@@ -194,11 +224,26 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
           currentFighterId = null
         }, 500)
       }
+      
+ 
+      hideBtnFighterTimer = setTimeout(() => {
+        const btnDetails = $(`.btn-details`)
+        btnDetails.classList.add('hidden')
+        currentFighterId = null
+      }, 500)
     })
-
+    
+    function activeBtnInfoFighter (id)  {
+      const btnDetails = $(`.btn-details`)
+ 
+      btnDetails.setAttribute("href",`/luchador/${event.detail.id}`)
+      btnDetails?.classList.remove('hidden')
+    }
+   
     document.addEventListener('boxer-card-hovered', (event: Event) => {
       if (currentFighterId) {
         clearTimeout(hideFighterTimer)
+      //  clearTimeout(hideBtnFighterTimer)
 
         const heroText = $(`[data-id="hero-text-${currentFighterId}"]`)
         const heroImage = $(`[data-id="hero-image-${currentFighterId}"]`)
@@ -207,6 +252,8 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
         heroImage?.classList.add('hidden')
         currentFighterId = null
       }
+
+      activeBtnInfoFighter(event.detail.id)
 
       const customEvent = event as CustomEvent<{ id: string }>
       const id = customEvent.detail.id

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -107,9 +107,9 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
       </div>
     </div>
 
-    <div class="relative flex h-full w-full max-w-6xl flex-col items-center justify-end gap-8 p-8">
-      <div class="flex w-full flex-wrap justify-between px-4">
-        <div class="flex flex-wrap justify-start gap-4">
+    <div class="relative flex h-full w-full max-w-6xl flex-col items-center justify-end gap-8 -md:p-2 md:p-8">
+      <div class="flex w-full -md:flex-row md:flex-wrap gap-x-3 justify-between md:px-4">
+        <div class="flex -md:flex-row flex-wrap justify-start gap-4">
           {
             leftRow.map(({ id, name, versus }, index) => (
               <div
@@ -121,7 +121,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
           }
         </div>
 
-        <div class="flex flex-wrap justify-end gap-4">
+        <div class="flex -md:flex-row flex-wrap justify-end gap-4">
           {
             rightRow.map(({ id, name, versus }, index) => (
               <div
@@ -134,7 +134,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
         </div>
       </div>
 
-      <div class="flex flex-wrap justify-between gap-4">
+      <div class="flex -md:flex-row md:flex-wrap justify-between gap-4">
         <div class="flex flex-wrap justify-start gap-4">
           {
             leftSecondRow.map(({ id, name, versus }, index) => (

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -8,7 +8,14 @@ const rightRow = firstRow.slice(3)
 
 const secondRow = FIGHTERS.slice(6)
 const leftSecondRow = secondRow.slice(0, 4)
-const rightSecondRow = secondRow.slice(4, 8)
+let rightSecondRow = secondRow.slice(4, 8)
+
+const userAgent = Astro.request.headers.get('user-agent');
+const isAndroid = userAgent?.toLowerCase().includes('android');
+
+if (!isAndroid) {
+  rightSecondRow = [...secondRow.slice(7,8 ),...secondRow.slice(4, 7)]
+}
 
 const animationDelay = [500, 700, 800]
 const reverseDelay = [...animationDelay].reverse()
@@ -195,7 +202,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
 
 <script>
   import { $ } from '@/lib/dom-selector'
-
+  
   document.addEventListener('astro:page-load', () => {
     const $landing = $('#landing')
 


### PR DESCRIPTION
Desactive el href en las Cards de los boxeadores en en movil y añadi un botón que hace dicha funcionalidad (para acceder a la información del boxeador), funciona solo en dispositivos móviles, ya que senti una mala experiencia de usuarios al querer visualizar el boxeador y me redirecionaba a la página de la información.


## El nombre del boxeador estaba por detrás del.

### Antes

![Screenshot_2025-04-04-12-00-03-361_com kiwibrowser browser](https://github.com/user-attachments/assets/a199fb1e-2a8d-4b4d-aded-88164c426ae1)

### Después

![Screenshot_2025-04-04-12-00-26-846_com kiwibrowser browser](https://github.com/user-attachments/assets/a896bdf8-a6b1-47f6-9bf3-e33eb0d9b5ce)

## Los boxeadores de la segundo fila tenía una incongruencia en la UI con respecto a la primera fila.

### Antes

![IMG_20250404_124337](https://github.com/user-attachments/assets/3d44bd2f-12cc-42bf-b021-9889c3267f43)

### Después

![IMG_20250404_124317](https://github.com/user-attachments/assets/f4a93d9b-d1d1-4787-98c8-637f7a5f81ec)
