### PR TITLE
change state of PRERENDER to false

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -24,7 +24,7 @@ const birthDate = fighter.birthDate.toLocaleDateString('es-ES', {
 
 const opponent = FIGHTERS.find((f) => f.id === fighter.versus)
 
-export const prerender = true
+export const prerender = false
 ---
 
 <Layout title={`${fighter.name} | ${fixedTitle}`}>


### PR DESCRIPTION
## Describe your changes
Existía un error al hacer hover a las cards `getStaticPaths()` function required for dynamic routes., esto lo producía el estado de la constante PRERENDER en 'true' en el archivo [id].astro. está lento por que mi computador es muy básico.

## Include a screenshot/video where applicable
##BEFORE
[erorr al hacer hover.webm](https://github.com/user-attachments/assets/77892d50-326d-47b7-8c6b-dcfa073aedda)

##AFTER
[error corregido.webm](https://github.com/user-attachments/assets/2fbb5ce6-ad74-48e9-8d93-d45af59b6ffa)

## Type of change
 Se corrigió cambiándo el estado de la constante PRERENDER a false.

