### PR TITLE
fix(ui): prevent layout shift when opening modals using scrollbar-gutter

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -130,15 +130,3 @@ const {
     <Footer />
   </body>
 </html>
-
-<style>
-  html,
-  body {
-    margin: 0;
-    width: 100%;
-    height: 100%;
-    background: #f19fca;
-    display: flex;
-    flex-direction: column;
-  }
-</style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,11 +17,25 @@
 }
 
 @layer base {
-  /* Disable overscroll behavior */
   html,
   body {
+    display: flex;
+    flex-direction: column;
+    margin: 0;
+    width: 100%;
+    min-height: 100%;
+    /* Disable overscroll behavior */
     overscroll-behavior: none;
     overscroll-behavior-y: none;
+  }
+
+  html {
+    scrollbar-gutter: stable;
+    background: var(--color-theme-raisin-black);
+  }
+
+  body {
+    background: #f19fca;
   }
 
   /* Webkit Browsers (Chrome, Safari, Edge) */


### PR DESCRIPTION
## Describe your changes
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->

- Se agrega la declaración `scrollbar-gutter: stable` al elemento `html` y se le establece el mismo color del `scrollbar-track` al `background-color` para que el `scrollbar-gutter` sea consistente.
- Se modifica la declaración `height: 100%` aplicada en los elementos `html` y `body` para que sea `min-height: 100%` y no limite el alto de los elementos, evitando que se corten los colores de fondo.
- Por último, se mueven los estilos globales de `Layout.astro` al archivo `globals.css` para mantener consistencia (sé que no es parte de la PR, pero me picaron las manos 😔).

## Include a screenshot/video where applicable
<!-- Please add screenshots to help explain your changes. Delete this section if not needed. -->

Se bajó la opacidad del `backdrop` para mejorar la visualización, no es parte de la PR

Antes:

https://github.com/user-attachments/assets/ef6e72fc-cf46-4604-88f7-e24005396ea3

Después:

https://github.com/user-attachments/assets/5ddeefbf-4932-4545-919e-f374a36436cd

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
