### PR TITLE
🐛 Fix: Área invisible del <nav> bloqueando interacciones en escritorio

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -42,7 +42,7 @@ const isActive = (path: string) => pathname === path
     </div>
     <nav
       id="navContent"
-      class="bg-theme-french-mauve/90 invisible fixed right-0 top-0 mx-auto h-screen max-w-6xl translate-x-full items-center justify-between space-y-2 px-6 pt-14 text-xs font-light backdrop-blur-2xl md:visible md:relative md:flex md:h-fit md:w-full md:translate-x-0 md:space-y-0 md:bg-transparent md:py-4 md:backdrop-blur-none lg:text-sm"
+      class="bg-theme-french-mauve/90 invisible fixed right-0 top-0 mx-auto h-screen max-w-6xl translate-x-full items-center justify-between space-y-2 px-6 pt-14 text-xs font-light backdrop-blur-2xl md:visible md:relative md:flex md:!h-fit md:w-full md:translate-x-0 md:space-y-0 md:bg-transparent md:py-4 md:backdrop-blur-none lg:text-sm"
     >
       <div
         class:list={[


### PR DESCRIPTION
## Describe your changes

Actualmente, el "nav" tiene una altura de 100vh debido a una sobreescrita por estilos globales, que en version escritorio genera una zona invisible que se superpone al contenido e impide hacer clic en elementos

Isuue abierto por @GFrancV  -> [Ver issue](https://github.com/midudev/la-velada-web-oficial/issues/1381)

## Include a screenshot/video where applicable

https://github.com/user-attachments/assets/2d89402b-4ce5-40f5-b37c-9ba5bcdb93c9

Clase utilitaria ignorada del navbar

<img width="457" alt="Captura de pantalla 2025-04-30 a la(s) 10 17 33 p m" src="https://github.com/user-attachments/assets/c1193fb2-35a0-4328-a5a5-d5fa8d159ec6" />


### styles/globals.css

![captura-2024-09-24-1823](https://github.com/user-attachments/assets/2615e828-2e2c-4bfe-9857-4fc7d8b65170)


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
