### PR TITLE
fix: correct blurred images size to not overflow

### DIFF
--- a/src/components/LiteYouTube.astro
+++ b/src/components/LiteYouTube.astro
@@ -16,7 +16,7 @@ const { videoId, title, backgroundImage, withShadowImage } = Astro.props
         src={backgroundImage}
         alt=""
         aria-hidden="true"
-        class="absolute -z-10 mx-auto max-w-4xl scale-105 object-center opacity-70 blur-xl brightness-150"
+        class="absolute inset-0 -z-10 mx-auto scale-105 object-center opacity-70 blur-xl brightness-150"
         loading="lazy"
         decoding="async"
       />

--- a/src/sections/Entradas.astro
+++ b/src/sections/Entradas.astro
@@ -2,13 +2,15 @@
 import CountdownSmall from '@/components/CountdownSmall.astro'
 ---
 
-<section class="animate-fade-in animate-delay-400 mb-0 mt-32 flex flex-col items-center gap-4">
+<section
+  class="animate-fade-in animate-delay-400 mb-0 mt-32 flex max-w-4xl flex-col items-center gap-4 px-5 py-36 md:mx-auto"
+>
   <div class="pointer-events-none relative inset-0 z-0">
     <img
       src="/images/entradas-la-velada.webp"
       alt=""
       aria-hidden="true"
-      class="absolute -z-10 mx-auto max-w-4xl scale-110 object-center opacity-70 blur-xl brightness-75"
+      class="absolute inset-0 -z-10 mx-auto scale-105 object-center opacity-70 blur-xl brightness-75"
       loading="lazy"
       decoding="async"
     />


### PR DESCRIPTION
## Describe your changes

Fix blurred image sizes

## Include a screenshot/video where applicable

Before:

![Screenshot 2025-04-24 at 13 23 04](https://github.com/user-attachments/assets/4b3e3daf-71ed-460b-b1c7-d45d8ba59206)

After:

![Screenshot 2025-04-24 at 13 24 09](https://github.com/user-attachments/assets/e10869e8-1f09-4ac3-9328-76a8f2225720)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
