### PR TITLE
fix: evita que la imagen del luchador se solape con la info al hacer hover

### DIFF
--- a/src/pages/combates/[id].astro
+++ b/src/pages/combates/[id].astro
@@ -48,7 +48,7 @@ export const prerender = true
       <div>
         <div class="my-8 grid grid-cols-3 gap-4">
           <!-- Columna del primer luchador -->
-          <div class="group flex flex-col items-center space-y-4">
+          <div class="group flex flex-col items-center space-y-4 xl:space-y-8">
             <!-- Foto del luchador -->
             <div class="h-42 flex justify-center">
               <BoxerCard
@@ -73,7 +73,7 @@ export const prerender = true
           </div>
 
           <!-- Columna central con etiquetas -->
-          <div class="flex flex-col items-center space-y-4">
+          <div class="flex flex-col items-center space-y-4 xl:space-y-8">
             <!-- Espacio para mantener alineación -->
             <div class="h-42"></div>
             <!-- Etiquetas -->
@@ -86,7 +86,7 @@ export const prerender = true
           </div>
 
           <!-- Columna del segundo luchador -->
-          <div class="group flex flex-col items-center space-y-4">
+          <div class="group flex flex-col items-center space-y-4 xl:space-y-8">
             <!-- Foto del luchador -->
             <div class="h-42 flex justify-center">
               <BoxerCard


### PR DESCRIPTION
## Describe your changes
Se ajustó el espaciado vertical entre las secciones de cada luchador para evitar que la imagen, al escalarse con hover, se superponga a la información textual.

Este cambio solo afecta el diseño visual en pantallas grandes.


## Include a screenshot/video where applicable
| Antes                                   | Después                                 |
|----------------------------------------|----------------------------------------|
| ![Antes](https://github.com/user-attachments/assets/ab3b3ed8-10b8-4944-b8c1-8db97047a859)      | ![Después](https://github.com/user-attachments/assets/6fa6a8d6-0c14-4e3e-8eeb-098dfc8614f2)  |


## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
