### PR TITLE
Mejorar la animación en el componente de combate según el número de combate para hacer que venga de izquierda, derecha o abajo

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -32,7 +32,7 @@ import { combates } from '@/consts/pageTitles'
               href={`combates/${id}`}
               title={`Ir al combate ${number} de ${title}`}
             >
-              <div class="combat group animate-fade-in animate-delay-200 relative flex h-[40vh] w-full sm:h-[50vh] lg">
+              <div class= {`combat group ${number == 7 ? 'animate-fade-in-up' : number % 2 == 0 ? 'animate-fade-in-left' : 'animate-fade-in-right'}  animate-delay-200 relative flex h-[40vh] w-full sm:h-[50vh] lg`}>
                 {fighters.map((fighter, index) => (
                   <img
                     src={`/images/fighters/big/${fighter}.webp`}


### PR DESCRIPTION
Hola Midu que tal como estas, espero que bien. Esta PR da una mejor animación en la pagina de combates se usaron la animaciones de tu plugin de tailwind y se uso el la "number" propiedad para hacer este efecto. Espero te guste


Antes: 

https://github.com/user-attachments/assets/944ffe0d-e654-4f59-8978-e0753bb60dbb


despues:

https://github.com/user-attachments/assets/58b1dc43-69a3-420e-b40a-02ba513c3b93


Nota: GitHub solo me deja subir videos de 6 segundos, por eso no va tan rápido el video

