### PR TITLE
fix: accessibility by ensuring proper cursor styles on text elements

### DIFF
--- a/src/components/BoxerClipCard.astro
+++ b/src/components/BoxerClipCard.astro
@@ -1,8 +1,6 @@
 ---
-
 const { index, text, url, externalPlayer } = Astro.props
 const delay = index * 400
-const { id } = Astro.params
 ---
 
 <li
@@ -14,22 +12,18 @@ const { id } = Astro.params
       <a
         href={url}
         target="_blank"
-        class="clips-drawer-open animate-fade-in duration-600 before:z-1 group relative z-0 flex cursor-pointer flex-col items-start justify-start space-x-2 break-words rounded-2xl rounded-br-none bg-pink-200/60 px-3 pt-6 pb-4 text-left text-lg font-normal lowercase before:absolute before:-top-5 before:left-6 before:text-8xl before:text-pink-500 before:content-['“'] hover:scale-105"
+        class="clips-drawer-open animate-fade-in duration-600 before:z-1 group relative z-0 flex cursor-pointer flex-col items-start justify-start space-x-2 break-words rounded-2xl rounded-br-none bg-pink-200/60 px-3 pb-4 pt-6 text-left text-lg font-normal lowercase before:absolute before:-top-5 before:left-6 before:text-8xl before:text-pink-500 before:content-['“'] hover:scale-105"
       >
         <span class="text-dark-magenta">{text}</span>
-        <span class="relative mt-2 flex w-full items-center justify-end text-sm text-red-600 before:absolute before:right-0 before:top-0 before:h-[2px] before:w-[60px] before:rounded-full before:bg-pink-500 before:content-['']">
-        </span>
+        <span class="relative mt-2 flex w-full items-center justify-end text-sm text-red-600 before:absolute before:right-0 before:top-0 before:h-[2px] before:w-[60px] before:rounded-full before:bg-pink-500 before:content-['']" />
       </a>
     )
   }
   {
     !externalPlayer && (
-      <article
-        class="animate-fade-in duration-600 before:z-1 relative z-0 flex cursor-pointer flex-col items-start justify-start space-x-2 text-wrap break-words rounded-2xl rounded-br-none bg-pink-200/60 px-3 pt-6 pb-4 text-left text-lg font-normal lowercase before:absolute before:-top-5 before:left-6 before:text-8xl before:text-pink-500 before:content-['“'] hover:scale-105"
-      >
-        <span class="text-dark-magenta">{text}</span>
-        <span class="relative mt-2 flex w-full items-center justify-end text-sm text-red-600 before:absolute before:right-0 before:top-0 before:h-[2px] before:w-[60px] before:rounded-full before:bg-pink-500 before:content-['']">
-        </span>
+      <article class="animate-fade-in duration-600 before:z-1 relative z-0 flex flex-col items-start justify-start space-x-2 text-wrap break-words rounded-2xl rounded-br-none bg-pink-200/60 px-3 pb-4 pt-6 text-left text-lg font-normal lowercase before:absolute before:-top-5 before:left-6 before:text-8xl before:text-pink-500 before:content-['“'] hover:scale-105">
+        <span class="text-dark-magenta cursor-default">{text}</span>
+        <span class="relative mt-2 flex w-full items-center justify-end text-sm text-red-600 before:absolute before:right-0 before:top-0 before:h-[2px] before:w-[60px] before:rounded-full before:bg-pink-500 before:content-['']" />
       </article>
     )
   }

--- a/src/components/BoxerClipList.astro
+++ b/src/components/BoxerClipList.astro
@@ -24,8 +24,12 @@ const clips_sorted_by_text_size = clips.sort((a, b) => b.text.length - a.text.le
       <BoxerClipCard externalPlayer={externalPlayer} index={i} text={clip.text} url={clip.url} />
     ))
   }
-  <li  class=" mt-4 flex justify-end  cursor-pointer  p-0">
-    <label for="clip-drawer-toggle" style={{ animationDelay: `${400*clips.length}ms` }} class="animate-fade-in-up h-6 text-dark-magenta bg-white/20 duration-600 hover:scale-105 relative mt-2 flex px-2 py-0 rounded-sm items-center justify-end  text-sm  cursor-pointer">
+  <li class="mt-4 flex cursor-pointer justify-end p-0">
+    <label
+      for="clip-drawer-toggle"
+      style={{ animationDelay: `${400 * clips.length}ms` }}
+      class="animate-fade-in-up text-dark-magenta duration-600 relative mt-2 flex h-6 cursor-pointer items-center justify-end rounded-sm bg-white/20 px-2 py-0 text-sm hover:scale-105"
+    >
       <Youtube class="mr-2 inline-flex w-4 text-red-600" />
       <span class="text-xs">Ver clips del combate</span>
     </label>


### PR DESCRIPTION
## Describe your changes
Replaced pointers for default cursor on non-interactable texts.

## Include a screenshot/video where applicable
Before:
![chrome_XzIyNZfgXb](https://github.com/user-attachments/assets/a17f6cff-c0fb-4a06-bd7d-73fd200527fe)

After:
![chrome_luTLbZ89gC](https://github.com/user-attachments/assets/cc331eff-44c6-4643-b7a9-1504f8c3d0c8)

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)
