### PR TITLE
Adjust the height of countdown components for better display on lg screens

### DIFF
--- a/src/sections/Countdown.astro
+++ b/src/sections/Countdown.astro
@@ -23,7 +23,7 @@ const { timestamp } = Astro.props
       attribute={{ 'data-days': '' }}
       className="text-6xl font-bold md:text-7xl lg:text-8xl"
       wrapperClassName="my-0"
-      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[5.5rem]'}
+      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[6rem]'}
       max={129}
       withBackground={true}
     />
@@ -33,7 +33,7 @@ const { timestamp } = Astro.props
       dateType="HORAS"
       attribute={{ 'data-hours': '' }}
       className="text-6xl font-bold md:text-7xl lg:text-8xl"
-      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[5.5rem]'}
+      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[6rem]'}
       max={23}
       withBackground={true}
     />
@@ -43,7 +43,7 @@ const { timestamp } = Astro.props
       dateType="MINUTOS"
       attribute={{ 'data-minutes': '' }}
       className="text-6xl font-bold md:text-7xl lg:text-8xl"
-      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[5.5rem]'}
+      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[6rem]'}
       max={59}
       withBackground={true}
     />
@@ -53,7 +53,7 @@ const { timestamp } = Astro.props
       dateType="SEGUNDOS"
       attribute={{ 'data-seconds': '' }}
       className="text-6xl font-bold md:text-7xl lg:text-8xl"
-      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[5.5rem]'}
+      height={'h-[3.5rem] sm:h-[3.8rem] md:h-[4.2rem] lg:h-[6rem]'}
       max={59}
       withBackground={true}
     />


### PR DESCRIPTION
Small fix to prevent countdown numbers from being cut off on large screens:

Before:
![image](https://github.com/user-attachments/assets/9d6eb432-7629-40ff-9654-2ccada9cccf6)

After:
![image](https://github.com/user-attachments/assets/48afb453-d845-4620-a747-644caf57daf1)
