### PR TITLE
feat: add scroll animation on the combats cards

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -32,7 +32,7 @@ import { combates } from '@/consts/pageTitles'
               href={`combates/${id}`}
               title={`Ir al combate ${number} de ${title}`}
             >
-              <div class="group animate-fade-in animate-delay-200 relative flex h-[40vh] w-full sm:h-[50vh]">
+              <div class="group animate-fade-in animate-delay-200 view-animate-single view-timeline-axis-block animate-range-[entry_25%_cover_30%] animate-fill-mode-both relative flex h-[40vh] w-full sm:h-[50vh]">
                 {fighters.map((fighter, index) => (
                   <img
                     src={`/images/fighters/big/${fighter}.webp`}


### PR DESCRIPTION
# IDEA
## **Animación por scroll en las tarjetas de cada combate:**

Se agregó una animación de scroll para las cards.

- Se incluyeron nuevas clases en el contenedor, agregando las siguientes utilidades:
  - `view-animate-single`
  - `view-timeline-axis-block`
  - `animate-range-[entry_25%_cover_30%]`
  - `animate-fill-mode-both`

Estas clases permiten que las cards se animen al hacer scroll, mejorando la experiencia visual al navegar por la página.

**Detalles técnicos:**

- **Antes:**  
  ```html
  <div class="group animate-fade-in animate-delay-200 relative flex h-[40vh] w-full sm:h-[50vh]">
  ```

- **Después:**  
  ```html
  <div class="group animate-fade-in animate-delay-200 view-animate-single view-timeline-axis-block animate-range-[entry_25%_cover_30%] animate-fill-mode-both relative flex h-[40vh] w-full sm:h-[50vh]">
  ```

Con este cambio, se garantiza que la animación se active en el momento preciso durante el scroll, ofreciendo un efecto visual fluido y dinámico en las cards.

**Demo:**


https://github.com/user-attachments/assets/5f18d9b6-3b81-4f78-866b-6c8b118d3093

*mobile*


https://github.com/user-attachments/assets/632a182d-dc7f-4afc-8f8d-85a229281bd1



---