### PR TITLE
Add dynamic image loading for fighter gallery based on available images

### DIFF
--- a/src/components/BoxerGallery.astro
+++ b/src/components/BoxerGallery.astro
@@ -1,5 +1,6 @@
 ---
 import SectionTitle from '@/components/SectionTitle.astro'
+import { fighterGallery } from '@/utils/get-image-count'
 
 interface Props {
   id: string
@@ -8,20 +9,21 @@ interface Props {
 
 const { id, name } = Astro.props
 
-const IMAGES_TO_LOAD = 5
+let gallery = fighterGallery(id)
+const IMAGES_TO_LOAD = Math.min(gallery, 5)
 ---
 
 <section class="mx-auto max-w-6xl px-2 py-36 lg:px-10">
   <SectionTitle title="Galería de Fotos" />
 
-  <div id="boxer-gallery" class="mt-10 grid grid-cols-6 gap-3 pt-12">
+  <div id="boxer-gallery" class={`mt-10 grid gap-3 pt-12 ${gallery === 4 ? "grid-cols-8" : "grid-cols-6"}`} >
     {
       Array.from({ length: IMAGES_TO_LOAD }).map((_, index) => (
         <a
           class:list={[
-            'boxer-image aspect-square transition hover:scale-105 hover:brightness-125',
-            { 'col-span-3': index < 2 },
-            { 'col-span-2': index >= 2 },
+            "boxer-image aspect-square transition hover:scale-105 hover:brightness-125",
+            { "col-span-3": gallery === 2 || (gallery === 5 && index < 2) },
+            { "col-span-2": [3, 4].includes(gallery) || (gallery === 5 && index >= 2), },
           ]}
           href={`/images/fighters/gallery/${id}/${index + 1}.webp`}
           title={`Abrir imagen ${index} de la galería de ${name}`}

--- a/src/utils/get-image-count.ts
+++ b/src/utils/get-image-count.ts
@@ -1,0 +1,15 @@
+import fs from 'fs'
+import path from 'path'
+
+export function fighterGallery(id: string): number {
+    const dirPath = path.join(process.cwd(), 'public', 'images', 'fighters', 'gallery', id)
+
+    try {
+        const files = fs.readdirSync(dirPath)
+        const webpFiles = files.filter((file) => file.endsWith('.webp'))
+
+        return webpFiles.length
+    } catch (error) {
+        return 0
+    }
+}


### PR DESCRIPTION
## Describe your changes
Implemented dynamic image loading for the fighter gallery. The system now automatically loads available images based on what's present, reducing manual configuration and improving scalability.

## Include a screenshot/video where applicable
![2 Images](https://github.com/user-attachments/assets/6b9ecefd-a0bd-4766-9ca2-073e423af160)
![3 Images](https://github.com/user-attachments/assets/5d03600c-1846-424d-828c-47d6fd9506d2)
![4 Images](https://github.com/user-attachments/assets/51688d99-cd2f-4399-8d52-30b072a3a1af)
![5 Images](https://github.com/user-attachments/assets/472c4d89-27c1-4ebd-9f91-9f70b3918063)

## Type of change
- [X] New feature (non-breaking change which adds functionality)
