### PR TITLE
Actualiza las redirecciones para el subdominio de 2024 y 2025, asegur…

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,27 +1,39 @@
 {
   "redirects": [
     {
-      "source": "/((?!^/?$).+)/",
-      "destination": "/$1",
-      "permanent": true
-    }
-  ],
-  "rewrites": [
-    {
       "source": "/2024",
-      "destination": "https://2024.infolavelada.com"
+      "destination": "https://2024.infolavelada.com",
+      "permanent": true
+    },
+    {
+      "source": "/2024/",
+      "destination": "https://2024.infolavelada.com",
+      "permanent": true
     },
     {
       "source": "/2024/:path*",
-      "destination": "https://2024.infolavelada.com/:path*"
+      "destination": "https://2024.infolavelada.com/:path*",
+      "permanent": true
     },
     {
       "source": "/2025",
-      "destination": "https://2025.infolavelada.com"
+      "destination": "https://2025.infolavelada.com",
+      "permanent": true
+    },
+    {
+      "source": "/2025/",
+      "destination": "https://2025.infolavelada.com",
+      "permanent": true
     },
     {
       "source": "/2025/:path*",
-      "destination": "https://2025.infolavelada.com/:path*"
+      "destination": "https://2025.infolavelada.com/:path*",
+      "permanent": true
+    },
+    {
+      "source": "/((?!^/?$).+)/",
+      "destination": "/$1",
+      "permanent": true
     }
   ]
 }


### PR DESCRIPTION
…ando que todas las rutas sean permanentes.

## Describe your changes

He pasado las rutas de /2024 y /2025 de rewrites a redirects permanentes (308).

**¿Por qué?**

Así el navegador salta directamente al subdominio oficial (2024.infolavelada.com).
Es mucho mejor para el SEO que los rewrites.

He configurado :path* para que si alguien entra en /2024/fotos lo mande bien a la subruta del subdominio.
Añadido soporte para las URLs con y sin barra final (/).

**Type of change**

New feature (Optimización de redirecciones)
Un detalle clave: Al poner permanent: true, Vercel enviará un código 308. Esto es genial porque los navegadores y Google recordarán la nueva dirección para siempre.

## Include a screenshot/video where applicable

Si entras a este enlace no hace la redireccion al nuevo subdominio: https://www.infolavelada.com/2025

<img width="1806" height="1046" alt="Captura de pantalla 2026-03-11 a las 23 55 40" src="https://github.com/user-attachments/assets/6f214228-0798-41c1-b1f7-ccafa71fd7ac" />
