### PR TITLE
fix: enable text selection on 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -15,7 +15,7 @@ export const prerender = true
     <div class="w-full max-w-3xl items-center justify-center">
       <h1 class="text-theme-raisin-black">
         <span
-          class="rotate-113 mb-12 block text-[120px] font-bold tracking-[.025em]"
+          class="rotate-113 mb-12 w-fit mx-auto block text-[120px] font-bold tracking-[.025em]"
           aria-hidden="true"
         >
           404


### PR DESCRIPTION
## Describe your changes
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
Se agregan las clases `w-fit` y `mx-auto` al elemento `span` con el texto 404 para evitar que se sobre ponga a los textos debajo de el.

## Explicación

El elemento `span` con el texto 404 se sobre ponía en la mitad a los textos "¡FUERA DE COMBATE!" y "vaya, parece que te han noqueado..." lo que impedía una correcta selección.

El problema radicaba en que el elemento tenia un display block lo que le daba un width: 100% y al rotarse 113 grados se sobre ponía a los otros textos, teniendo en cuenta que este elemento va primero en el DOM.

## Screenshot/Video
<!-- Please add screenshots to help explain your changes. Delete this section if not needed. -->

### Antes:

https://github.com/user-attachments/assets/efca3d39-2499-45f8-92f9-44f606198ef3

<img width="1117" height="993" alt="image" src="https://github.com/user-attachments/assets/45c3f955-fc46-4843-a975-aac5bef2e386" />

### Después:

https://github.com/user-attachments/assets/5f4dda58-c22e-4d36-8329-cac2d5dd0977

<img width="1118" height="988" alt="image" src="https://github.com/user-attachments/assets/b902bc42-7db0-4e98-af4d-8aefe025daae" />


## Type of change
<!-- Please delete options that are not relevant. -->



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
