### PR TITLE
feat(global.css): change `h-screen` and `min-h-screen` to be dynamic

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -57,6 +57,24 @@
     scrollbar-width: none;
     /* Firefox */
   }
+
+  .min-h-screen {
+    min-height: 100svh;
+  }
+
+  .h-screen {
+    height: 100svh;
+  }
+
+  @media (min-width: 768px) {
+    .min-h-screen {
+      min-height: 100vh;
+    }
+
+    .h-screen {
+      height: 100vh;
+    }
+  }
 }
 
 @font-face {


### PR DESCRIPTION
## Describe your changes

In mobile, some browsers have buttons at top and or at bottom of the screen, covering up some parts of the UI.

I made the change in the `global.css` because changing it in all instances and keeping track of all new uses `h-screen` or `min-h-screen` to be `h-svh md:h-screen` is not feasible with this much developers and changes.

## Include a screenshot/video where applicable

Before:

![IMG_6695](https://github.com/user-attachments/assets/772fd9c5-2c5b-4aec-9fef-83e9e028c13a)

After:

![IMG_6694](https://github.com/user-attachments/assets/79339e0c-6619-455c-ad52-391bfd1d4141)

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
