### PR TITLE
Fix clickable area for ticket purchase on the Home page

### DIFF
--- a/src/sections/Entradas.astro
+++ b/src/sections/Entradas.astro
@@ -18,17 +18,13 @@
       decoding="async"
     />
   </div>
-  <p
-    class="z-50 text-wrap rounded-lg border border-white bg-pink-400/90 px-6 py-2 text-center text-lg font-bold text-white shadow-md sm:text-2xl"
+  <a
+    class="z-50 text-wrap rounded-lg border border-white bg-pink-400/90 px-6 py-2 text-center text-lg font-bold text-white shadow-md sm:text-2xl transition-transform hover:scale-110 cursor-pointer"
+    href="https://www.entradas.com/artist/la-velada-del-ano/la-velada-del-ano-v-3883352/?affiliate=LVL"
+    rel="noopener noreferrer"
+    target="_blank"
+    title="Comprar entradas para La Velada V"
   >
-    <a
-      class="transition-transform hover:scale-110"
-      href="https://www.entradas.com/artist/la-velada-del-ano/la-velada-del-ano-v-3883352/?affiliate=LVL"
-      rel="noopener noreferrer"
-      target="_blank"
-      title="Comprar entradas para La Velada V"
-    >
-      ¡Entradas ya a la venta!
-    </a>
-  </p>
+    ¡Entradas ya a la venta!
+  </a>
 </section>


### PR DESCRIPTION
## Describe your changes
Previously, the <a> element was nested within a <p> tag, and due to its automatic margins, it was not possible to click the entire button area. This resulted in limited accessibility to the ticket purchase page. 
After addressing the issue, the clickable area has been expanded to ensure full accessibility to the purchase page.

## Include a screenshot/video where applicable
Antes:
![antes](https://github.com/user-attachments/assets/c08f0234-15da-4225-a2c2-7fa97d002d8c)
![despues](https://github.com/user-attachments/assets/96f47b09-756f-4c64-aa8e-eed6a6e9a534)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)