### PR TITLE
Added padding to the Sponsor banner

### DIFF
--- a/src/components/BannerSponsors.astro
+++ b/src/components/BannerSponsors.astro
@@ -3,7 +3,7 @@ import { BANNERS } from '@/consts/bannerData'
 import SectionTitle from './SectionTitle.astro'
 ---
 
-<section id="banners" class="mx-auto my-16 max-w-xl lg:my-36">
+<section id="banners" class="mx-auto my-16 max-w-xl lg:my-36 p-5">
   <SectionTitle title='Promociones' />
   <div class="flex flex-col items-center gap-8">
     {


### PR DESCRIPTION
Added padding to the sponsor banner so that it has the same spacing as the Hero video in Presentation

**Before**

[sponsor-before.webm](https://github.com/user-attachments/assets/7240d00c-a5bb-4025-b265-03301a85db3e)

**After**

[sponsor-after.webm](https://github.com/user-attachments/assets/79e13125-a151-45c3-be93-bdcde29f4655)

- [ ] UI