### PR TITLE
Mejorar responsive en pagina luchador

### DIFF
--- a/src/components/BoxerSocialLink.astro
+++ b/src/components/BoxerSocialLink.astro
@@ -31,7 +31,7 @@ const getColorBySocialNetwork = (name: string) => {
   href={social.url}
   target="_blank"
   aria-label={social.label ?? social.name}
-  class={`${getColorBySocialNetwork(social.name)} w-20 py-1 flex flex-col items-center justify-center rounded-lg shadow-lg transition duration-500 hover:scale-125`}
+  class={`${getColorBySocialNetwork(social.name)} w-18 sm:w-20 py-1 flex flex-col items-center justify-center rounded-lg shadow-lg transition duration-500 hover:scale-125`}
 >
   {social.image?.logo && (
     // Asegúrate de que logo es un componente o imagen


### PR DESCRIPTION
se tuvo que reducir el tamaño de el componente BoxerSocialLink a w-18 en tamaños de pantalla pequeños para que quede mejor el responsive.

Antes:

![antes](https://github.com/user-attachments/assets/f86f6f79-7e71-4d7d-83eb-fdd73abea00f)


Despues:

![despues](https://github.com/user-attachments/assets/9e971001-f975-46b4-9764-ceb18724f5d1)
