### PR TITLE
Fix nav content (menu) mobile height

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -40,11 +40,11 @@ const isActive = (path: string) => pathname === path
       <img src="/favicon.svg" alt="logo" class="h-auto w-7" />
     </a>
 
-    <div id="overlay-menu" class="bg-theme-raisin-black/50 fixed inset-0 hidden h-screen md:hidden">
+    <div id="overlay-menu" class="bg-theme-raisin-black/50 fixed inset-0 hidden h-[100vh] md:hidden">
     </div>
     <nav
       id="navContent"
-      class="bg-theme-french-mauve/90 invisible fixed right-0 top-0 mx-auto h-screen max-w-6xl translate-x-full items-center justify-between space-y-2 px-6 pt-14 text-xs font-light backdrop-blur-2xl md:visible md:relative md:flex md:!h-fit md:w-full md:translate-x-0 md:space-y-0 md:bg-transparent md:py-4 md:backdrop-blur-none lg:text-sm"
+      class="bg-theme-french-mauve/90 invisible fixed right-0 top-0 mx-auto h-[100vh] max-w-6xl translate-x-full items-center justify-between space-y-2 px-6 pt-14 text-xs font-light backdrop-blur-2xl md:visible md:relative md:flex md:!h-fit md:w-full md:translate-x-0 md:space-y-0 md:bg-transparent md:py-4 md:backdrop-blur-none lg:text-sm"
     >
       <div
         class:list={[


### PR DESCRIPTION
## Describe your changes

Se cambió el height de `#navContent` y `#overlay-menu` en mobile, de `h-screen` a `h-[100vh]`.
La razón principal es que `h-screen` aplica `height: 100svh` en CSS, a pesar de que la documentación de Tailwind CSS indica que aplica `height: 100vh`, que es lo deseado para evitar que se corte en navegadores con vh dinámico, en este caso, testeado en Brave Mobile.

[Height - Tailwind CSS](https://tailwindcss.com/docs/height)

## Include a screenshot/video where applicable

### Lo que aplica `h-screen`

![image](https://github.com/user-attachments/assets/bb4b6479-c9de-4264-92fb-3ad09f5561e0)

### Cambios

Base:

![image](https://github.com/user-attachments/assets/5332c5c1-72ee-480e-93eb-47fefa8df16d)

Al hacer scroll

Antes:

![image](https://github.com/user-attachments/assets/79f8f37a-3501-418a-9273-e0b74ea56a90)

Ahora:

![image](https://github.com/user-attachments/assets/b73c17ad-eaf4-4a82-87b2-f34bf2d34292)

## Type of change
<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
