### PR TITLE
fix(seo): correct JSON-LD event data and add recommended schema.org fields

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -72,26 +72,32 @@ const {
         "name": "La Velada del Año VI",
         "description": "Evento de boxeo aficionado entre streamers y creadores de contenido, organizado por Ibai Llanos",
         "image": "https://www.infolavelada.com/og.jpg",
-        "startDate": "2026-03-09T19:00:00+01:00",
+        "startDate": "2026-07-25T20:00:00+02:00",
         "eventStatus": "https://schema.org/EventScheduled",
         "eventAttendanceMode": "https://schema.org/MixedEventAttendanceMode",
+        "url": "https://www.infolavelada.com/",
         "location": {
           "@type": "Place",
-          "name": "Teatro Victoria",
+          "name": "Estadio La Cartuja de Sevilla",
           "address": {
             "@type": "PostalAddress",
-            "addressLocality": "Barcelona",
-            "addressRegion": "Cataluña",
+            "addressLocality": "Sevilla",
+            "addressRegion": "Andalucía",
             "addressCountry": "ES"
           }
         },
         "organizer": {
           "@type": "Person",
-          "name": "Ibai Llanos"
+          "name": "Ibai Llanos",
+          "url": "https://www.twitch.tv/ibai"
         },
         "performer": {
           "@type": "PerformingGroup",
           "name": "Creadores de contenido"
+        },
+        "offers": {
+          "@type": "Offer",
+          "availability": "https://schema.org/SoldOut"
         }
       }
     </script>


### PR DESCRIPTION
## Describe your changes

The JSON-LD Event schema in `Layout.astro` contained incorrect location and date information from a previous edition. Updated all fields to match La Velada del Año VI and added recommended schema.org properties.

### Bug fixes:
- **startDate**: `2026-03-09T19:00:00+01:00` → `2026-07-25T20:00:00+02:00`
- **location.name**: `Teatro Victoria` → `Estadio La Cartuja de Sevilla` (official name)
- **addressLocality**: `Barcelona` → `Sevilla`
- **addressRegion**: `Cataluña` → `Andalucía`

### Additions ([schema.org/Event](https://schema.org/Event) recommended fields):
- `url` — link to the official website
- `organizer.url` — Ibai's Twitch channel
- `offers` — with `SoldOut` availability status

This ensures search engines display correct event information in rich results.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the event start date/time to 2026-07-25T20:00:00+02:00.
  * Changed venue to Estadio La Cartuja de Sevilla, Sevilla, Andalucía (country: ES).
  * Added a top-level event URL and added an organizer URL.
  * Added ticket offer metadata showing availability as SoldOut.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->