### PR TITLE
fix: 404 page text visibility on dark background

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -13,7 +13,7 @@ export const prerender = true
     class="mask-fade-bottom flex min-h-screen w-full items-center justify-center text-center"
   >
     <div class="w-full max-w-3xl items-center justify-center">
-      <h1 class="text-theme-midnight">
+      <h1 class="text-theme-cream">
         <span
           class="rotate-113 mb-12 w-fit mx-auto block text-[120px] font-bold tracking-[.025em]"
           aria-hidden="true"
@@ -22,7 +22,7 @@ export const prerender = true
         </span>
         <span class="mb-2 block text-4xl font-bold tracking-wider">¡FUERA DE COMBATE!</span>
       </h1>
-      <p class="text-theme-midnight mb-6 text-xl tracking-wide">
+      <p class="text-theme-cream mb-6 text-xl tracking-wide">
         vaya, parece que te han noqueado...
       </p>
       <div class="flex min-h-4 items-center justify-center">


### PR DESCRIPTION
## Descripción
Corrige la visibilidad del texto en la página 404, que era invisible  al usar `text-theme-midnight` (texto oscuro) 
sobre el fondo oscuro del Layout.

## Cambios
- Reemplazado `text-theme-midnight` por `text-theme-cream` en el `<h1>` y `<p>`

## Antes / Después
Solo se veía el botón "Volver al ring". Ahora se muestra todo el contenido correctamente.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text color styling on the 404 error page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->