### PR TITLE
Error visual en sección del estadio corregido con padding (p-20)

### DIFF
--- a/src/components/HeroCss.astro
+++ b/src/components/HeroCss.astro
@@ -41,7 +41,7 @@ const secondRow = FIGHTERS.slice(6)
 
       <div class="relative z-50">
         <h3
-          class="text-theme-seashell animate-fade-in animate-delay-500 z-0 mt-4 leading-[100%] font-light"
+          class="text-theme-seashell animate-fade-in animate-delay-500 p-20 z-0 mt-4 leading-[100%] font-light"
         >
           ESTADIO<br />LA CARTUJA,<br /><strong>SEVILLA</strong>
         </h3>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -43,7 +43,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
         <div class="absolute top-0 z-0 size-64 bg-pink-400/80 blur-2xl"></div>
       </figure>
 
-      <div class="relative z-10">
+      <div class="relative p-20 z-10">
         <h3
           class="text-theme-seashell animate-fade-in animate-delay-500 z-0 mt-4 leading-relaxed font-medium tracking-wider"
         >


### PR DESCRIPTION
🧩 Problema:
En la sección donde se muestra la ubicación del evento ("Estadio La Cartuja, Sevilla"), el contenido se superponía o quedaba visualmente comprimido, como se muestra en la imagen adjunta.
![1](https://github.com/user-attachments/assets/8da91c2d-05c5-49e6-9f31-b4c703c4eea4)
la solución fue agregarle p-20

y quedo asi:
![2](https://github.com/user-attachments/assets/345d3791-74d8-4186-bb18-db718aefa66f)
