### PR TITLE
Aplicar efecto hover a la tarjeta de perfil del boxeador

### DIFF
--- a/src/components/BoxerProfileCard.astro
+++ b/src/components/BoxerProfileCard.astro
@@ -11,7 +11,7 @@ const generateRandomBars = () => {
 
 const bars = generateRandomBars();
 ---
-<article class="w-full hover:scale-105 transition-all duration-600 max-w-[450px] lg:min-w-[300px] border-2 border-white/40 bg-pink-600/40 rounded-xl overflow-hidden ">
+<article class="boxer-profile-card w-full hover:scale-105 transition-all duration-600 max-w-[450px] lg:min-w-[300px] border-2 border-white/40 bg-pink-600/40 rounded-xl overflow-hidden ">
   <!-- Contenedor principal -->
   <main class="grid grid-flow-row sm:grid-flow-col w-full grid-cols-2 lowercase">
     <!-- Informacion General -->
@@ -79,3 +79,53 @@ const bars = generateRandomBars();
     </section>
   </footer>
 </article>
+
+<style>
+  .boxer-profile-card {
+    backdrop-filter: blur(0px);
+  }
+  .boxer-profile-card:hover {
+    backdrop-filter: blur(2px);
+    box-shadow:
+      rgb(82, 89, 92) 10px 10px 20px,
+      rgb(24, 26, 27) -10px -10px 20px;
+  }
+
+  .boxer-profile-card::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 10%;
+    right: 10%;
+    height: auto;
+
+    opacity: 0;
+    transition:
+      opacity .3s ease,
+      transform .3s ease;
+  }
+
+  .boxer-profile-card:hover::before {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .boxer-profile-card::after {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: -100%;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(to right,
+            rgba(255, 255, 255, 0.030) 0%,
+            rgba(255, 255, 255, 0.150) 50%,
+            rgba(255, 255, 255, 0.030) 100%);
+    transition: left 1s ease;
+    z-index: 1;
+  }
+
+  .boxer-profile-card:hover::after {
+    left: 100%;
+  }
+</style>

--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -7,6 +7,7 @@ import BoxerCard from '@/components/BoxerCard.astro'
 import BoxerClipList from '@/components/BoxerClipList.astro'
 import BoxerClipDrawer from '@/components/BoxerClipDrawer.astro'
 import BoxerProfileCard from '@/components/BoxerProfileCard.astro'
+import BoxerGallery from '@/components/BoxerGallery.astro'
 
 const { id } = Astro.params
 


### PR DESCRIPTION
## IDEA

Se agregó la clase `boxer-profile-card` al componente principal `<article>` para encapsular estilos específicos relacionados con la tarjeta del perfil del boxeador. Esta clase permite aplicar un efecto de cristal y animación visual al hacer **hover** sobre la tarjeta.

Se añadieron estilos personalizados utilizando pseudo-elementos `::before` y `::after` junto con la pseudo-clase `:hover`, creando un efecto visual de resplandor y desenfoque que mejora la experiencia del usuario al interactuar con la tarjeta.

**Cambios destacados:**

- Se encapsularon los estilos del efecto hover.
- Se utilizó `backdrop-filter` para generar un desenfoque tipo *glass effect*.
- Se implementaron transiciones para `opacity`, `transform` y `left` para animar suavemente los pseudo-elementos.
- Se actualizaron algunas clases de Tailwind para mejorar la legibilidad y consistencia del layout sin modificar la estructura funcional del componente.

Este cambio no rompe la funcionalidad existente, únicamente mejora el estilo y comportamiento visual de la tarjeta.

## Include a screenshot/video where applicable

[hover-cardinfo-westcol.webm](https://github.com/user-attachments/assets/0aca7264-665a-43d4-8c43-f19e43d2ac72)


## Type of change

- [x] New feature (non-breaking change which adds functionality)  
- [ ] Bug fix  
- [ ] Breaking change  
- [ ] Documentation update

