### PR TITLE
fix: ajustar separación en combates Viruzz/Tomás y Perxitaa/Gaspi

### DIFF
--- a/src/pages/combates/index.astro
+++ b/src/pages/combates/index.astro
@@ -58,6 +58,8 @@ export const prerender = true
                       class:list={[
                         'mask-fade-bottom-quick absolute z-20 h-full w-auto object-contain object-bottom transition-transform duration-300 group-hover:scale-110',
                         fighterIndex === 0 ? 'left-0' : 'right-0',
+                        (fighter === 'perxitaa' || fighter === 'viruzz') && 'max-sm:-translate-x-5 lg:-translate-x-5',
+                        (fighter === 'gaspi' || fighter === 'tomas') && 'max-sm:translate-x-5 lg:translate-x-5',
                       ]}
                       alt={`Imagen de ${fighter}`}
                       transition:name={`combat-img:${fighter}`}

--- a/src/sections/PorraHome.astro
+++ b/src/sections/PorraHome.astro
@@ -39,12 +39,14 @@ const getFighterById = (id: string) => {
                 'animate-delay-200 lg',
               ]}
             >
-              {fighters.map((fighter, fighterIndex) => (
+              {fighters.map((fighter, fighterIndex) => (                
                 <img
                   src={`/images/fighters/combat/${fighter}.webp`}
                   class:list={[
                     'mask-fade-bottom-quick absolute z-20 h-full w-auto object-contain object-bottom transition-transform duration-300 group-hover:scale-110',
                     fighterIndex === 0 ? 'left-0' : 'right-0',
+                    (fighter === "perxitaa" || fighter === "viruzz") && 'max-sm:-translate-x-5 lg:-translate-x-5',
+                    (fighter === "gaspi" || fighter === "tomas" ) && 'max-sm:translate-x-5 lg:translate-x-5'
                   ]}
                   alt={`Imagen de ${fighter}`}
                   transition:name={`combat-img:${fighter}`}


### PR DESCRIPTION
Se ajustó la posición de los luchadores en los combates **Viruzz vs Tomás** y **Perxitaa vs Gaspi** para evitar que se superpongan visualmente.

| Antes | Después |
|-------|---------|
| ![Antes](https://github.com/user-attachments/assets/d9b13fff-376b-477f-9d03-ecb1bef3ebc3) | ![Después](https://github.com/user-attachments/assets/1b0e3ea2-51cf-4e40-825b-b020ae721e7f) |
| ![Antes](https://github.com/user-attachments/assets/441ebced-02df-4711-bd10-cc6d8cce5f6c) | ![Después](https://github.com/user-attachments/assets/45532b3b-4586-46d2-9c23-3b0efb25ad5a) |

