### PR TITLE
fix: reduce font-size text by mobile first

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -14,7 +14,7 @@ import { combates } from '@/consts/pageTitles'
     <div class="flex w-full flex-col items-center text-center">
       <div id="landing" class="absolute top-0 flex w-full flex-col items-center py-30">
         <h3
-          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_50%)] tracking-wider brightness-125 transition-all duration-300"
+          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-[2.5rem] md:text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_50%)] tracking-wider brightness-125 transition-all duration-300"
         >
           <strong>LISTA DE LOS</strong>
           <br /><strong>COMBATES</strong>


### PR DESCRIPTION
## Tamaño de texto mobile first
Se ajustó el tamaño del texto en el elemento `<h3>` para hacerlo más responsivo en dispositivos móviles. Ahora, en pantallas pequeñas se muestra con `text-[2.5rem]` y en pantallas medianas o más grandes se mantiene `text-6xl`. De esta forma, el texto se ve más equilibrado y legible en distintos tamaños de pantalla.

**Antes:**

![Captura de pantalla 2025-04-04 155037](https://github.com/user-attachments/assets/c7df9608-23ff-403a-b89c-b7d30d544bb6)


**Después:**

![Captura de pantalla 2025-04-04 155055](https://github.com/user-attachments/assets/a90ec2e0-7cb6-4c1e-9610-d6b7d9639396)


## Type of change

- ✅ Breaking change (fix or feature that would cause existing functionality to not work as expected)

