### PR TITLE
fix: adjust the font size of the bout list header for mobile devices

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -14,7 +14,7 @@ import { combates } from '@/consts/pageTitles'
     <div class="flex w-full flex-col items-center text-center">
       <div id="landing" class="absolute top-0 flex w-full flex-col items-center py-30">
         <h3
-          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_50%)] tracking-wider brightness-125 transition-all duration-300"
+          class="text-theme-seashell animate-fade-in animate-delay-300 mt-4 -skew-3 text-[42px] sm:text-6xl leading-[100%] font-medium [text-shadow:_5px_5px_10px_rgb(0_0_0_/_50%)] tracking-wider brightness-125 transition-all duration-300"
         >
           <strong>LISTA DE LOS</strong>
           <br /><strong>COMBATES</strong>


### PR DESCRIPTION
## Describe your changes
El tamaño de letra de la vista de combate se sobre sale en la vista del movil, para ello se agrego una linea de codigo para cambiar el tamaño de letra según el ancho de pantalla usando tailwind.

## Include a screenshot/video where applicable
Antes:
![image](https://github.com/user-attachments/assets/69ed1864-dc8b-4f87-bb91-4f0435ba7b35)

Después:
![image](https://github.com/user-attachments/assets/a5642529-1dca-479c-885d-173cef0388da)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
