### PR TITLE
feat: agregar clips para Andoni y Carlos Belcast

### DIFF
--- a/src/consts/fighters.ts
+++ b/src/consts/fighters.ts
@@ -520,7 +520,20 @@ export const FIGHTERS: Fighters[] = [
         }
       }
     ],
-    clips: [],
+    clips: [
+      {
+        text: 'Yo voy a ir obviamente a ganar, y que eso no afecte nuestra relación.',
+        url: 'https://www.youtube.com/embed/NbaFxQiuFek?si=b9Sxnq2S0zG-74SV&amp;clip=Ugkx_ci1g5b732avNi7KVaeOw46sgni4lutX&amp;clipt=ELDMJBjYkiU'
+      },
+      {
+        text: 'Cualquier puño de ambos, si entra, es un puño de una persona pesada. Entonces es muy probable que, si entra de manera contundente… pues que acabe.',
+        url: 'https://www.youtube.com/embed/NbaFxQiuFek?si=mrqP0DjJ6dMTG3A9&amp;clip=UgkxOd-2XnnjkWi3KR1fp5cmGPP3s1yXdQqY&amp;clipt=ELjGGhiAlxs'
+      },
+      {
+        text: 'Carlos y yo habíamos dicho que por cada puño íbamos a lanzarnos un ‘te amo’.',
+        url: 'https://www.youtube.com/embed/NbaFxQiuFek?si=km59ayaLbPKm19qb&amp;clip=UgkxDfmm-4rtX6GmFfRRue8dNTsqDS2D4YbF&amp;clipt=EMG4Jhin6iY'
+      },
+    ],
     workout: {
       videoID: 'QDy_MM6y-7U',
       thumbnail: '/images/fighters/workoutThumbnails/andoni-thumbnail.webp'
@@ -1078,6 +1091,19 @@ export const FIGHTERS: Fighters[] = [
         }
       }
     ],
-    clips: [],
+    clips: [
+      {
+        text: 'Estoy de acuerdo, es una máquina, y eso hace más emocionante para mí la pelea. Una pelea difícil, un reto para mí.',
+        url: 'https://www.youtube.com/embed/NbaFxQiuFek?si=_zo9rym4J9nuprTz&amp;clip=UgkxA55s3XmbPCzb0W3fcV3a5ynwEsfrpWnY&amp;clipt=EMD-DBjIpQ0'
+      },
+      {
+        text: 'Quiero poner a mi país en alto, es lo que más quiero.',
+        url: 'https://www.youtube.com/embed/NbaFxQiuFek?si=ycZse19c6kilirh5&amp;clip=Ugkx_DVmBQCwGsesR_3YKdmsSI2VEzymSdZW&amp;clipt=EMWoDRjH1w0'
+      },
+      {
+        text: 'Somos muy grandes amigos, nos queremos mucho… pero eso no quiere decir que nos vayamos a dar con todo.',
+        url: 'https://www.youtube.com/embed/NbaFxQiuFek?si=1KpotzlUDqM1VYYQ&amp;clip=UgkxQadrp40FBpmDXn2yaSgdQJVUYUFaAqKO&amp;clipt=EOTJIhjL_CI'
+      },
+    ],
   },
 ] as const


### PR DESCRIPTION
## Describe your changes
Esta PR agrega nuevos clips al array clips de los luchadores Andoni y Carlos Belcast en el archivo consts/fighters.ts.
Cada clip contiene una frase representativa del luchador y un enlace a YouTube que lleva directamente al momento exacto en que se dice.

Estos cambios continúan con la mejora del contenido audiovisual en los perfiles de los luchadores, destacando momentos importantes para los fans.

## Include a screenshot/video where applicable
<!-- Please add screenshots to help explain your changes. Delete this section if not needed. -->

## Type of change
<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
