### PR TITLE
fix: update ticket availability message to reflect sold-out status

### DIFF
--- a/src/sections/Header.astro
+++ b/src/sections/Header.astro
@@ -133,7 +133,7 @@ const isActive = (path: string) => pathname === path
             >COMPRA LAS ENTRADAS
             <span
               class="absolute inset-0 top-3.5 mt-1 text-left text-[10px] leading-normal tracking-wide text-yellow-500 md:text-center"
-              >¡Últimas disponibles!</span
+              >¡Entradas agotadas!</span
             >
           </span>
           <div class="relative mt-3 h-[2px] w-full overflow-hidden">


### PR DESCRIPTION
This pull request includes a minor update to the `src/sections/Header.astro` file. The change updates the text displayed in the header from "¡Últimas disponibles!" to "¡Entradas agotadas!" to reflect the current ticket availability status.

* [`src/sections/Header.astro`](diffhunk://#diff-bfe361cc3d592867dd9a05ad47650fddb7ef4b91eda96bddfd0a0de60c36e18dL136-R136): Updated the text inside a `<span>` element to indicate that tickets are now sold out.