### PR TITLE
Feat: Fix responsive on boxer selection

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,7 +17,7 @@ export default defineConfig({
 
   experimental: {
 
-    svg: true
+    svg: true,
    },
 
   adapter: vercel(),

--- a/src/components/BoxerCard.astro
+++ b/src/components/BoxerCard.astro
@@ -10,7 +10,7 @@ interface Props {
 ---
 
 <a
-  class={`boxer-card ${extraClass} inline-block transition-all w-10 sm:w-14 md:w-16 lg:w-20 xl:w-24 2xl:w-26 group relative rounded-lg duration-300 hover:scale-110 hover:shadow-lg hover:z-20 focus-visible:scale-110 focus-visible:shadow-lg focus-visible:z-20 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-theme-tickle-me-pink`}
+  class={`boxer-card ${extraClass} inline-block transition-all w-24 sm:w-24 md:w-16 lg:w-20 xl:w-24 2xl:w-26 group relative rounded-lg duration-300 hover:scale-110 hover:shadow-lg hover:z-20 focus-visible:scale-110 focus-visible:shadow-lg focus-visible:z-20 focus:outline-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-theme-tickle-me-pink`}
   aria-label={`Ver perfil del boxeador ${name}`}
   href={`/luchador/${id}`}
   data-id={id}

--- a/src/components/BoxerGallery.astro
+++ b/src/components/BoxerGallery.astro
@@ -23,7 +23,7 @@ const IMAGES_TO_LOAD = Math.min(gallery,5)
           class:list={[
             "boxer-image aspect-square transition hover:scale-105 hover:brightness-125",
             { "col-span-3": gallery === 2 || (gallery === 5 && index < 2) },
-            { "col-span-2": [3, 4].includes(gallery) || (gallery === 5 && index >= 2), },
+            { "col-span-2": [3, 4].includes(gallery) || (gallery === 5 && index >= 2) },
           ]}
           href={`/images/fighters/gallery/${id}/${index + 1}.webp`}
           title={`Abrir imagen ${index} de la galería de ${name}`}

--- a/src/components/Boxers/BoxerBigImages.astro
+++ b/src/components/Boxers/BoxerBigImages.astro
@@ -1,0 +1,49 @@
+---
+import type { Fighters } from '@/types/fighters'
+interface Props {
+  boxers: Fighters[]
+}
+
+const { boxers } = Astro.props
+---
+
+<div id="fighter-container" class="pointer-events-none absolute inset-0 flex flex-col items-center">
+  <div class="z-1 relative top-96 mx-auto flex h-[4.5rem] w-full items-center justify-center">
+    {
+      boxers.map(({ id, name }) => (
+        <div class="relative h-20 overflow-hidden">
+          <img
+            data-id={`hero-text-${id}`}
+            src={`/images/fighters/text/${id}.webp`}
+            alt={name}
+            decoding="async"
+            class="mask-fade-text hidden h-full w-auto"
+            fetchpriority="low"
+          />
+          <div
+            id={`mask-fade-text-${id}`}
+            class="absolute inset-0 -translate-x-full rotate-45 bg-gradient-to-tr from-transparent via-white/20 to-transparent transition-transform duration-[2s] ease-in-out"
+          />
+        </div>
+      ))
+    }
+  </div>
+
+  <div
+    class="mask-fade-bottom relative bottom-0 mx-auto flex h-[80vh] w-full items-center justify-center"
+  >
+    {
+      boxers.map(({ id, name }) => (
+        <img
+          transition:name={`image-${id}`}
+          data-id={`hero-image-${id}`}
+          src={`/images/fighters/big/${id}.webp`}
+          alt={name}
+          decoding="async"
+          class="absolute hidden h-full w-auto object-cover lg:object-contain"
+          fetchpriority="low"
+        />
+      ))
+    }
+  </div>
+</div>

--- a/src/components/Boxers/ColumnBoxers.astro
+++ b/src/components/Boxers/ColumnBoxers.astro
@@ -1,0 +1,110 @@
+---
+import BoxerCard from '@/components/BoxerCard.astro'
+import type { HTMLAttributes } from 'astro/types'
+
+import type { Fighters } from '@/types/fighters'
+
+interface Props {
+  boxers: Fighters[]
+  class?: string
+  selectedBoxer: Fighters
+  imgLoading?: HTMLAttributes<'img'>['loading']
+}
+
+const { boxers, class: className = '', selectedBoxer, imgLoading } = Astro.props
+
+const hasSameOpponents = (selectedBoxerOpponents: string[], opponents: string[]) => {
+  return selectedBoxerOpponents.every((sBoxerOpponent) => opponents.includes(sBoxerOpponent))
+}
+
+const isOpponent = (id: Fighters['id'], versus: Fighters['versus']) => {
+  const selectedBoxerOpponents = Array.isArray(selectedBoxer.versus)
+    ? selectedBoxer.versus
+    : [selectedBoxer.versus]
+
+  const opponents = Array.isArray(versus) ? versus : [versus]
+
+  return (
+    selectedBoxerOpponents.includes(id) ||
+    (hasSameOpponents(selectedBoxerOpponents, opponents) && id !== selectedBoxer.id)
+  )
+}
+---
+
+<div class:list={`flex flex-col ${className}`}>
+  {
+    boxers.map(({ id, name, versus }) => (
+      <BoxerCard id={id} name={name} versus={versus} class="boxer-link" />
+    ))
+  }
+</div>
+
+<style>
+  @reference "../../styles/global.css";
+
+  .boxer-link {
+    @apply relative mb-2 flex flex-col items-center justify-center transition-opacity duration-300 ease-in-out md:size-28 xl:size-36;
+
+    &:hover {
+      @apply opacity-90;
+    }
+
+    & .boxer-image {
+      @apply z-20 aspect-square h-full w-full object-contain transition-opacity duration-300 ease-in-out;
+      mask-image: linear-gradient(to bottom, black 85%, transparent 100%);
+      filter: grayscale(100%);
+      transition: filter 0.3s ease;
+    }
+  }
+
+  .boxer-link-background {
+    @apply absolute bottom-0 block h-3/5 w-full opacity-25 transition-opacity duration-300 ease-in-out;
+    background: linear-gradient(
+      180deg,
+      rgba(255, 255, 255, 1) 0%,
+      rgba(255, 255, 255, 0.5) 30%,
+      rgba(0, 0, 0, 0) 95%
+    );
+  }
+
+  .boxer-link:hover .boxer-image,
+  .boxer-link.active .boxer-image {
+    transition: scale 0.3s ease-in-out;
+    scale: 1.05;
+    filter: grayscale(0%);
+  }
+
+  .boxer-link.ally {
+    & .boxer-image {
+      transition: scale 0.3s ease-in-out;
+      scale: 1.05;
+    }
+
+    &::after {
+      content: 'aliada';
+      @apply pointer-events-none absolute bottom-0 z-50 text-2xl text-green-500;
+      text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  .boxer-link.opponent {
+    & .boxer-image {
+      transition: scale 0.3s ease-in-out;
+      scale: 1.05;
+    }
+
+    &::after {
+      content: 'versus';
+      @apply pointer-events-none absolute bottom-0 z-50 text-2xl text-red-500;
+      text-shadow: 0 0 5px rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  .boxer-link.active .boxer-link-background,
+  .boxer-link:hover .boxer-link-background {
+    filter: brightness(0.5);
+  }
+  .rotate-y-180 {
+    transform: rotateY(180deg);
+  }
+</style>

--- a/src/components/Boxers/SelectYourBoxer.astro
+++ b/src/components/Boxers/SelectYourBoxer.astro
@@ -3,6 +3,7 @@ import BoxerCard from '@/components/BoxerCard.astro'
 import BoxerBigImages from '@/components/Boxers/BoxerBigImages.astro'
 import ColumnBoxers from '@/components/Boxers/ColumnBoxers.astro'
 import type { Fighters } from '@/types/fighters'
+import HorizontalScroll from '@/components/Icons/HorizontalScroll.astro'
 
 interface Props {
   boxers: Fighters[]
@@ -82,12 +83,12 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
 <div class="-mt-20 flex flex-col items-center justify-center md:mt-32 md:hidden">
   <div class="carousel mt-8 w-full max-w-[100vw] overflow-y-hidden overflow-x-scroll">
     <div
-      class="carousel-inner flex snap-x snap-mandatory overflow-y-hidden overflow-x-scroll pr-[40%]"
+      class="fadeout-horizontal no-scrollbar flex snap-x snap-mandatory gap-12 overflow-y-hidden overflow-x-scroll py-2 pr-[40%]"
     >
       {
         boxers.map((boxer, index) => (
           <div
-            class:list={`carousel-item w-[70%] flex-shrink-0 snap-center px-2 ${index === 0 ? 'ml-[65%]' : ''} `}
+            class:list={`w-fit flex-shrink-0 snap-center px-2 ${index === 0 ? 'ml-[75%]' : ''} `}
           >
             <ColumnBoxers boxers={[boxer]} selectedBoxer={selectedBoxer} />
           </div>
@@ -95,4 +96,17 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
       }
     </div>
   </div>
+  <HorizontalScroll class:list={['text-theme-seashell w-16 pt-2 opacity-80']} />
 </div>
+
+<style>
+  .fadeout-horizontal {
+    mask-image: linear-gradient(
+      to right,
+      transparent,
+      black 4.5rem,
+      black calc(100% - 4.5rem),
+      transparent
+    );
+  }
+</style>

--- a/src/components/Boxers/SelectYourBoxer.astro
+++ b/src/components/Boxers/SelectYourBoxer.astro
@@ -1,0 +1,98 @@
+---
+import BoxerCard from '@/components/BoxerCard.astro'
+import BoxerBigImages from '@/components/Boxers/BoxerBigImages.astro'
+import ColumnBoxers from '@/components/Boxers/ColumnBoxers.astro'
+import type { Fighters } from '@/types/fighters'
+
+interface Props {
+  boxers: Fighters[]
+  selectedBoxer: Fighters
+}
+
+const { boxers, selectedBoxer } = Astro.props
+
+const firstRow = boxers.slice(0, 6)
+const leftRow = firstRow.slice(0, 3)
+const rightRow = firstRow.slice(3)
+
+const secondRow = boxers.slice(6)
+const leftSecondRow = secondRow.slice(0, 4)
+const rightSecondRow = secondRow.slice(4, 8)
+
+const animationDelay = [500, 700, 800]
+const reverseDelay = [...animationDelay].reverse()
+
+const animationDelaySecondRow = [...animationDelay, 900]
+const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
+---
+
+<BoxerBigImages boxers={boxers} />
+
+<div
+  id="fighters-selection-container"
+  class="relative flex h-full w-full max-w-6xl flex-col items-center justify-end gap-8 sm:p-4"
+>
+  <div class="hidden w-full flex-wrap justify-center gap-4 px-0 sm:justify-between sm:px-4 md:flex">
+    <div class="flex flex-wrap justify-start gap-4">
+      {
+        leftRow.map(({ id, name, versus }, index) => (
+          <div
+            class={`animate-fade-in-right animate-duration-slower animate-delay-${animationDelay[index]}`}
+          >
+            <BoxerCard id={id} name={name} class="boxer-left" versus={versus} />
+          </div>
+        ))
+      }
+    </div>
+
+    <div class="hidden flex-wrap justify-end gap-4 md:flex">
+      {
+        rightRow.map(({ id, name, versus }, index) => (
+          <div
+            class={`animate-fade-in-left animate-duration-slower animate-delay-${reverseDelay[index]}`}
+          >
+            <BoxerCard id={id} name={name} class="boxer-right" versus={versus} />
+          </div>
+        ))
+      }
+    </div>
+  </div>
+
+  <div class="hidden flex-wrap justify-center gap-4 sm:justify-between md:flex">
+    <div class="flex flex-wrap justify-start gap-4">
+      {
+        leftSecondRow.map(({ id, name, versus }, index) => (
+          <div class={`animate-fade-in-up animate-delay-${animationDelaySecondRow[index]}`}>
+            <BoxerCard id={id} name={name} class="boxer-left" versus={versus} />
+          </div>
+        ))
+      }
+    </div>
+    <div class="hidden flex-wrap justify-end gap-4 md:flex">
+      {
+        rightSecondRow.map(({ id, name, versus }, index) => (
+          <div class={`animate-fade-in-up animate-delay-${reverseDelaySecondRow[index]}`}>
+            <BoxerCard id={id} name={name} class="boxer-right" versus={versus} />
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</div>
+<div class="-mt-20 flex flex-col items-center justify-center md:mt-32 md:hidden">
+  <div class="carousel mt-8 w-full max-w-[100vw] overflow-y-hidden overflow-x-scroll">
+    <div
+      class="carousel-inner flex snap-x snap-mandatory overflow-y-hidden overflow-x-scroll pr-[40%]"
+    >
+      {
+        boxers.map((boxer, index) => (
+          <div
+            class:list={`carousel-item w-[70%] flex-shrink-0 snap-center px-2 ${index === 0 ? 'ml-[65%]' : ''} `}
+          >
+            <ColumnBoxers boxers={[boxer]} selectedBoxer={selectedBoxer} />
+          </div>
+        ))
+      }
+    </div>
+  </div>
+</div>

--- a/src/components/Icons/HorizontalScroll.astro
+++ b/src/components/Icons/HorizontalScroll.astro
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66.1 44" class:list={Astro.props.class}
+  ><defs
+    ><style>
+      .cls-1 {
+        stroke: currentColor;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        stroke-width: 2px;
+        fill: none;
+      }
+    </style></defs
+  ><path d="M0 0h44v44H0V0Z" style="stroke-width:0;fill:none"></path><path
+    class="cls-1"
+    d="M29.33 22H5.5M8.69 16.56l-5.5 5.5 5.5 5.5M34.47 17.42 39.05 22l-4.58 4.58L29.89 22l4.58-4.58ZM62.88 22H39.05M59.6 16.56l5.5 5.5-5.5 5.5"
+  ></path></svg
+>

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -33,8 +33,6 @@ const selectedBoxer = FIGHTERS.find((boxer) => boxer.id === selectedBoxerId) ?? 
         <div class="absolute top-0 z-0 size-64 bg-pink-400/80 blur-2xl"></div>
       </figure>
 
-
-
       <div class="relative z-10">
         <h3 class="text-theme-seashell animate-fade-in animate-delay-500 z-0 mt-0 font-medium">
           <a
@@ -83,14 +81,36 @@ const selectedBoxer = FIGHTERS.find((boxer) => boxer.id === selectedBoxerId) ?? 
 
   document.addEventListener('astro:page-load', () => {
     const $landing = $('#landing')
+    let isMobile = window.matchMedia('(max-width: 768px)').matches
+
+    // Para que cuando cambie el tamaño de la ventana cambie el estado de si es mobile
+    // por si alguien al hacer resize ve que no funciona bien el cambio
+    // Los cambios estan pensandos para que se apliquen al entrar con un dispositivo u otro
+    window.addEventListener('resize', () => {
+      isMobile = window.matchMedia('(max-width: 768px)').matches
+    })
 
     let currentFighterId: string | null = null
     let hideFighterTimer: ReturnType<typeof setTimeout>
 
     document.addEventListener('boxer-card-exit', () => {
-      $landing?.classList.remove('hidden')
+      let showFighter = false
 
       if (!currentFighterId) return
+
+      if (isMobile) {
+        for (const card of boxerCards) {
+          if (card.getAttribute('data-id') === currentFighterId) {
+            if (card.getAttribute('data-selected') === 'true') {
+              showFighter = true
+              break
+            }
+          }
+        }
+
+        if (showFighter) return
+      }
+      $landing?.classList.remove('hidden')
 
       const heroText = $(`[data-id="hero-text-${currentFighterId}"]`)
       const heroImage = $(`[data-id="hero-image-${currentFighterId}"]`)
@@ -226,11 +246,43 @@ const selectedBoxer = FIGHTERS.find((boxer) => boxer.id === selectedBoxerId) ?? 
     const $fightersContainer = document.getElementById(
       'fighters-selection-container',
     ) as HTMLElement
-    $fightersContainer.appendChild($fighterSelector)
+    if (!isMobile) {
+      $fightersContainer.appendChild($fighterSelector)
+    }
+
+    if (isMobile) {
+      // Quitamos `data-selected` cuando el usuario hace click en el contenedor
+      $fightersContainer.addEventListener('click', (event) => {
+        event.preventDefault()
+        event.stopPropagation()
+        boxerCards.forEach((card) => card.removeAttribute('data-selected'))
+        $landing?.classList.remove('hidden')
+      })
+    }
 
     const boxerCards = document.querySelectorAll('.boxer-card')
 
-    boxerCards.forEach((card) => {
+    boxerCards.forEach((card, cardIndex) => {
+      if (isMobile) {
+        // Agregamos `data-selected` cuando el usuario hace click en el card
+        card.addEventListener('click', (event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          // Si no tiene `data-selected` entonces lo agregamos
+          if (card.getAttribute('data-selected') === null) {
+            card.setAttribute('data-selected', 'true')
+            // Aseguramos que solo se selecciona el luchador que se hizo click
+            boxerCards.forEach((selectedCard, idx) => {
+              if (selectedCard.getAttribute('data-selected') === null || idx === cardIndex) return
+              selectedCard.removeAttribute('data-selected')
+            })
+            return
+          }
+          // Si ya tiene `data-selected` entonces lo quitamos y vamos a la url
+          card.removeAttribute('data-selected')
+          window.location.href = `/luchador/${card.getAttribute('data-id')}`
+        })
+      }
       card.addEventListener('mouseenter', () => {
         const { width, height, left, top } = card.getBoundingClientRect()
         const { left: leftFighterContainer, top: topFighterContainer } =

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -1,20 +1,10 @@
 ---
 import { FIGHTERS } from '@/consts/fighters'
 import BoxerCard from '@/components/BoxerCard.astro'
+import SelectYourBoxer from '@/components/Boxers/SelectYourBoxer.astro'
 
-const firstRow = FIGHTERS.slice(0, 6)
-const leftRow = firstRow.slice(0, 3)
-const rightRow = firstRow.slice(3)
-
-const secondRow = FIGHTERS.slice(6)
-const leftSecondRow = secondRow.slice(0, 4)
-const rightSecondRow = secondRow.slice(4, 8)
-
-const animationDelay = [500, 700, 800]
-const reverseDelay = [...animationDelay].reverse()
-
-const animationDelaySecondRow = [...animationDelay, 900]
-const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
+const selectedBoxerId = Astro.url.searchParams.get('luchador') ?? FIGHTERS[0].id
+const selectedBoxer = FIGHTERS.find((boxer) => boxer.id === selectedBoxerId) ?? FIGHTERS[0]
 ---
 
 <section class="relative flex min-h-screen w-full">
@@ -67,102 +57,7 @@ const reverseDelaySecondRow = [...animationDelaySecondRow].reverse()
         </a>
       </div>
     </div>
-
-    <div
-      id="fighter-container"
-      class="pointer-events-none absolute inset-0 flex flex-col items-center"
-    >
-      <div class="z-1 relative top-96 mx-auto flex h-[4.5rem] w-full items-center justify-center">
-        {
-          FIGHTERS.map(({ id, name }) => (
-            <div class="relative h-20 overflow-hidden">
-              <img
-                data-id={`hero-text-${id}`}
-                src={`/images/fighters/text/${id}.webp`}
-                alt={name}
-                decoding="async"
-                class="mask-fade-text hidden h-full w-auto"
-                fetchpriority="low"
-              />
-              <div
-                id={`mask-fade-text-${id}`}
-                class="absolute inset-0 -translate-x-full rotate-45 bg-gradient-to-tr from-transparent via-white/20 to-transparent transition-transform duration-[2s] ease-in-out"
-              />
-            </div>
-          ))
-        }
-      </div>
-
-      <div
-        class="mask-fade-bottom relative bottom-0 mx-auto flex h-[80vh] w-full items-center justify-center"
-      >
-        {
-          FIGHTERS.map(({ id, name }) => (
-            <img
-              transition:name={`image-${id}`}
-              data-id={`hero-image-${id}`}
-              src={`/images/fighters/big/${id}.webp`}
-              alt={name}
-              decoding="async"
-              class="absolute hidden h-full w-auto object-cover lg:object-contain"
-              fetchpriority="low"
-            />
-          ))
-        }
-      </div>
-    </div>
-
-    <div
-      id="fighters-selection-container"
-      class="relative flex h-full w-full max-w-6xl flex-col items-center justify-end gap-8 sm:p-4"
-    >
-      <div class="flex w-full flex-wrap justify-center gap-4 px-0 sm:justify-between sm:px-4">
-        <div class="flex flex-wrap justify-start gap-4">
-          {
-            leftRow.map(({ id, name, versus }, index) => (
-              <div
-                class={`animate-fade-in-right animate-duration-slower animate-delay-${animationDelay[index]}`}
-              >
-                <BoxerCard id={id} name={name} class="boxer-left" versus={versus} />
-              </div>
-            ))
-          }
-        </div>
-
-        <div class="flex flex-wrap justify-end gap-4">
-          {
-            rightRow.map(({ id, name, versus }, index) => (
-              <div
-                class={`animate-fade-in-left animate-duration-slower animate-delay-${reverseDelay[index]}`}
-              >
-                <BoxerCard id={id} name={name} class="boxer-right" versus={versus} />
-              </div>
-            ))
-          }
-        </div>
-      </div>
-
-      <div class="flex flex-wrap justify-center gap-4 sm:justify-between">
-        <div class="flex flex-wrap justify-start gap-4">
-          {
-            leftSecondRow.map(({ id, name, versus }, index) => (
-              <div class={`animate-fade-in-up animate-delay-${animationDelaySecondRow[index]}`}>
-                <BoxerCard id={id} name={name} class="boxer-left" versus={versus} />
-              </div>
-            ))
-          }
-        </div>
-        <div class="flex flex-wrap justify-end gap-4">
-          {
-            rightSecondRow.map(({ id, name, versus }, index) => (
-              <div class={`animate-fade-in-up animate-delay-${reverseDelaySecondRow[index]}`}>
-                <BoxerCard id={id} name={name} class="boxer-right" versus={versus} />
-              </div>
-            ))
-          }
-        </div>
-      </div>
-    </div>
+    <SelectYourBoxer boxers={FIGHTERS} selectedBoxer={selectedBoxer} />
   </div>
 </section>
 

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,7 @@
 }
 
 @layer base {
+
   /* Webkit Browsers (Chrome, Safari, Edge) */
   ::-webkit-scrollbar {
     width: 10px;
@@ -33,13 +34,28 @@
   }
 
   ::-webkit-scrollbar-thumb:hover {
-    background-color: var(--color-theme-tickle-me-pink); /* Efecto hover */
+    background-color: var(--color-theme-tickle-me-pink);
+    /* Efecto hover */
   }
 
   /* Firefox */
   * {
     scrollbar-color: var(--color-theme-french-mauve) var(--color-theme-raisin-black);
     scrollbar-width: thin;
+  }
+}
+
+@layer utilities {
+  .no-scrollbar::-webkit-scrollbar {
+    display: none;
+  }
+
+  /* Hide scrollbar for IE, Edge and Firefox */
+  .no-scrollbar {
+    -ms-overflow-style: none;
+    /* IE and Edge */
+    scrollbar-width: none;
+    /* Firefox */
   }
 }
 


### PR DESCRIPTION
## Describe your changes

If it is a mobile device change the selector to a scrollable one, where if it clicks it adds `data-selected` first, and if clicked on a selected one, it goes to boxer's page.

## Include a screenshot/video where applicable

https://github.com/user-attachments/assets/1b28d09a-1232-44c1-ba3e-d05d63bb665b

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
