### PR TITLE
fix: missing hyperlink to infojobs

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -28,7 +28,14 @@ import InfojobsLogo from '@/assets/sponsors/Infojobs.svg'
 
     <div class="mb-8 mt-3 flex flex-col items-center justify-center">
       <span class="mb-1 text-xs text-[#2a1f26]">Web patrocinada por</span>
-      <InfojobsLogo class="h-6 w-auto text-[#2a1f26] md:h-7" style="max-width:120px" />
+      <a
+        href="https://www.infojobs.net"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="flex items-center justify-center transition hover:scale-125"
+      >
+        <InfojobsLogo class="h-6 w-auto text-[#2a1f26] md:h-7" style="max-width:120px" />
+      </a>
     </div>
 
     <div class="pb-48 opacity-90">


### PR DESCRIPTION
## Describe your changes
Wrapped footer's Infojobs logo in a hyperlink for external navigation.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)