### PR TITLE
Actualizada la skill astro-framework con nuevas referencias y reglas

### DIFF
--- a/.agents/skills/astro-framework/AGENTS.md
+++ b/.agents/skills/astro-framework/AGENTS.md
@@ -1,857 +1,123 @@
-# Astro Framework Guidelines
+# Astro Framework Cheatsheet
 
-> Compiled guidelines for AI coding agents. This document contains all rules from the `rules/` directory in a single file for agents that prefer consolidated documentation.
-
-**Version:** 1.0.0
-**Last Updated:** 2025-01-25
-
----
-
-## Table of Contents
-
-1. [Astro Components](#astro-components)
-2. [Client Hydration](#client-hydration)
-3. [Content Collections](#content-collections)
-4. [Routing](#routing)
-5. [SSR & Adapters](#ssr--adapters)
-6. [Images](#images)
-7. [TypeScript](#typescript)
-
----
-
-## Astro Components
-
-**Applies to:** `**/*.astro`
-
-### Component Structure
-
-Always use the frontmatter pattern with proper separation:
-
-```astro
----
-// 1. Imports
-import Layout from '../layouts/Layout.astro';
-import { getCollection } from 'astro:content';
-
-// 2. Props interface
-interface Props {
-  title: string;
-  description?: string;
-}
-
-// 3. Destructure props with defaults
-const { title, description = 'Default' } = Astro.props;
-
-// 4. Data fetching and logic
-const posts = await getCollection('blog');
----
-
-<!-- 5. Template -->
-<Layout title={title}>
-  <h1>{title}</h1>
-</Layout>
-
-<!-- 6. Scoped styles -->
-<style>
-  h1 { color: navy; }
-</style>
-```
-
-### Rules
-
-**MUST DO:**
-- Define `interface Props` for type safety
-- Use destructuring with defaults for optional props
-- Keep frontmatter logic minimal and focused
-- Use slots for composable content
-- Use `class:list` for conditional classes
-- Import components and assets at the top
-
-**MUST NOT DO:**
-- Access browser APIs (window, document) in frontmatter - runs on server
-- Use side effects in frontmatter - runs on every render
-- Mix UI framework components without client directives
-- Forget alt text on images
-- Use inline styles when scoped styles work
-- Skip TypeScript interfaces for Props
-
-### Slots Pattern
-
-```astro
----
-interface Props {
-  title: string;
-}
-const { title } = Astro.props;
-const hasFooter = Astro.slots.has('footer');
----
-
-<article>
-  <header><h1>{title}</h1></header>
-  <main><slot /></main>
-  {hasFooter && <footer><slot name="footer" /></footer>}
-</article>
-```
-
-### Dynamic Attributes
-
-```astro
----
-const id = "main";
-const isActive = true;
----
-
-<div
-  id={id}
-  class:list={['base', { active: isActive }]}
-  data-active={isActive}
->
-  Content
-</div>
-```
-
----
-
-## Client Hydration
-
-**Applies to:** `**/*.astro`, `**/components/**/*.tsx`, `**/components/**/*.jsx`, `**/components/**/*.vue`, `**/components/**/*.svelte`
-
-### Islands Architecture Principle
-
-Ship zero JavaScript by default. Only hydrate components that need interactivity.
-
-### Decision Tree
-
-```
-Does the component need interactivity?
-├── No → No directive (static HTML)
-└── Yes → Is it above the fold?
-    ├── Yes → Is it critical?
-    │   ├── Yes → client:load
-    │   └── No → client:idle
-    └── No → Is it viewport dependent?
-        ├── Yes → client:visible
-        └── No → Is it device dependent?
-            ├── Yes → client:media
-            └── No → client:visible
-```
-
-### Rules
-
-**MUST DO:**
-- Default to no hydration - question every `client:` directive
-- Use `client:visible` for below-the-fold interactive content
-- Use `client:idle` for non-critical above-the-fold interactions
-- Use `client:media` for device-specific components
-- Always specify framework for `client:only="react"` (required)
-- Test that pages work without JavaScript
-
-**MUST NOT DO:**
-- Use `client:load` on everything - defeats islands purpose
-- Hydrate static content (navbars, footers without interactions)
-- Use `client:only` without the framework string
-- Forget that `client:only` skips SSR entirely
-- Hydrate large components that only need minor interactivity
-
-### Example
-
-```astro
----
-import Header from './Header.astro';        // Static - no JS
-import SearchBox from './SearchBox.jsx';    // Needs hydration
-import Comments from './Comments.jsx';       // Below fold
-import MobileMenu from './MobileMenu.jsx';  // Mobile only
-import Chart from './Chart.jsx';            // Browser APIs only
----
-
-<!-- Static, no JavaScript -->
-<Header />
-
-<!-- Critical above-fold interactivity -->
-<SearchBox client:load />
-
-<!-- Hydrate when visible (below fold) -->
-<Comments client:visible />
-
-<!-- Hydrate only on mobile -->
-<MobileMenu client:media="(max-width: 768px)" />
-
-<!-- Client-only (uses browser APIs) -->
-<Chart client:only="react" />
-```
-
-### Props Serialization
-
-```astro
----
-import Counter from './Counter.jsx';
-const initialCount = 10;
----
-
-<!-- Props are serialized to the client -->
-<Counter client:load initialCount={initialCount} />
-```
-
-**Note:** Props must be serializable (no functions, no class instances).
-
----
-
-## Content Collections
-
-**Applies to:** `src/content/**/*`, `src/content/config.ts`
-
-### Collection Configuration
-
-Always define schemas in `src/content/config.ts`:
-
-```typescript
-import { defineCollection, z, reference } from 'astro:content';
-
-const blog = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    title: z.string(),
-    description: z.string().max(160),
-    pubDate: z.coerce.date(),
-    updatedDate: z.coerce.date().optional(),
-    draft: z.boolean().default(false),
-    cover: image(),
-    coverAlt: z.string(),
-    author: reference('authors'),
-    tags: z.array(z.string()).default([]),
-  }),
-});
-
-export const collections = { blog };
-```
-
-### Rules
-
-**MUST DO:**
-- Use `z.coerce.date()` for date fields - handles string dates from frontmatter
-- Use `image()` helper for optimized images
-- Use `reference()` for cross-collection relationships
-- Set sensible defaults with `.default()`
-- Add `.optional()` for non-required fields
-- Filter drafts in production: `getCollection('blog', ({ data }) => !data.draft)`
-- Export all collections from the config
-
-**MUST NOT DO:**
-- Use plain `z.date()` - won't parse frontmatter strings
-- Skip schema validation
-- Store sensitive data in content collections
-- Use arbitrary image paths - use the image() schema helper
-- Forget to handle the case when `getEntry` returns undefined
-
-### Querying Collections
-
-```typescript
-// Get all published posts, sorted by date
-const posts = (await getCollection('blog', ({ data }) => {
-  return import.meta.env.PROD ? !data.draft : true;
-})).sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
-
-// Get single entry
-const post = await getEntry('blog', 'my-post-slug');
-if (!post) return Astro.redirect('/404');
-
-// Resolve references
-const author = await getEntry(post.data.author);
-```
-
-### Rendering Content
-
-```astro
----
-const { Content, headings } = await post.render();
----
-
-<article>
-  <h1>{post.data.title}</h1>
-  <nav>
-    {headings.map(h => (
-      <a href={`#${h.slug}`}>{h.text}</a>
-    ))}
-  </nav>
-  <Content />
-</article>
-```
-
-### File Organization
-
-```
-src/content/
-├── config.ts           # Required: collection schemas
-├── blog/
-│   ├── post-1.md
-│   └── post-2.mdx
-└── authors/
-    └── john.json
-```
-
----
-
-## Routing
-
-**Applies to:** `src/pages/**/*`
-
-### File-Based Routing
-
-```
-src/pages/
-├── index.astro          → /
-├── about.astro          → /about
-├── blog/
-│   ├── index.astro      → /blog
-│   └── [slug].astro     → /blog/:slug
-├── [...path].astro      → /* (catch-all)
-└── api/
-    └── posts.json.ts    → /api/posts.json
-```
-
-### Rules
-
-**MUST DO:**
-- Use `getStaticPaths()` for dynamic routes in static mode
-- Return proper status codes from API endpoints
-- Validate params in SSR routes
-- Use content collections for dynamic content pages
-- Handle 404 cases explicitly
-
-**MUST NOT DO:**
-- Access `Astro.request` in prerendered pages
-- Forget `getStaticPaths()` in static output mode
-- Return sensitive data in API responses without auth
-
-### Dynamic Routes Pattern
-
-```astro
----
-// src/pages/blog/[slug].astro
-import { getCollection } from 'astro:content';
-
-export async function getStaticPaths() {
-  const posts = await getCollection('blog');
-  return posts.map(post => ({
-    params: { slug: post.slug },
-    props: { post },
-  }));
-}
-
-const { post } = Astro.props;
-const { Content } = await post.render();
----
-
-<article>
-  <h1>{post.data.title}</h1>
-  <Content />
-</article>
-```
-
-### Rest Parameters (Catch-All)
-
-```astro
----
-// src/pages/docs/[...path].astro
-export function getStaticPaths() {
-  return [
-    { params: { path: undefined } },      // /docs
-    { params: { path: 'intro' } },        // /docs/intro
-    { params: { path: 'guides/start' } }, // /docs/guides/start
-  ];
-}
-
-const { path } = Astro.params;
----
-```
-
-### API Endpoints
-
-```typescript
-// src/pages/api/posts.ts
-import type { APIRoute } from 'astro';
-
-export const GET: APIRoute = async ({ params, request }) => {
-  const data = await fetchPosts();
-
-  return new Response(JSON.stringify(data), {
-    status: 200,
-    headers: { 'Content-Type': 'application/json' },
-  });
-};
-
-export const POST: APIRoute = async ({ request }) => {
-  const body = await request.json();
-
-  if (!body.title) {
-    return new Response(JSON.stringify({ error: 'Title required' }), {
-      status: 400,
-    });
-  }
-
-  const post = await createPost(body);
-  return new Response(JSON.stringify(post), { status: 201 });
-};
-```
-
-### Pagination
-
-```astro
----
-// src/pages/blog/[...page].astro
-export async function getStaticPaths({ paginate }) {
-  const posts = await getCollection('blog');
-  return paginate(posts.sort((a, b) =>
-    b.data.pubDate.valueOf() - a.data.pubDate.valueOf()
-  ), { pageSize: 10 });
-}
-
-const { page } = Astro.props;
----
-
-<ul>
-  {page.data.map(post => <li>{post.data.title}</li>)}
-</ul>
-
-{page.url.prev && <a href={page.url.prev}>Previous</a>}
-{page.url.next && <a href={page.url.next}>Next</a>}
-```
-
-### Redirects
-
-```javascript
-// astro.config.mjs
-export default defineConfig({
-  redirects: {
-    '/old': '/new',
-    '/blog/[...slug]': '/posts/[...slug]',
-  },
-});
-```
-
----
-
-## SSR & Adapters
-
-**Applies to:** `astro.config.mjs`, `src/pages/**/*`, `src/middleware.ts`
-
-### Output Modes
-
-```javascript
-// astro.config.mjs
-export default defineConfig({
-  output: 'static',  // Default - all prerendered
-  output: 'server',  // All server-rendered
-  output: 'hybrid',  // Static default, opt-in SSR
-  adapter: vercel(), // Required for server/hybrid
-});
-```
-
-### Rules
-
-**MUST DO:**
-- Use `hybrid` mode when only some pages need SSR
-- Install appropriate adapter for deployment target
-- Use `export const prerender = false` to opt into SSR (hybrid mode)
-- Use `export const prerender = true` to opt out of SSR (server mode)
-- Handle errors and return proper HTTP status codes
-- Validate and sanitize all user input
-
-**MUST NOT DO:**
-- Forget to install an adapter for server/hybrid output
-- Access request/cookies in prerendered pages
-- Trust user input without validation
-- Expose sensitive data in responses
-- Use SSR when static would work
-
-### Opting In/Out of Prerendering
-
-```astro
----
-// In hybrid mode (default: prerendered)
-export const prerender = false; // Make this page SSR
-
-// In server mode (default: SSR)
-export const prerender = true; // Prerender this page
----
-```
-
-### Request Handling
-
-```astro
----
-// SSR page
-const url = Astro.url;
-const pathname = url.pathname;
-const searchParams = url.searchParams;
-
-const method = Astro.request.method;
-const headers = Astro.request.headers;
-const userAgent = headers.get('user-agent');
-
-// Cookies
-const session = Astro.cookies.get('session')?.value;
-Astro.cookies.set('visited', 'true', {
-  path: '/',
-  httpOnly: true,
-  secure: true,
-  maxAge: 60 * 60 * 24,
-});
-
-// Redirects
-if (!session) {
-  return Astro.redirect('/login');
-}
----
-```
-
-### Middleware
-
-```typescript
-// src/middleware.ts
-import { defineMiddleware, sequence } from 'astro:middleware';
-
-const auth = defineMiddleware(async ({ cookies, locals, redirect, url }, next) => {
-  const token = cookies.get('token')?.value;
-  locals.user = token ? await verifyToken(token) : null;
-
-  if (!locals.user && url.pathname.startsWith('/dashboard')) {
-    return redirect('/login');
-  }
-
-  return next();
-});
-
-const logging = defineMiddleware(async ({ url }, next) => {
-  console.log(`[${new Date().toISOString()}] ${url.pathname}`);
-  return next();
-});
-
-export const onRequest = sequence(logging, auth);
-```
-
-### Type Locals
-
-```typescript
-// src/env.d.ts
-declare namespace App {
-  interface Locals {
-    user: { id: string; name: string } | null;
-  }
-}
-```
-
-### Adapters
-
-```bash
-# Node.js
-npx astro add node
-
-# Vercel
-npx astro add vercel
-
-# Netlify
-npx astro add netlify
-
-# Cloudflare
-npx astro add cloudflare
-```
-
----
-
-## Images
-
-**Applies to:** `**/*.astro`, `**/*.mdx`, `src/content/**/*`
-
-### Image Component
-
-```astro
----
-import { Image } from 'astro:assets';
-import heroImage from '../images/hero.jpg';
----
-
-<Image
-  src={heroImage}
-  alt="Descriptive alt text"
-  width={800}
-  height={600}
-  format="webp"
-  quality={80}
-/>
-```
-
-### Rules
-
-**MUST DO:**
-- Import local images - enables optimization
-- Always provide meaningful alt text
-- Use `<Image>` component for local images
-- Use `<Picture>` for responsive hero images
-- Specify width/height to prevent layout shift
-- Configure allowed domains for remote images
-- Use the image() schema helper in content collections
-
-**MUST NOT DO:**
-- Use string paths for local images: `src="/images/hero.jpg"`
-- Skip alt text (accessibility requirement)
-- Use `<img>` tags for local images (misses optimization)
-- Forget width/height for remote images
-- Allow arbitrary remote domains
-
-### Local vs Remote Images
-
-```astro
----
-import { Image } from 'astro:assets';
-import localImage from '../images/photo.jpg';
----
-
-<!-- Local: import required, auto-optimized -->
-<Image src={localImage} alt="Local photo" />
-
-<!-- Remote: dimensions required -->
-<Image
-  src="https://example.com/photo.jpg"
-  alt="Remote photo"
-  width={400}
-  height={300}
-/>
-
-<!-- Remote with inferred size (fetches image) -->
-<Image
-  src="https://example.com/photo.jpg"
-  alt="Remote photo"
-  inferSize
-/>
-```
-
-### Picture for Responsive Images
-
-```astro
----
-import { Picture } from 'astro:assets';
-import hero from '../images/hero.jpg';
----
-
-<Picture
-  src={hero}
-  alt="Hero image"
-  formats={['avif', 'webp', 'jpg']}
-  widths={[400, 800, 1200]}
-  sizes="(max-width: 600px) 400px, (max-width: 1000px) 800px, 1200px"
-/>
-```
-
-### Content Collections with Images
-
-```typescript
-// src/content/config.ts
-const blog = defineCollection({
-  type: 'content',
-  schema: ({ image }) => z.object({
-    title: z.string(),
-    cover: image(),           // Validates and optimizes
-    coverAlt: z.string(),
-  }),
-});
-```
-
-```markdown
----
-title: My Post
-cover: ./images/cover.jpg
-coverAlt: Post cover showing...
----
-```
-
-### Background Images
-
-```astro
----
-import { getImage } from 'astro:assets';
-import bg from '../images/background.jpg';
-
-const optimizedBg = await getImage({
-  src: bg,
-  format: 'webp',
-  width: 1920,
-});
----
-
-<section style={`background-image: url(${optimizedBg.src})`}>
-  Content
-</section>
-```
-
-### Configuration
-
-```javascript
-// astro.config.mjs
-export default defineConfig({
-  image: {
-    domains: ['cdn.example.com'],
-    remotePatterns: [
-      { protocol: 'https', hostname: '**.unsplash.com' },
-    ],
-  },
-});
-```
-
----
-
-## TypeScript
-
-**Applies to:** `tsconfig.json`, `src/env.d.ts`, `**/*.ts`, `**/*.astro`
-
-### tsconfig.json
-
-```json
-{
-  "extends": "astro/tsconfigs/strict",
-  "compilerOptions": {
-    "baseUrl": ".",
-    "paths": {
-      "@/*": ["src/*"],
-      "@components/*": ["src/components/*"],
-      "@layouts/*": ["src/layouts/*"],
-      "@content/*": ["src/content/*"]
-    }
-  }
-}
-```
-
-### Rules
-
-**MUST DO:**
-- Use `astro/tsconfigs/strict` or `strictest` preset
-- Define path aliases for cleaner imports
-- Type Props interface in all components
-- Type locals in `src/env.d.ts`
-- Type environment variables
-
-**MUST NOT DO:**
-- Use `any` type - use `unknown` and narrow
-- Skip typing Props interface
-- Ignore TypeScript errors
-- Use `astro/tsconfigs/base` in production projects
-
-### Component Props
-
-```astro
----
-interface Props {
-  title: string;
-  description?: string;
-  tags: string[];
-  variant?: 'primary' | 'secondary';
-}
-
-const {
-  title,
-  description = 'Default description',
-  tags,
-  variant = 'primary',
-} = Astro.props;
----
-```
-
-### Environment Variables
-
-```typescript
-// src/env.d.ts
-/// <reference types="astro/client" />
-
-interface ImportMetaEnv {
-  readonly PUBLIC_API_URL: string;
-  readonly DATABASE_URL: string;
-  readonly SECRET_KEY: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}
-```
-
-### Locals Typing
-
-```typescript
-// src/env.d.ts
-declare namespace App {
-  interface Locals {
-    user: {
-      id: string;
-      email: string;
-      name: string;
-    } | null;
-    theme: 'light' | 'dark';
-    requestId: string;
-  }
-}
-```
-
-### Content Collection Types
-
-```typescript
-// src/content/config.ts
-import { defineCollection, z, reference } from 'astro:content';
-
-const blog = defineCollection({
-  type: 'content',
-  schema: z.object({
-    title: z.string(),
-    author: reference('authors'),
-  }),
-});
-
-// Types are auto-generated:
-// import type { CollectionEntry } from 'astro:content';
-// type BlogPost = CollectionEntry<'blog'>;
-```
-
-### API Route Types
-
-```typescript
-// src/pages/api/example.ts
-import type { APIRoute, APIContext } from 'astro';
-
-export const GET: APIRoute = async (context: APIContext) => {
-  const { params, request, cookies, locals, url } = context;
-
-  return new Response(JSON.stringify({ ok: true }), {
-    headers: { 'Content-Type': 'application/json' },
-  });
-};
-```
-
-### Path Aliases Usage
-
-```astro
----
-// With aliases
-import Layout from '@layouts/Layout.astro';
-import Card from '@components/Card.astro';
-import { getCollection } from 'astro:content';
-
-// Instead of
-import Layout from '../../../layouts/Layout.astro';
----
-```
+**Version:** 2.0.0 | **Astro 5.x** | **Updated:** 2026-03-22 | **Author**: [webreactiva.com](https://webreactiva.com/ia)
 
 ---
 
 ## Quick Reference Card
 
-| Category | Key Rule |
-|----------|----------|
-| **Components** | Always define `interface Props` |
-| **Hydration** | Default to no directive; question every `client:` |
-| **Collections** | Use `z.coerce.date()` for dates |
-| **Routing** | Use `getStaticPaths()` for dynamic routes |
-| **SSR** | Use `hybrid` mode when only some pages need SSR |
-| **Images** | Import local images; use `<Image>` component |
-| **TypeScript** | Extend `astro/tsconfigs/strict` |
+| Topic | Rule of Thumb |
+|-------|---------------|
+| **Components** | Define `interface Props`; frontmatter = server only; use `class:list` for conditional classes |
+| **Hydration** | Default: no directive (zero JS). Question every `client:` |
+| **Server Islands** | `server:defer` for personalized/dynamic server content on cached pages |
+| **Content Collections** | Content Layer API with loaders in `src/content.config.ts` (NOT `src/content/config.ts`) |
+| **Rendering content** | `import { render } from 'astro:content'` then `const { Content } = await render(entry)` |
+| **Routing** | File-based; `getStaticPaths()` required for dynamic routes in static mode |
+| **Output modes** | `static` (default), `server` (all SSR), `hybrid` (static default, opt-in SSR) |
+| **Sessions** | `Astro.session?.get/set`; always use optional chaining; SSR only |
+| **Env vars** | `astro:env` schema with `envField` for type safety; import from `astro:env/client` or `astro:env/server` |
+| **Images** | Import local images; use `<Image>` / `<Picture>` from `astro:assets`; always set alt text |
+| **i18n** | Use `getRelativeLocaleUrl()` for links, never hardcode locale prefixes |
+| **TypeScript** | Extend `astro/tsconfigs/strict`; define path aliases; type `App.Locals` in `src/env.d.ts` |
+| **API routes** | Export named handlers (`GET`, `POST`, etc.) typed as `APIRoute` |
 
 ---
 
-*Generated from rules in the `rules/` directory. For individual rule files, see the `rules/` folder.*
+## Decision Trees
+
+### Output Mode
+```
+All static? ──> output: 'static' (default, no adapter)
+All dynamic? ──> output: 'server' + adapter
+Mix? ──> output: 'hybrid' + adapter
+  Opt into SSR (hybrid): export const prerender = false
+  Opt out of SSR (server): export const prerender = true
+```
+
+### Hydration Directive
+```
+Needs interactivity?
+├─ No ──> No directive (zero JS)
+└─ Yes ──> Above fold + critical? ──> client:load
+            Above fold + non-critical? ──> client:idle
+            Below fold? ──> client:visible
+            Device-specific? ──> client:media="(query)"
+            Browser APIs only, skip SSR? ──> client:only="react"
+```
+
+### Server Island vs Client Island
+```
+Needs server data (cookies, DB, personalization)? ──> server:defer + slot="fallback"
+Needs browser interactivity? ──> client:* directive
+Neither? ──> Static .astro component
+```
+
+---
+
+## Critical "NEVER Do" List
+
+- **NEVER** access `window`/`document` in `.astro` frontmatter (server-only)
+- **NEVER** use `client:load` on everything — defeats islands architecture
+- **NEVER** use `client:only` without the framework string argument
+- **NEVER** use plain `z.date()` for frontmatter dates — use `z.coerce.date()`
+- **NEVER** use string paths for local images (`src="/images/hero.jpg"`) — import them
+- **NEVER** access `Astro.request`/`Astro.cookies`/`Astro.session` in prerendered pages
+- **NEVER** rely on `Astro.url` inside a server island (returns internal route; use `Referer` header)
+- **NEVER** pass large objects/functions as server island props (IDs only; >2048 bytes forces POST)
+- **NEVER** use sessions in edge middleware or static pages
+- **NEVER** forget `getStaticPaths()` for `[param]` routes in static output
+- **NEVER** skip `slot="fallback"` on `server:defer` components
+- **NEVER** use `any` — use `unknown` and narrow
+- **NEVER** import Zod from `zod` — use `astro/zod` (Astro 5+)
+
+---
+
+## Astro 5+ Migration Notes (Post-Training Knowledge)
+
+### Content Collections (Content Layer API)
+
+- Config file: `src/content.config.ts` (was `src/content/config.ts`)
+- Uses `loader` property instead of `type: 'content'` / `type: 'data'`
+- Loaders: `import { glob, file } from 'astro/loaders'`
+- Zod: `import { z } from 'astro/zod'` (NOT from `zod` package)
+- Rendering: `import { render } from 'astro:content'` then `await render(entry)` (was `entry.render()`)
+- `reference()` for cross-collection relationships; `image()` schema helper for optimized images
+
+### server:defer (Stable in Astro 5)
+
+- Requires adapter; props must be serializable and small
+- Use `Referer` header inside island to get parent page URL
+
+### Sessions (Astro 5.7+)
+
+- `Astro.session?.get(key)` / `.set(key, value)` — always optional-chain
+- Configure `session.driver` in config via `sessionDrivers` from `astro/config`
+- `session.regenerate()` after login, `session.destroy()` on logout
+- Type via `App.SessionData` in `src/env.d.ts`
+
+### astro:env (Stable in Astro 5)
+
+- Schema in `astro.config.mjs` with `envField` from `astro/config`
+- Import from `astro:env/client` or `astro:env/server`
+- Three kinds: public client (bundled), public server (server bundle), secret server (not bundled)
+- No secret client vars — not supported by design
+
+### Actions
+
+- `defineAction` from `astro:actions` with `astro/zod` schemas
+
+## Key Patterns (Brief)
+
+- **Component structure:** imports, `interface Props`, destructure with defaults, logic, template, scoped `<style>`
+- **Slots:** `Astro.slots.has('name')` to conditionally render named slot wrappers
+- **Middleware:** `defineMiddleware` from `astro:middleware`; chain with `sequence(a, b)`; file: `src/middleware.ts`
+- **Pagination:** `getStaticPaths({ paginate })` returns `page.data`, `page.url.prev/next`
+- **Redirects:** `redirects: { '/old': '/new' }` in `astro.config.mjs`
+- **Cookies (SSR):** `Astro.cookies.get('name')?.value` / `.set('name', value, options)`
+
+## References
+
+Deep-dive docs with full code examples live in `references/`:
+
+`actions.md` `client-directives.md` `components.md` `configuration.md` `content-collections.md` `environment-variables.md` `i18n-routing.md` `images.md` `middleware.md` `routing.md` `server-islands.md` `sessions.md` `ssr-adapters.md` `styling.md` `view-transitions.md`

--- a/.agents/skills/astro-framework/SKILL.md
+++ b/.agents/skills/astro-framework/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: astro-framework
-description: Comprehensive Astro framework development guide for building fast, content-driven websites using islands architecture. Use this skill when creating Astro components, implementing islands with selective hydration, working with content collections, configuring SSR adapters, building API endpoints, implementing view transitions, or integrating UI frameworks (React, Vue, Svelte, Solid). Triggers on Astro, islands architecture, content collections, client directives, view transitions, Astro SSR, hybrid rendering, static site generation, astro.config.
+description: Astro framework specialist for building fast, content-driven websites with islands architecture. Use when creating Astro components, configuring hydration (client:load/idle/visible/media), using server:defer (server islands), Content Layer API (glob/file loaders, live loaders), sessions, astro:env, i18n routing, actions, SSR adapters, view transitions, or integrating React/Vue/Svelte/Solid. Not for full-SPA frameworks (Next.js, Remix, SvelteKit).
 license: MIT
 metadata:
   author: delineas
-  version: "1.0.0"
+  version: "2.0.0"
   category: framework
-  tags: astro, islands, ssr, ssg, content-collections, view-transitions
+  tags: astro, islands, ssr, ssg, content-collections, content-layer, view-transitions, server-islands, sessions, i18n, actions, astro-env
 ---
 
 # Astro Framework Specialist
@@ -22,21 +22,106 @@ You are a senior frontend engineer with extensive Astro experience. You speciali
 Activate this skill when:
 - Building content-driven websites (blogs, docs, marketing sites)
 - Implementing islands architecture with selective hydration
-- Creating content collections with type-safe schemas
+- Using server islands (`server:defer`) for deferred server rendering
+- Creating content collections with the Content Layer API (loaders, glob, file)
 - Setting up SSR with adapters (Node, Vercel, Netlify, Cloudflare)
 - Building API endpoints and server actions
 - Implementing view transitions for SPA-like navigation
+- Managing server-side sessions for user state
+- Configuring type-safe environment variables with `astro:env`
+- Setting up i18n routing for multilingual sites
 - Integrating UI frameworks (React, Vue, Svelte, Solid)
 - Optimizing images and performance
 - Configuring `astro.config.mjs`
+- Building live data collections with Live Loaders
 
 ## Core Workflow
 
 1. **Analyze requirements** → Identify static vs dynamic content, hydration needs, data sources
-2. **Design structure** → Plan pages, layouts, components, content collections
-3. **Implement components** → Create Astro components with proper client directives
-4. **Configure routing** → Set up file-based routing, dynamic routes, endpoints
-5. **Optimize delivery** → Configure adapters, image optimization, view transitions
+2. **Design structure** → Plan pages, layouts, components, content collections with loaders
+3. **Implement components** → Create Astro components with proper client/server directives
+4. **Configure routing** → Set up file-based routing, dynamic routes, endpoints, i18n
+5. **Optimize delivery** → Configure adapters, image optimization, view transitions, caching
+
+## Expert Decision Frameworks
+
+### Output Mode Selection
+
+```
+static (default)
+├── Blog, docs, landing pages, portfolios
+├── Content changes per-deploy, not per-request
+├── <500 pages and builds under 5 min
+└── No user-specific content needed
+
+hybrid (80% of real-world projects)
+├── Mostly static + login/dashboard/API routes
+├── E-commerce: static catalog + dynamic cart/checkout
+├── Use server islands to avoid making whole pages SSR
+└── Best balance of performance + flexibility
+
+server (rarely needed)
+├── >80% of pages need request data (cookies, headers, DB)
+├── Full SaaS/dashboard behind auth
+└── Warning: you lose edge HTML caching on all pages
+```
+
+**Signs you picked wrong:**
+- Builds >10 min with `getStaticPaths` → switch to `hybrid`
+- Using `prerender = false` on >50% of pages → switch to `server`
+- Whole app is `server` but only 2 pages read cookies → switch to `hybrid`
+
+### Hydration Strategy — Common Mistakes
+
+- **`client:visible` on hero/header** → It's already in viewport at load time, so it hydrates immediately anyway. Use `client:load` directly and skip the IntersectionObserver overhead.
+- **`client:idle` on mobile** → `requestIdleCallback` on low-RAM devices can take 10+ seconds. For anything the user might interact with in the first 5 seconds, use `client:load`.
+- **Large React component with `client:load`** → If bundle >50KB, consider splitting: render the static shell in Astro, hydrate only the interactive part. Or use `client:idle` if it's below the fold.
+- **Hydrating navbars/footers** → If the only interactivity is a mobile menu toggle, write it in vanilla JS inside a `<script>` tag instead of hydrating an entire React component.
+
+### Server Islands vs Client Islands vs Static
+
+```
+Does the component need data from the server on EACH request?
+(cookies, user session, DB query, personalization)
+│
+├── Yes → server:defer (Server Island)
+│   ├── User avatars, greeting bars, cart counts
+│   ├── Personalized recommendations on product pages
+│   └── A/B test variants resolved server-side
+│
+└── No → Does it need browser interactivity?
+    │
+    ├── Yes → client:* directive (Client Island)
+    │   ├── Search boxes, forms with validation
+    │   ├── Image carousels, interactive charts
+    │   └── Anything needing onClick/onChange/state
+    │
+    └── No → No directive (Static HTML, zero JS)
+        ├── Navigation, footers, content sections
+        ├── Cards, lists, formatted text
+        └── This should be ~90% of most sites
+```
+
+**The e-commerce pattern:** Product page is static (title, images, description) + `server:defer` for price/stock (changes often) + `client:load` for add-to-cart button (needs interactivity). Three rendering strategies on one page.
+
+### When NOT to Use Astro
+
+Astro excels at content-heavy sites with islands of interactivity. Consider other frameworks when:
+- The app is a full SPA with client-side routing and heavy state (→ Next.js, SvelteKit, Remix)
+- Real-time collaborative features are core (→ Next.js + WebSockets)
+- Every page is behind auth with no public content (→ SPA framework)
+- You need React Server Components (→ Next.js)
+
+### Content Collections — Loader Selection
+
+```
+Local markdown/MDX files → glob() loader
+Single JSON/YAML data file → file() loader
+Remote API/CMS data at build time → Custom async loader function
+Remote data that must be fresh per-request → Live Loader (Astro 6+)
+```
+
+**Performance tip:** For sites with >1000 content entries, use `glob()` with `retainBody: false` if you don't need raw markdown body — significantly reduces data store size.
 
 ## Reference Documentation
 
@@ -46,15 +131,19 @@ Load detailed guidance based on your current task:
 |-------|-----------|--------------|
 | Components | [references/components.md](references/components.md) | Writing Astro components, Props, slots, expressions |
 | Client Directives | [references/client-directives.md](references/client-directives.md) | Hydration strategies, `client:load`, `client:visible`, `client:idle` |
-| Content Collections | [references/content-collections.md](references/content-collections.md) | Schemas, loaders, `getCollection`, `getEntry` |
+| Content Collections | [references/content-collections.md](references/content-collections.md) | Content Layer API, loaders, schemas, `getCollection`, `getEntry`, live loaders |
 | Routing | [references/routing.md](references/routing.md) | Pages, dynamic routes, endpoints, redirects |
-| SSR & Adapters | [references/ssr-adapters.md](references/ssr-adapters.md) | On-demand rendering, adapters, server islands |
+| SSR & Adapters | [references/ssr-adapters.md](references/ssr-adapters.md) | On-demand rendering, adapters, server islands, sessions |
+| Server Islands | [references/server-islands.md](references/server-islands.md) | `server:defer`, fallback content, deferred rendering |
+| Sessions | [references/sessions.md](references/sessions.md) | `Astro.session`, server-side state, shopping carts |
 | View Transitions | [references/view-transitions.md](references/view-transitions.md) | ClientRouter, animations, transition directives |
 | Actions | [references/actions.md](references/actions.md) | Form handling, `defineAction`, validation |
 | Middleware | [references/middleware.md](references/middleware.md) | `onRequest`, sequence, `context.locals` |
 | Styling | [references/styling.md](references/styling.md) | Scoped CSS, global styles, `class:list` |
 | Images | [references/images.md](references/images.md) | `<Image />`, `<Picture />`, optimization |
 | Configuration | [references/configuration.md](references/configuration.md) | `astro.config.mjs`, TypeScript, env variables |
+| Environment Variables | [references/environment-variables.md](references/environment-variables.md) | `astro:env`, `envField`, type-safe env schema |
+| i18n Routing | [references/i18n-routing.md](references/i18n-routing.md) | Multilingual sites, locales, `astro:i18n` helpers |
 
 ## Guidelines by Context
 
@@ -62,11 +151,13 @@ Context-specific rules are available in the `rules/` directory:
 
 - `rules/astro-components.rule.md` → Component structure patterns
 - `rules/client-hydration.rule.md` → Hydration strategy decisions
-- `rules/content-collections.rule.md` → Collection schema best practices
+- `rules/content-collections.rule.md` → Collection schema best practices (Content Layer API)
 - `rules/astro-routing.rule.md` → Routing patterns and dynamic routes
 - `rules/astro-ssr.rule.md` → SSR configuration and adapters
 - `rules/astro-images.rule.md` → Image optimization patterns
 - `rules/astro-typescript.rule.md` → TypeScript configuration
+- `rules/server-islands.rule.md` → Server island patterns and `server:defer`
+- `rules/sessions.rule.md` → Server-side session management
 
 ## Critical Rules
 
@@ -74,12 +165,17 @@ Context-specific rules are available in the `rules/` directory:
 
 - Use islands architecture—only hydrate interactive components
 - Choose appropriate client directives based on interaction needs
+- Use `server:defer` for personalized/dynamic content on static pages
 - Define content collection schemas with Zod for type safety
+- Use Content Layer API with loaders (`glob`, `file`) in `src/content.config.ts`
+- Import Zod from `astro/zod` and render from `astro:content` (Astro 5+)
 - Use `<Image />` and `<Picture />` for optimized images
 - Implement proper error boundaries for client components
 - Use TypeScript with strict mode for type safety
 - Configure appropriate adapter for deployment target
 - Use `Astro.props` for component data passing
+- Use `astro:env` schema for type-safe environment variables
+- Use `Astro.session` for server-side state management
 
 ### MUST NOT DO
 
@@ -91,6 +187,9 @@ Context-specific rules are available in the `rules/` directory:
 - Access `Astro.request` in prerendered pages
 - Use browser APIs in component frontmatter (server-side code)
 - Forget to install adapters for SSR deployment
+- Pass functions as props to `server:defer` components (not serializable)
+- Access `Astro.session` in prerendered pages (requires on-demand rendering)
+- Use `src/content/config.ts` for new projects (use `src/content.config.ts` with loaders)
 
 ## Quick Reference
 
@@ -119,32 +218,47 @@ const data = await fetch('https://api.example.com/data');
 </style>
 ```
 
-### Client Directive Priority
+### Directive Priority
 
 1. **No directive** → Static HTML, zero JavaScript
-2. **`client:load`** → Hydrate immediately on page load
-3. **`client:idle`** → Hydrate when browser is idle
-4. **`client:visible`** → Hydrate when component enters viewport
-5. **`client:media`** → Hydrate when media query matches
-6. **`client:only`** → Skip SSR, render only on client
+2. **`server:defer`** → Deferred server rendering (server island)
+3. **`client:load`** → Hydrate immediately on page load
+4. **`client:idle`** → Hydrate when browser is idle
+5. **`client:visible`** → Hydrate when component enters viewport
+6. **`client:media`** → Hydrate when media query matches
+7. **`client:only`** → Skip SSR, render only on client
 
-### Content Collection Schema
+### Content Collection Schema (Astro 5+)
 
 ```typescript
-// src/content/config.ts
-import { defineCollection, z } from 'astro:content';
+// src/content.config.ts
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const blog = defineCollection({
-  type: 'content',
+  loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
   schema: z.object({
     title: z.string(),
-    date: z.date(),
+    date: z.coerce.date(),
     draft: z.boolean().default(false),
     tags: z.array(z.string()).optional(),
   }),
 });
 
 export const collections = { blog };
+```
+
+### Server Island
+
+```astro
+---
+import UserAvatar from '../components/UserAvatar.astro';
+---
+
+<UserAvatar server:defer>
+  <img slot="fallback" src="/generic-avatar.svg" alt="Loading..." />
+</UserAvatar>
 ```
 
 ## Output Format
@@ -159,4 +273,4 @@ When implementing Astro features, provide:
 
 ## Technologies
 
-Astro 4+, Islands Architecture, Content Collections, Zod Schemas, View Transitions API, Server Islands, Actions, Middleware, Adapters (Node, Vercel, Netlify, Cloudflare, Deno), React/Vue/Svelte/Solid integrations, Image Optimization, MDX, Markdoc, TypeScript, Scoped CSS, Tailwind CSS
+Astro 5+/6+, Islands Architecture, Content Layer API (glob/file loaders, live loaders), Zod Schemas, View Transitions API, Server Islands (`server:defer`), Sessions, Actions, Middleware, astro:env (type-safe environment variables), i18n Routing, Adapters (Node, Vercel, Netlify, Cloudflare, Deno), React/Vue/Svelte/Solid integrations, Image Optimization, MDX, Markdoc, TypeScript, Scoped CSS, Tailwind CSS

--- a/.agents/skills/astro-framework/references/client-directives.md
+++ b/.agents/skills/astro-framework/references/client-directives.md
@@ -182,6 +182,68 @@ import DataVisualization from './DataVisualization.jsx';
 </div>
 ```
 
+## Expert Gotchas
+
+### `client:visible` on Above-the-Fold Components
+
+`client:visible` uses IntersectionObserver to detect viewport entry. If the component is **already visible** on load (hero, header, above-fold CTA), the observer fires immediately anyway — you pay the observer setup cost for zero benefit. Use `client:load` directly.
+
+### `client:idle` on Low-End Mobile
+
+`requestIdleCallback` on low-RAM Android devices can delay **10+ seconds** because the main thread never goes truly idle. If users might interact with the component within the first 5 seconds, use `client:load` instead. Reserve `client:idle` for genuinely non-urgent components (analytics widgets, secondary sidebars).
+
+### The Navbar Hydration Trap
+
+A common mistake: wrapping an entire React/Vue navbar in `client:load` just for a mobile hamburger toggle. The toggle is 5 lines of vanilla JS, but you're shipping an entire framework runtime. Instead:
+
+```astro
+<nav>
+  <ul class="nav-links">{/* static links */}</ul>
+  <button id="menu-toggle" aria-expanded="false">Menu</button>
+</nav>
+
+<script>
+  const toggle = document.getElementById('menu-toggle');
+  toggle?.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    document.querySelector('.nav-links')?.classList.toggle('open');
+  });
+</script>
+```
+
+**Rule of thumb:** If the only interactivity is show/hide or toggle, use a `<script>` tag. If there's state management, forms, or complex UI logic, use a framework component with a client directive.
+
+### Large Bundle Splitting
+
+If a React component's bundle exceeds ~50KB, consider splitting:
+
+1. Render the **static shell** as an Astro component (heading, layout, placeholder)
+2. Hydrate only the **interactive part** as a smaller React island
+
+```astro
+<!-- Instead of one large hydrated component -->
+<ProductPage client:load />
+
+<!-- Split into static + interactive -->
+<div class="product-layout">
+  <h1>{product.title}</h1>
+  <img src={product.image} alt={product.title} />
+  <p>{product.description}</p>
+  <!-- Only the interactive part hydrates -->
+  <AddToCartButton client:load productId={product.id} />
+</div>
+```
+
+### When `client:only` Is Actually Needed
+
+`client:only` skips SSR entirely — no HTML on first paint. This hurts SEO and perceived performance. Use it **only** when:
+- The component crashes during SSR (e.g., reads `window.innerWidth` at module scope)
+- A third-party library has no SSR support and no workaround
+- The component is purely decorative and non-essential (e.g., a confetti animation)
+
+If the component just needs `window` in an event handler, `client:load` works fine — `window` is available after hydration.
+
 ## Best Practices
 
 1. **Default to no directive** - Only hydrate what needs interactivity

--- a/.agents/skills/astro-framework/references/configuration.md
+++ b/.agents/skills/astro-framework/references/configuration.md
@@ -349,17 +349,33 @@ import { PUBLIC_API_URL } from 'astro:env/client';
 ---
 ```
 
+## Session Configuration (Astro 5.7+)
+
+```javascript
+import { defineConfig, sessionDrivers } from 'astro/config';
+
+export default defineConfig({
+  session: {
+    driver: sessionDrivers.redis({
+      url: process.env.REDIS_URL,
+    }),
+    // Or use filesystem, memory, etc.
+  },
+});
+```
+
 ## Experimental Features
 
 ```javascript
 export default defineConfig({
   experimental: {
-    serverIslands: true,
     contentIntellisense: true,
     clientPrerender: true,
   },
 });
 ```
+
+> **Note:** Server islands (`server:defer`) are stable since Astro 5 — no experimental flag needed.
 
 ## Full Example
 

--- a/.agents/skills/astro-framework/references/content-collections.md
+++ b/.agents/skills/astro-framework/references/content-collections.md
@@ -2,31 +2,35 @@
 
 Content collections provide type-safe content management with schema validation using Zod.
 
-## Setup
+## Setup (Astro 5+ Content Layer API)
 
 ### Directory Structure
 
 ```
 src/
+├── content.config.ts    # Collection schemas (Astro 5+)
 ├── content/
-│   ├── config.ts       # Collection schemas
-│   ├── blog/           # Blog collection
+│   ├── blog/            # Blog collection
 │   │   ├── post-1.md
 │   │   ├── post-2.mdx
-│   │   └── drafts/     # Subdirectories supported
+│   │   └── drafts/      # Subdirectories supported
 │   │       └── draft-1.md
-│   └── authors/        # Another collection
+│   └── authors/         # Another collection
 │       └── john.json
 ```
 
-### Configuration File
+> **Note:** In Astro 5+, the config file is `src/content.config.ts` (not `src/content/config.ts`). Collections use `loader` instead of `type`.
+
+### Configuration File (Astro 5+ — Recommended)
 
 ```typescript
-// src/content/config.ts
-import { defineCollection, z } from 'astro:content';
+// src/content.config.ts
+import { defineCollection } from 'astro:content';
+import { glob, file } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const blogCollection = defineCollection({
-  type: 'content', // Markdown/MDX files
+  loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
   schema: z.object({
     title: z.string(),
     description: z.string(),
@@ -40,7 +44,7 @@ const blogCollection = defineCollection({
 });
 
 const authorsCollection = defineCollection({
-  type: 'data', // JSON/YAML files
+  loader: file('src/data/authors.json'),
   schema: z.object({
     name: z.string(),
     email: z.string().email(),
@@ -59,7 +63,146 @@ export const collections = {
 };
 ```
 
-## Collection Types
+### Legacy Configuration (Astro 4)
+
+```typescript
+// src/content/config.ts (legacy path)
+import { defineCollection, z } from 'astro:content';
+
+const blogCollection = defineCollection({
+  type: 'content', // Markdown/MDX files
+  schema: z.object({
+    title: z.string(),
+    pubDate: z.coerce.date(),
+  }),
+});
+
+const authorsCollection = defineCollection({
+  type: 'data', // JSON/YAML files
+  schema: z.object({
+    name: z.string(),
+    email: z.string().email(),
+  }),
+});
+
+export const collections = { blog: blogCollection, authors: authorsCollection };
+```
+
+## Built-in Loaders (Astro 5+)
+
+### `glob()` — Multiple files
+
+Loads entries from directories of Markdown, MDX, JSON, YAML, or TOML files:
+
+```typescript
+import { glob } from 'astro/loaders';
+
+const blog = defineCollection({
+  loader: glob({
+    base: './src/content/blog',
+    pattern: '**/*.{md,mdx}',
+  }),
+  schema: z.object({ title: z.string() }),
+});
+```
+
+Options: `pattern`, `base`, `generateId()` (custom ID generation), `retainBody` (set `false` to exclude raw body).
+
+### `file()` — Single file
+
+Loads entries from a single JSON, YAML, or TOML file:
+
+```typescript
+import { file } from 'astro/loaders';
+
+const authors = defineCollection({
+  loader: file('src/data/authors.json'),
+  schema: z.object({ name: z.string() }),
+});
+```
+
+Supports a custom `parser` for non-standard formats (e.g., CSV).
+
+### Custom Loaders
+
+Load from any source (APIs, databases, CMSes):
+
+```typescript
+const products = defineCollection({
+  loader: async () => {
+    const response = await fetch('https://api.example.com/products');
+    const data = await response.json();
+    return data.map((product: any) => ({
+      id: product.id,
+      ...product,
+    }));
+  },
+  schema: z.object({ name: z.string(), price: z.number() }),
+});
+```
+
+### Object Loaders (Advanced)
+
+For full control with incremental updates, caching, and file watching:
+
+```typescript
+import type { Loader } from 'astro/loaders';
+
+function myLoader(options: { url: string }): Loader {
+  return {
+    name: 'my-loader',
+    load: async ({ store, meta, logger }) => {
+      const lastModified = meta.get('lastModified');
+      const data = await fetchData(options.url, lastModified);
+
+      store.clear();
+      for (const item of data) {
+        store.set({ id: item.id, data: item });
+      }
+
+      meta.set('lastModified', new Date().toISOString());
+    },
+  };
+}
+```
+
+## Live Loaders (Astro 6+)
+
+Live loaders fetch data fresh on every request — no data store to update. Use for real-time data:
+
+```typescript
+import type { LiveLoader } from 'astro/loaders';
+
+function productLoader(config: { apiKey: string }): LiveLoader<Product> {
+  return {
+    name: 'product-loader',
+    loadCollection: async ({ filter }) => {
+      const data = await fetchProducts(config.apiKey, filter);
+      return {
+        entries: data.map(p => ({ id: p.sku, data: p })),
+      };
+    },
+    loadEntry: async ({ filter }) => {
+      const product = await fetchProduct(config.apiKey, filter.id);
+      if (!product) return undefined;
+      return { id: product.sku, data: product };
+    },
+  };
+}
+```
+
+Query live collections with `getLiveCollection()` and `getLiveEntry()`:
+
+```astro
+---
+import { getLiveCollection, getLiveEntry } from 'astro:content';
+
+const { entries, error } = await getLiveCollection('products');
+const { entry, error: entryError } = await getLiveEntry('products', 'sku-123');
+---
+```
+
+## Collection Types (Legacy — Astro 4)
 
 ### Content Collections (`type: 'content'`)
 
@@ -96,7 +239,8 @@ For JSON or YAML data files:
 ### Common Field Types
 
 ```typescript
-import { z } from 'astro:content';
+import { z } from 'astro/zod'; // Astro 5+
+// import { z } from 'astro:content'; // Legacy (Astro 4)
 
 const schema = z.object({
   // Strings
@@ -144,11 +288,13 @@ const schema = z.object({
 ### Image Schema
 
 ```typescript
-import { defineCollection, z } from 'astro:content';
-import { image } from 'astro:schema';
+// Astro 5+ with loader
+import { defineCollection } from 'astro:content';
+import { glob } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const blog = defineCollection({
-  type: 'content',
+  loader: glob({ base: './src/content/blog', pattern: '**/*.md' }),
   schema: ({ image }) => z.object({
     title: z.string(),
     cover: image(), // Validates and optimizes images
@@ -160,10 +306,11 @@ const blog = defineCollection({
 ### Reference Other Collections
 
 ```typescript
-import { defineCollection, z, reference } from 'astro:content';
+import { defineCollection, reference } from 'astro:content';
+import { z } from 'astro/zod';
 
 const blog = defineCollection({
-  type: 'content',
+  loader: glob({ base: './src/content/blog', pattern: '**/*.md' }),
   schema: z.object({
     title: z.string(),
     author: reference('authors'), // References authors collection
@@ -247,12 +394,14 @@ const relatedPosts = await getEntries(post.data.relatedPosts);
 
 ## Rendering Content
 
+### Astro 5+ (import `render` from `astro:content`)
+
 ```astro
 ---
-import { getEntry } from 'astro:content';
+import { getEntry, render } from 'astro:content';
 
 const post = await getEntry('blog', 'my-post');
-const { Content, headings, remarkPluginFrontmatter } = await post.render();
+const { Content, headings } = await render(post);
 ---
 
 <article>
@@ -272,23 +421,32 @@ const { Content, headings, remarkPluginFrontmatter } = await post.render();
 </article>
 ```
 
+### Legacy (Astro 4)
+
+```astro
+---
+const post = await getEntry('blog', 'my-post');
+const { Content, headings } = await post.render();
+---
+```
+
 ## Dynamic Routes with Collections
 
 ```astro
 ---
 // src/pages/blog/[...slug].astro
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
   return posts.map((post) => ({
-    params: { slug: post.slug },
+    params: { slug: post.id },
     props: { post },
   }));
 }
 
 const { post } = Astro.props;
-const { Content } = await post.render();
+const { Content } = await render(post);
 ---
 
 <article>
@@ -297,55 +455,53 @@ const { Content } = await post.render();
 </article>
 ```
 
-## Content Loaders (Astro 5+)
+> **Note:** In Astro 5+, use `post.id` instead of `post.slug` for routing params.
 
-### Built-in Loaders
+## Expert Guidance
+
+### Loader Selection Decision Tree
+
+```
+Local markdown/MDX files → glob() loader
+Single JSON/YAML data file → file() loader
+Remote API/CMS data at build → Custom async loader function
+Remote data fresh per-request → Live Loader (Astro 6+)
+```
+
+### Performance: `retainBody` for Large Sites
+
+For sites with >1000 content entries where you only need frontmatter data (e.g., listing pages, tag indexes), disable body storage:
 
 ```typescript
-// src/content/config.ts
-import { defineCollection, z } from 'astro:content';
-import { glob, file } from 'astro/loaders';
-
-// Glob loader for multiple files
 const blog = defineCollection({
-  loader: glob({ pattern: "**/*.md", base: "./src/data/blog" }),
-  schema: z.object({
-    title: z.string(),
-    pubDate: z.coerce.date(),
+  loader: glob({
+    base: './src/content/blog',
+    pattern: '**/*.md',
+    retainBody: false, // Significantly reduces data store size
   }),
-});
-
-// File loader for single JSON/YAML
-const settings = defineCollection({
-  loader: file("./src/data/settings.json"),
-  schema: z.object({
-    siteName: z.string(),
-    siteUrl: z.string().url(),
-  }),
-});
-
-export const collections = { blog, settings };
-```
-
-### Custom Loaders
-
-```typescript
-// Load from API
-const products = defineCollection({
-  loader: async () => {
-    const response = await fetch('https://api.example.com/products');
-    const data = await response.json();
-    return data.map((product: any) => ({
-      id: product.id,
-      ...product,
-    }));
-  },
-  schema: z.object({
-    name: z.string(),
-    price: z.number(),
-  }),
+  schema: z.object({ title: z.string(), pubDate: z.coerce.date() }),
 });
 ```
+
+Only use `retainBody: false` for collections where you don't call `render()`. If you need to render content on detail pages, keep the default (`true`).
+
+### Migration Pitfalls (Astro 4 → 5)
+
+| What changed | Old (Astro 4) | New (Astro 5+) |
+|---|---|---|
+| Config file | `src/content/config.ts` | `src/content.config.ts` |
+| Collection type | `type: 'content'` / `type: 'data'` | `loader: glob(...)` / `loader: file(...)` |
+| Zod import | `import { z } from 'astro:content'` | `import { z } from 'astro/zod'` |
+| Rendering | `const { Content } = await entry.render()` | `import { render } from 'astro:content'; await render(entry)` |
+| Route param | `post.slug` | `post.id` |
+
+**The most common migration bug:** importing `z` from `astro:content` instead of `astro/zod`. This still compiles but can cause subtle type mismatches with the new Content Layer API.
+
+### Schema Design Anti-Patterns
+
+- **`z.date()` for frontmatter dates** → Always use `z.coerce.date()`. YAML/frontmatter dates arrive as strings; `z.date()` rejects them silently
+- **Missing `.default()` on optional booleans** → `draft: z.boolean().optional()` means `undefined`, not `false`. Use `z.boolean().default(false)` so filtering logic works correctly
+- **String paths for images** → Use the `image()` schema helper to enable Astro's image optimization pipeline. String URLs bypass optimization entirely
 
 ## Best Practices
 

--- a/.agents/skills/astro-framework/references/environment-variables.md
+++ b/.agents/skills/astro-framework/references/environment-variables.md
@@ -1,0 +1,120 @@
+# Type-Safe Environment Variables (`astro:env`)
+
+**Added in:** Astro 5.0+
+
+The `astro:env` API provides a type-safe schema for environment variables with validation, proper context separation, and secret management.
+
+## Setup
+
+### Define Schema
+
+```javascript
+// astro.config.mjs
+import { defineConfig, envField } from 'astro/config';
+
+export default defineConfig({
+  env: {
+    schema: {
+      // Public client variable — available everywhere
+      API_URL: envField.string({
+        context: 'client',
+        access: 'public',
+        optional: true,
+      }),
+
+      // Public server variable — server bundle only
+      PORT: envField.number({
+        context: 'server',
+        access: 'public',
+        default: 4321,
+      }),
+
+      // Secret server variable — not in bundle, runtime only
+      API_SECRET: envField.string({
+        context: 'server',
+        access: 'secret',
+      }),
+
+      // Boolean variable
+      FEATURE_FLAG: envField.boolean({
+        context: 'client',
+        access: 'public',
+        default: false,
+      }),
+
+      // Enum variable
+      LOG_LEVEL: envField.enum({
+        context: 'server',
+        access: 'public',
+        values: ['debug', 'info', 'warn', 'error'],
+        default: 'info',
+      }),
+    },
+  },
+});
+```
+
+### Use Variables
+
+Import from the appropriate module:
+
+```astro
+---
+import { API_URL } from 'astro:env/client';
+import { API_SECRET, PORT } from 'astro:env/server';
+
+const data = await fetch(`${API_URL}/users`, {
+  headers: {
+    'Authorization': `Bearer ${API_SECRET}`,
+  },
+});
+---
+
+<script>
+  import { API_URL } from 'astro:env/client';
+  fetch(`${API_URL}/ping`);
+</script>
+```
+
+## Variable Types
+
+There are three kinds, determined by `context` + `access`:
+
+| Kind | Context | Access | Available In | In Bundle? |
+|------|---------|--------|-------------|-----------|
+| Public client | `client` | `public` | Client + Server | Yes |
+| Public server | `server` | `public` | Server only | Yes |
+| Secret server | `server` | `secret` | Server only | No |
+
+**Secret client variables are not supported** — there's no safe way to send secrets to the client.
+
+## Data Types
+
+```javascript
+envField.string({ context: 'server', access: 'public' })
+envField.number({ context: 'server', access: 'public' })
+envField.boolean({ context: 'client', access: 'public' })
+envField.enum({ context: 'server', access: 'public', values: ['a', 'b'] })
+```
+
+Common options: `default`, `optional`, `min`, `max`, `length`, `url`, `includes`, `startsWith`, `endsWith`.
+
+## `getSecret()`
+
+For programmatic access to secrets (e.g., keys that depend on dynamic data):
+
+```typescript
+import { getSecret } from 'astro:env/server';
+
+// Returns string | undefined
+const apiKey = getSecret('DYNAMIC_API_KEY');
+```
+
+Use `getSecret()` instead of `process.env` — its implementation is provided by your adapter, so you won't need to update calls if you switch adapters.
+
+## When to Use `astro:env` vs `import.meta.env`
+
+- **`astro:env`**: Type-safe, validated at build time, proper client/server separation. Use for all new projects.
+- **`import.meta.env`**: Vite's built-in support. Still works, but no schema validation. `PUBLIC_` prefix exposes to client.
+
+Both can coexist in the same project.

--- a/.agents/skills/astro-framework/references/i18n-routing.md
+++ b/.agents/skills/astro-framework/references/i18n-routing.md
@@ -1,0 +1,199 @@
+# Internationalization (i18n) Routing
+
+Astro's built-in i18n routing helps you build multilingual sites with URL-based locale management, fallback content, and helper functions.
+
+## Setup
+
+```javascript
+// astro.config.mjs
+import { defineConfig } from 'astro/config';
+
+export default defineConfig({
+  i18n: {
+    defaultLocale: 'en',
+    locales: ['en', 'es', 'fr', 'de'],
+  },
+});
+```
+
+### Folder Structure
+
+Create locale-specific folders inside `src/pages/`:
+
+```
+src/pages/
+├── index.astro          → / (English, default)
+├── about.astro          → /about
+├── es/
+│   ├── index.astro      → /es
+│   └── about.astro      → /es/about
+└── fr/
+    ├── index.astro      → /fr
+    └── about.astro      → /fr/about
+```
+
+## Routing Options
+
+### `prefixDefaultLocale`
+
+By default, the default locale has no prefix. Set to `true` to add it:
+
+```javascript
+i18n: {
+  defaultLocale: 'en',
+  locales: ['en', 'es', 'fr'],
+  routing: {
+    prefixDefaultLocale: true, // /en/about instead of /about
+  },
+}
+```
+
+### Fallback Languages
+
+Serve content from another locale when a page doesn't exist:
+
+```javascript
+i18n: {
+  defaultLocale: 'en',
+  locales: ['en', 'es', 'fr'],
+  fallback: {
+    fr: 'es', // French pages fall back to Spanish
+  },
+  routing: {
+    fallbackType: 'rewrite', // Show fallback content at the original URL
+    // fallbackType: 'redirect', // (default) Redirect to fallback locale URL
+  },
+}
+```
+
+### Manual Routing
+
+For full control, disable Astro's i18n middleware:
+
+```javascript
+i18n: {
+  defaultLocale: 'en',
+  locales: ['en', 'es', 'fr'],
+  routing: 'manual',
+}
+```
+
+Then implement your own middleware using helpers from `astro:i18n`:
+
+```typescript
+// src/middleware.ts
+import { defineMiddleware } from 'astro:middleware';
+import { redirectToDefaultLocale } from 'astro:i18n';
+
+export const onRequest = defineMiddleware(async (ctx, next) => {
+  if (ctx.url.startsWith('/about')) {
+    return next();
+  }
+  return redirectToDefaultLocale(302);
+});
+```
+
+### Custom Locale Paths
+
+Map multiple language codes to a single URL path:
+
+```javascript
+i18n: {
+  locales: ['es', 'en', {
+    path: 'french',
+    codes: ['fr', 'fr-BR', 'fr-CA'],
+  }],
+  defaultLocale: 'en',
+}
+```
+
+This maps `fr`, `fr-BR`, and `fr-CA` to `/french/` URLs.
+
+### Domain-Based Routing
+
+For server-rendered sites, map locales to different domains:
+
+```javascript
+i18n: {
+  locales: ['es', 'en', 'fr'],
+  defaultLocale: 'en',
+  domains: {
+    fr: 'https://fr.example.com',
+    es: 'https://example.es',
+  },
+}
+```
+
+Requires `output: 'server'` and a `site` configuration.
+
+## Helper Functions
+
+Import from `astro:i18n`:
+
+```astro
+---
+import {
+  getRelativeLocaleUrl,
+  getAbsoluteLocaleUrl,
+  getRelativeLocaleUrlList,
+  getAbsoluteLocaleUrlList,
+  getPathByLocale,
+  getLocaleByPath,
+} from 'astro:i18n';
+
+// Generate localized URLs
+const aboutES = getRelativeLocaleUrl('es', 'about');
+// → /es/about
+
+// Get all locale variants of a page
+const allAboutUrls = getRelativeLocaleUrlList('about');
+// → ['/about', '/es/about', '/fr/about']
+---
+
+<!-- Language switcher -->
+<nav>
+  <a href={getRelativeLocaleUrl('en', 'about')}>English</a>
+  <a href={getRelativeLocaleUrl('es', 'about')}>Español</a>
+  <a href={getRelativeLocaleUrl('fr', 'about')}>Français</a>
+</nav>
+```
+
+## Content Collections with i18n
+
+Organize translated content in subdirectories:
+
+```
+src/content/blog/
+├── en/
+│   └── post-1.md
+└── es/
+    └── post-1.md
+```
+
+```astro
+---
+// src/pages/[lang]/blog/[...slug].astro
+import { getCollection, render } from 'astro:content';
+
+export async function getStaticPaths() {
+  const pages = await getCollection('blog');
+  return pages.map(page => {
+    const [lang, ...slug] = page.id.split('/');
+    return { params: { lang, slug: slug.join('/') || undefined }, props: page };
+  });
+}
+
+const page = Astro.props;
+const { Content } = await render(page);
+---
+
+<Content />
+```
+
+## Best Practices
+
+1. **Use `getRelativeLocaleUrl()`** for generating links — don't hardcode locale prefixes
+2. **Set up fallbacks** to avoid 404s for untranslated content
+3. **Use `rewrite` fallback type** for better UX (shows content at original URL)
+4. **Consider `prefixDefaultLocale: true`** for consistency across all locales
+5. **Type locale params** to catch typos at build time

--- a/.agents/skills/astro-framework/references/server-islands.md
+++ b/.agents/skills/astro-framework/references/server-islands.md
@@ -1,0 +1,196 @@
+# Server Islands
+
+Server islands allow you to defer rendering of specific Astro components to the server, loading them independently from the rest of the page. This keeps your main content fast while dynamic/personalized sections load separately.
+
+## How It Works
+
+1. The page renders immediately with fallback content as placeholder
+2. Each `server:defer` component is fetched via a separate request
+3. The component's HTML replaces the fallback when ready
+4. Each island loads independently — a slow island won't block others
+
+## Basic Usage
+
+Add `server:defer` to any Astro component to turn it into a server island:
+
+```astro
+---
+import Avatar from '../components/Avatar.astro';
+import ProductReviews from '../components/ProductReviews.astro';
+---
+
+<!-- Static content renders immediately -->
+<h1>Product Page</h1>
+<p>This content is fast and cacheable.</p>
+
+<!-- Server island: deferred rendering -->
+<Avatar server:defer />
+
+<!-- Server island with fallback -->
+<ProductReviews server:defer>
+  <div slot="fallback">
+    <p>Loading reviews...</p>
+  </div>
+</ProductReviews>
+```
+
+## Fallback Content
+
+Use the named `"fallback"` slot to show placeholder content while the island loads:
+
+```astro
+<Avatar server:defer>
+  <!-- Generic placeholder shown until real avatar loads -->
+  <img slot="fallback" src="/generic-avatar.svg" alt="Loading..." />
+</Avatar>
+```
+
+Good fallback patterns:
+- Generic placeholder (e.g., generic avatar instead of user's avatar)
+- Loading skeleton/spinner
+- Placeholder UI with approximate dimensions (prevents layout shift)
+
+## Server Island Components
+
+Inside a server island component, you can do anything a normal SSR component can:
+
+```astro
+---
+// src/components/Avatar.astro
+// This runs on the server when the island is requested
+const userSession = Astro.cookies.get('session');
+const avatarURL = await getUserAvatar(userSession);
+---
+
+<img alt="User avatar" src={avatarURL} />
+```
+
+## Props
+
+Props passed to server islands must be **serializable** — they're encoded in the request URL.
+
+**Supported types:** plain objects, `number`, `string`, `Array`, `Map`, `Set`, `RegExp`, `Date`, `BigInt`, `URL`, `Uint8Array`, `Uint16Array`, `Uint32Array`, `Infinity`
+
+**NOT supported:** functions, class instances, circular references
+
+```astro
+<!-- OK: serializable props -->
+<ProductCard server:defer productId="abc-123" />
+<UserBadge server:defer userId={42} showAvatar={true} />
+
+<!-- NOT OK: functions can't be serialized -->
+<Component server:defer onClick={handleClick} />
+```
+
+**Keep props small.** Props are encoded in the URL query string. If the URL exceeds ~2048 bytes, Astro switches to a POST request which browsers don't cache. Pass IDs rather than full data objects.
+
+## Accessing the Page URL
+
+Server islands run in their own isolated context. `Astro.url` returns the island's internal URL (e.g., `/_server-islands/Avatar`), not the page URL.
+
+To access the page URL, check the `Referer` header:
+
+```astro
+---
+const referer = Astro.request.headers.get('Referer');
+const url = new URL(referer);
+const productId = url.searchParams.get('product');
+---
+```
+
+## Caching
+
+Server island data is fetched via GET requests, so standard `Cache-Control` headers work:
+
+```astro
+---
+// Cache this island for 1 hour
+Astro.response.headers.set('Cache-Control', 'max-age=3600');
+---
+```
+
+## Requirements
+
+- An adapter must be installed (Node, Vercel, Netlify, Cloudflare, etc.)
+- Server islands work in both `server` and `hybrid` output modes
+- The page containing the island can be prerendered — only the island itself needs server rendering
+
+## Use Cases
+
+Server islands are ideal for:
+- **Personalized content** on otherwise static pages (user avatars, greeting bars)
+- **Dynamic data** that changes frequently (product prices, stock status, reviews)
+- **Authenticated sections** (user dashboards widgets on a public page)
+- **Slow data sources** that would delay the whole page if rendered inline
+
+## Expert Patterns
+
+### The E-Commerce Page Pattern
+
+The most common server island pattern — three rendering strategies on one page:
+
+```astro
+---
+import PriceStock from '../components/PriceStock.astro';
+import AddToCart from '../components/AddToCart.jsx';
+---
+
+<!-- Static: title, images, description (cached at CDN) -->
+<h1>{product.title}</h1>
+<img src={product.image} alt={product.title} />
+<p>{product.description}</p>
+
+<!-- Server island: price/stock changes often, needs server data -->
+<PriceStock server:defer productId={product.id}>
+  <div slot="fallback" class="price-skeleton" />
+</PriceStock>
+
+<!-- Client island: add-to-cart needs onClick/state -->
+<AddToCart client:load productId={product.id} />
+```
+
+### Common Mistakes
+
+**Passing large objects as props:**
+```astro
+<!-- BAD: entire product object gets URL-encoded -->
+<PriceStock server:defer product={fullProductObject} />
+
+<!-- GOOD: pass only the ID, fetch inside the island -->
+<PriceStock server:defer productId={product.id} />
+```
+
+If serialized props exceed ~2048 bytes, Astro switches from GET to POST — losing browser/CDN caching entirely.
+
+**Forgetting the fallback slot:**
+Without `slot="fallback"`, users see nothing until the island loads. Always provide a placeholder that matches the island's dimensions to prevent layout shift.
+
+**Using `Astro.url` instead of `Referer`:**
+`Astro.url` inside a server island returns `/_server-islands/ComponentName`, not the page URL. This is a frequent bug source. Always use the `Referer` header:
+
+```astro
+---
+// WRONG: returns /_server-islands/PriceStock
+const url = Astro.url;
+
+// RIGHT: returns the actual page URL
+const pageUrl = new URL(Astro.request.headers.get('Referer'));
+---
+```
+
+### When NOT to Use Server Islands
+
+- **Data that doesn't change per-request** → Use static rendering with rebuild triggers instead
+- **Components needing fast interactivity** (clicks, hover effects) → Use `client:*` directives
+- **Nested server islands** → Not supported; flatten your component hierarchy
+- **Components depending on page layout context** → Server islands render in isolation; they can't access parent component state
+
+## Encryption Key for Deployments
+
+Props are encrypted. In rolling deployments or multi-region setups where frontend/backend may use different keys:
+
+```bash
+astro create-key
+```
+
+Set the result as `ASTRO_KEY` environment variable in your build environment to keep encryption in sync.

--- a/.agents/skills/astro-framework/references/sessions.md
+++ b/.agents/skills/astro-framework/references/sessions.md
@@ -1,0 +1,141 @@
+# Sessions
+
+Sessions store data on the server between requests for on-demand rendered pages. Unlike cookies, sessions have no size limits and are more secure since data never leaves the server.
+
+**Added in:** Astro 5.7+
+
+## Setup
+
+Sessions require a storage driver. Some adapters (Node, Cloudflare, Netlify) configure a default driver automatically.
+
+```javascript
+// astro.config.mjs
+import { defineConfig, sessionDrivers } from 'astro/config';
+import vercel from '@astrojs/vercel';
+
+export default defineConfig({
+  adapter: vercel(),
+  session: {
+    driver: sessionDrivers.redis({
+      url: process.env.REDIS_URL,
+    }),
+  },
+});
+```
+
+Any [unstorage driver](https://unstorage.unjs.io/drivers) can be used (Redis, filesystem, memory, etc.).
+
+## Using Sessions
+
+### In Astro Components and Pages
+
+```astro
+---
+export const prerender = false; // Required in hybrid mode
+
+const cart = await Astro.session?.get('cart');
+---
+
+<a href="/checkout">Cart: {cart?.length ?? 0} items</a>
+```
+
+### In API Endpoints
+
+```typescript
+// src/pages/api/addToCart.ts
+export async function POST(context: APIContext) {
+  const cart = await context.session?.get('cart') || [];
+  const data = await context.request.json<{ item: string }>();
+
+  if (!data?.item) {
+    return new Response('Item is required', { status: 400 });
+  }
+
+  cart.push(data.item);
+  await context.session?.set('cart', cart);
+  return Response.json(cart);
+}
+```
+
+### In Actions
+
+```typescript
+import { defineAction } from 'astro:actions';
+import { z } from 'astro/zod';
+
+export const server = {
+  addToCart: defineAction({
+    input: z.object({ productId: z.string() }),
+    handler: async (input, context) => {
+      const cart = await context.session?.get('cart') || [];
+      cart.push(input.productId);
+      await context.session?.set('cart', cart);
+      return cart;
+    },
+  }),
+};
+```
+
+### In Middleware
+
+```typescript
+import { defineMiddleware } from 'astro:middleware';
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  context.session?.set('lastVisit', new Date());
+  return next();
+});
+```
+
+**Note:** Sessions are not supported in edge middleware.
+
+## Session API
+
+| Method | Description |
+|--------|-------------|
+| `session.get(key)` | Get a value by key |
+| `session.set(key, value)` | Set a value |
+| `session.regenerate()` | Create a new session ID (use after login) |
+| `session.destroy()` | Delete the entire session (use on logout) |
+
+## Type Safety
+
+Define session data types in `src/env.d.ts`:
+
+```typescript
+declare namespace App {
+  interface SessionData {
+    user: {
+      id: string;
+      name: string;
+    };
+    cart: string[];
+    lastVisit: Date;
+  }
+}
+```
+
+This enables type-checking and autocomplete:
+
+```astro
+---
+const cart = await Astro.session?.get('cart');
+// const cart: string[] | undefined
+
+Astro.session?.set('user', { id: 1, name: 'Houston' });
+// Error: id should be string, not number
+---
+```
+
+## Supported Data Types
+
+Session values are serialized with [devalue](https://github.com/Rich-Harris/devalue). Supported types: strings, numbers, `Date`, `Map`, `Set`, `URL`, arrays, and plain objects.
+
+## Best Practices
+
+1. **Always use optional chaining** (`session?.get()`) — session may be undefined if not configured
+2. **Regenerate after login** — prevents session fixation attacks
+3. **Destroy on logout** — cleans up server-side data
+4. **Keep session data small** — store IDs and references, not large objects
+5. **Type your session data** — use `App.SessionData` for safety
+6. **Don't rely on sessions for prerendered pages** — sessions only work with on-demand rendering

--- a/.agents/skills/astro-framework/references/ssr-adapters.md
+++ b/.agents/skills/astro-framework/references/ssr-adapters.md
@@ -227,32 +227,61 @@ if (!user) {
 ---
 ```
 
-## Server Islands (Experimental)
+## Server Islands
 
-Defer rendering of specific components to the server:
-
-```javascript
-// astro.config.mjs
-export default defineConfig({
-  experimental: {
-    serverIslands: true,
-  },
-});
-```
+Defer rendering of specific Astro components to the server. Each island loads independently, keeping main content fast. No experimental flag needed in Astro 5+.
 
 ```astro
 ---
 import UserProfile from '../components/UserProfile.astro';
+import ProductReviews from '../components/ProductReviews.astro';
 ---
 
-<!-- Static content -->
+<!-- Static content renders immediately -->
 <h1>Welcome</h1>
 
 <!-- Server-rendered on each request -->
 <UserProfile server:defer>
   <p slot="fallback">Loading profile...</p>
 </UserProfile>
+
+<!-- Multiple islands load in parallel -->
+<ProductReviews server:defer productId="abc-123">
+  <div slot="fallback">Loading reviews...</div>
+</ProductReviews>
 ```
+
+Key points:
+- Requires an adapter (same as SSR)
+- Props must be serializable (no functions)
+- Use `Referer` header to access page URL inside island
+- See [references/server-islands.md](server-islands.md) for full details
+
+## Sessions
+
+Server-side session storage for on-demand rendered pages (Astro 5.7+):
+
+```javascript
+// astro.config.mjs
+import { defineConfig, sessionDrivers } from 'astro/config';
+
+export default defineConfig({
+  adapter: node({ mode: 'standalone' }),
+  session: {
+    driver: sessionDrivers.redis({ url: process.env.REDIS_URL }),
+  },
+});
+```
+
+```astro
+---
+export const prerender = false;
+const cart = await Astro.session?.get('cart');
+await Astro.session?.set('lastVisit', new Date());
+---
+```
+
+See [references/sessions.md](sessions.md) for full details.
 
 ## API Endpoints
 

--- a/.agents/skills/astro-framework/rules/content-collections.rule.md
+++ b/.agents/skills/astro-framework/rules/content-collections.rule.md
@@ -2,20 +2,24 @@
 description: Rules for content collections and type-safe content
 globs:
   - "src/content/**/*"
+  - "src/content.config.ts"
   - "src/content/config.ts"
+  - "src/live.config.ts"
 ---
 
 # Content Collections Rules
 
-## Collection Configuration
+## Collection Configuration (Astro 5+)
 
-Always define schemas in `src/content/config.ts`:
+Define schemas in `src/content.config.ts` using loaders:
 
 ```typescript
-import { defineCollection, z, reference } from 'astro:content';
+import { defineCollection, reference } from 'astro:content';
+import { glob, file } from 'astro/loaders';
+import { z } from 'astro/zod';
 
 const blog = defineCollection({
-  type: 'content',
+  loader: glob({ base: './src/content/blog', pattern: '**/*.{md,mdx}' }),
   schema: ({ image }) => z.object({
     title: z.string(),
     description: z.string().max(160),
@@ -31,6 +35,8 @@ const blog = defineCollection({
 
 export const collections = { blog };
 ```
+
+> **Migration note:** Astro 5+ uses `src/content.config.ts` (not `src/content/config.ts`), `loader` (not `type`), `import { z } from 'astro/zod'` (not `from 'astro:content'`), and `import { render } from 'astro:content'` for rendering.
 
 ## MUST DO
 
@@ -70,7 +76,10 @@ const author = await getEntry(post.data.author);
 
 ```astro
 ---
-const { Content, headings } = await post.render();
+import { getEntry, render } from 'astro:content';
+
+const post = await getEntry('blog', 'my-post');
+const { Content, headings } = await render(post);
 ---
 
 <article>
@@ -89,28 +98,30 @@ const { Content, headings } = await post.render();
 ```astro
 ---
 // src/pages/blog/[...slug].astro
-import { getCollection } from 'astro:content';
+import { getCollection, render } from 'astro:content';
 
 export async function getStaticPaths() {
   const posts = await getCollection('blog');
   return posts.map(post => ({
-    params: { slug: post.slug },
+    params: { slug: post.id },
     props: { post },
   }));
 }
 
 const { post } = Astro.props;
+const { Content } = await render(post);
 ---
 ```
 
 ## File Organization
 
 ```
-src/content/
-├── config.ts           # Required: collection schemas
-├── blog/
-│   ├── post-1.md
-│   └── post-2.mdx
-└── authors/
-    └── john.json
+src/
+├── content.config.ts    # Required: collection schemas (Astro 5+)
+├── content/
+│   ├── blog/
+│   │   ├── post-1.md
+│   │   └── post-2.mdx
+│   └── authors/
+│       └── john.json
 ```

--- a/.agents/skills/astro-framework/rules/server-islands.rule.md
+++ b/.agents/skills/astro-framework/rules/server-islands.rule.md
@@ -1,0 +1,45 @@
+---
+description: Rules for server islands with deferred rendering
+globs:
+  - "**/*.astro"
+  - "astro.config.mjs"
+---
+
+# Server Islands Rules
+
+## When to Use `server:defer`
+
+Use server islands when a component needs server-side data (cookies, DB, APIs) but the surrounding page can be static or cached.
+
+```astro
+<!-- Personalized component on an otherwise static page -->
+<UserGreeting server:defer>
+  <p slot="fallback">Welcome!</p>
+</UserGreeting>
+```
+
+## MUST DO
+
+- Always provide meaningful `slot="fallback"` content to prevent layout shift
+- Keep props small and serializable (pass IDs, not full objects)
+- Install an adapter — server islands require on-demand rendering
+- Use `Referer` header to access the parent page URL inside the island
+- Set `Cache-Control` headers on islands that don't change per-user
+
+## MUST NOT DO
+
+- Pass functions or class instances as props — they can't be serialized
+- Rely on `Astro.url` for the page URL — it returns the island's internal route
+- Use `server:defer` on components that don't need server data — use static rendering instead
+- Pass large data objects as props — exceeding ~2048 bytes in URL forces POST (uncacheable)
+- Forget to handle the loading state — always provide fallback content
+
+## Decision: Server Island vs Client Island
+
+```
+Does the component need dynamic SERVER data (cookies, DB, personalization)?
+├── Yes → server:defer (Server Island)
+└── No → Does it need browser interactivity (clicks, state)?
+    ├── Yes → client:load/idle/visible (Client Island)
+    └── No → No directive (Static HTML)
+```

--- a/.agents/skills/astro-framework/rules/sessions.rule.md
+++ b/.agents/skills/astro-framework/rules/sessions.rule.md
@@ -1,0 +1,46 @@
+---
+description: Rules for server-side sessions
+globs:
+  - "src/pages/**/*"
+  - "src/actions/**/*"
+  - "src/middleware.ts"
+  - "astro.config.mjs"
+---
+
+# Sessions Rules
+
+## When to Use Sessions
+
+Use sessions for server-side state that persists across requests: user data, shopping carts, form state, preferences. Sessions are more secure and flexible than cookies for storing structured data.
+
+## MUST DO
+
+- Configure a storage driver in `astro.config.mjs` (or use an adapter that provides one)
+- Use optional chaining: `Astro.session?.get()` — session may be undefined
+- Call `session.regenerate()` after login to prevent session fixation
+- Call `session.destroy()` on logout to clean up server data
+- Type session data via `App.SessionData` in `src/env.d.ts`
+- Use sessions only in on-demand rendered pages (`prerender = false`)
+
+## MUST NOT DO
+
+- Access `Astro.session` in prerendered/static pages — sessions require a server
+- Store large blobs in sessions — keep data small, store references/IDs
+- Use sessions in edge middleware — not supported
+- Forget to handle undefined session (when driver isn't configured)
+- Store sensitive secrets directly — sessions are server-side but still use reasonable data hygiene
+
+## Pattern: Session with Auth
+
+```astro
+---
+export const prerender = false;
+
+const user = await Astro.session?.get('user');
+if (!user) {
+  return Astro.redirect('/login');
+}
+---
+
+<h1>Welcome, {user.name}</h1>
+```


### PR DESCRIPTION
## Descripción

Actualizada la skill `astro-framework` en `.agents/skills/` con nuevas referencias y reglas para mejorar el soporte del agente al trabajar con la nuevas versiones de Astro +5 y +6

**Nuevas referencias añadidas:**
- Variables de entorno
- i18n routing
- Server Islands
- Sessions

**Nuevas reglas añadidas:**
- Server Islands
- Sessions

**Referencias actualizadas:**
- Content Collections (documentación ampliada)
- Client Directives
- Configuración
- SSR Adapters

**Otros cambios:**
- `AGENTS.md` y `SKILL.md` actualizados con la estructura revisada

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Documentation update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Astro Framework guidelines with condensed cheat sheet and decision trees.
  * Added comprehensive guides for server islands, sessions, i18n routing, and typed environment variables.
  * Enhanced client directives guidance with optimization tips and common pitfalls.
  * Updated content collections documentation for Astro 5+ Content Layer API.
  * Expanded reference materials with migration notes and best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->