### PR TITLE
Adding Padding for Entradas Hero Image

### DIFF
--- a/src/sections/Entradas.astro
+++ b/src/sections/Entradas.astro
@@ -2,7 +2,7 @@
 import CountdownSmall from '@/components/CountdownSmall.astro'
 ---
 
-<section class="animate-fade-in animate-delay-400 mb-0 mt-32 flex flex-col items-center gap-4">
+<section class="animate-fade-in animate-delay-400 mb-0 mt-32 flex flex-col items-center gap-4 p-5">
   <div class="pointer-events-none relative inset-0 z-0">
     <img
       src="/images/entradas-la-velada.webp"


### PR DESCRIPTION
Adding padding to the hero image in Entradas' section so that it has the same spacing as the Hero Video in Presentation.

**Before**

[before.webm](https://github.com/user-attachments/assets/a33e7398-b509-457a-ab14-42250799a2e3)

**After**

[After.webm](https://github.com/user-attachments/assets/e75c83ca-ad04-412b-a160-5e3e613add47)

- [ ] UI