### PR TITLE
fix(Hero): adjust positioning of background blur effect

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -29,7 +29,7 @@ const selectedBoxer = FIGHTERS.find((boxer) => boxer.id === selectedBoxerId) ?? 
           alt="La Velada del Año V"
           decoding="async"
         />
-        <div class="absolute top-0 z-0 size-64 bg-pink-400/80 blur-2xl"></div>
+        <div class="absolute z-0 size-64 bg-pink-400/80 blur-2xl top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2"></div>
       </figure>
 
       <div class="relative z-10">


### PR DESCRIPTION
## Describe your changes
Se hizo un ajuste en la posición del 'div' de fondo al logo en el Hero para que la viñeta rosa quede centrada.

## Include a screenshot/video where applicable

### Desktop:

![desktop](https://github.com/user-attachments/assets/2d2da833-4cbc-4554-8d11-8616c1c98f8e)

### Mobile:

![mobile](https://github.com/user-attachments/assets/948a82ae-e1ac-4a51-a8a7-34eb7d571319)



## Type of change
<!-- Please delete options that are not relevant. -->

- [ x ] Bug fix (non-breaking change which fixes an issue)
