### PR TITLE
fix(boxer-gallery): incorrect images selection on rapid navigation clicks

### DIFF
--- a/src/components/BoxerGallery.astro
+++ b/src/components/BoxerGallery.astro
@@ -59,7 +59,7 @@ const IMAGES_TO_LOAD = Math.min(gallery, 3)
       </p>
       <button
         data-btn-prev
-        class="group absolute left-[10px] z-10 hidden cursor-pointer text-transparent transition hover:scale-125 motion-reduce:transition-none motion-reduce:hover:scale-100 md:relative md:left-0 md:flex md:items-center md:justify-center"
+        class="group absolute left-[10px] z-10 hidden cursor-pointer select-none text-transparent transition hover:scale-125 motion-reduce:transition-none motion-reduce:hover:scale-100 md:relative md:left-0 md:flex md:items-center md:justify-center"
         id="btn-prev"
       >
         <Icons.ChevronLeft
@@ -85,7 +85,7 @@ const IMAGES_TO_LOAD = Math.min(gallery, 3)
       </div>
       <button
         data-btn-next
-        class="group absolute right-[10px] z-10 hidden cursor-pointer text-transparent transition hover:scale-125 motion-reduce:transition-none motion-reduce:hover:scale-100 md:relative md:right-0 md:flex md:items-center md:justify-center"
+        class="group absolute right-[10px] z-10 hidden cursor-pointer select-none text-transparent transition hover:scale-125 motion-reduce:transition-none motion-reduce:hover:scale-100 md:relative md:right-0 md:flex md:items-center md:justify-center"
         id="btn-next"
       >
         <Icons.ChevronRight


### PR DESCRIPTION
## Describe your changes
<!-- Please include a summary of the changes and the related issue. Please also include relevant motivation and context. -->
Se agrega la declaracion `user-select: none` con la clase de tailwind `select-none` a los botones de next y prev para evitar que se seleccionen las imagenes de la galería al navegar rápidamente o hacer doble click en los botones.

## Include a screenshot/video where applicable
<!-- Please add screenshots to help explain your changes. Delete this section if not needed. -->

Antes:

https://github.com/user-attachments/assets/d4fbf58c-16d2-4787-b951-7362a14284a1

Después:

https://github.com/user-attachments/assets/ab443a1b-7604-40fc-9f42-7c93050dd922

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
