### PR TITLE
Adjust layout to prevent bio and clips overlap on fighter page

### DIFF
--- a/src/pages/luchador/[id].astro
+++ b/src/pages/luchador/[id].astro
@@ -102,7 +102,7 @@ export const prerender = false
 
   {
     fighter.bio && (
-      <section class="relative z-10 mx-auto mb-16 mt-10 max-w-6xl px-4 font-sans font-semibold lg:-mt-48 lg:px-10">
+      <section class="relative z-10 mx-auto mb-16 mt-10 max-w-6xl px-4 font-sans font-semibold lg:-mt-24 lg:px-10">
         <div class="flex flex-col gap-8 lg:flex-row lg:gap-16">
           {/* Columna izquierda: Biografía */}
           <div class="gap-y flex flex-col justify-center gap-y-16 lg:w-1/2">


### PR DESCRIPTION
## Describe your changes
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
Adjusted the desktop layout on the fighter profile page to prevent the biography section from overlapping with the clips (currently the "ver clips del combate" section).
Reduced the negative top margin on the bio section to ensure each section is visually separated and improves the page’s readability.

## Include a screenshot/video where applicable
<!-- Please add screenshots to help explain your changes. Delete this section if not needed. -->
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/8618fbf9-02b2-4f22-b128-86e2ce404f86" width="400"/> | <img src="https://github.com/user-attachments/assets/cef65279-d13c-4e77-b133-f5a9a60ca63c" width="400"/> |
| <img src="https://github.com/user-attachments/assets/d8228c45-6a81-449d-8084-3bace915e62b" width="400"/> | <img src="https://github.com/user-attachments/assets/da6856f6-4879-4203-bd0b-38c6b48c1867" width="400"/> |




## Type of change
<!-- Please delete options that are not relevant. -->

- [✅] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
