### PR TITLE
fix(boxers): use webp as real fallback for boxer images

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -206,7 +206,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
           />
           <img
             data-active-image
-            src={fallbackHero.png}
+            src={fallbackHero.fallback}
             alt={`Foto principal de ${fallback.name}`}
             class="boxer-portrait relative z-10 h-full max-h-full w-auto max-w-full object-contain object-bottom transition-opacity duration-300"
             decoding="async"
@@ -292,7 +292,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
                       <source type="image/avif" srcset={selectImages.avif} />
                       <source type="image/webp" srcset={selectImages.webp} />
                       <img
-                        src={selectImages.png}
+                        src={selectImages.fallback}
                         alt=""
                         role="presentation"
                         loading="lazy"
@@ -353,7 +353,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
                 data-name={boxer.name}
                 data-photo-avif={heroImages.avif}
                 data-photo-webp={heroImages.webp}
-                data-photo-png={heroImages.png}
+                data-photo-fallback={heroImages.fallback}
                 data-flag={flag}
                 data-country={countryName}
                 aria-label={`Ver perfil de ${boxer.name}`}
@@ -366,7 +366,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
                   <source type="image/avif" srcset={selectImages.avif} />
                   <source type="image/webp" srcset={selectImages.webp} />
                   <img
-                    src={selectImages.png}
+                    src={selectImages.fallback}
                     alt=""
                     role="presentation"
                     loading="lazy"
@@ -1082,7 +1082,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   ): string | undefined {
     if (formats.avif && thumb.dataset.photoAvif) return thumb.dataset.photoAvif
     if (formats.webp && thumb.dataset.photoWebp) return thumb.dataset.photoWebp
-    return thumb.dataset.photoPng
+    return thumb.dataset.photoFallback
   }
 
   function setupMobileInfiniteSlider(root: HTMLElement) {
@@ -1225,15 +1225,15 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     /** Aplica el contenido (imagen, nombre, watermark, bandera, país) al
      *  panel del boxer. No toca el state ni las clases is-switching. */
     function applyBoxerContent(thumb: HTMLAnchorElement) {
-      const { name, photoAvif, photoWebp, photoPng, flag, country } =
+      const { name, photoAvif, photoWebp, photoFallback, flag, country } =
         thumb.dataset
-      if (!name || !photoPng) return
+      if (!name || !photoFallback) return
 
       // Actualizamos las sources del <picture> antes del src del <img>
       // para que el browser re-evalúe y use el mejor formato disponible.
       if (sourceAvif && photoAvif) sourceAvif.srcset = photoAvif
       if (sourceWebp && photoWebp) sourceWebp.srcset = photoWebp
-      image!.src = photoPng
+      image!.src = photoFallback
       image!.alt = `Foto principal de ${name}`
 
       nameNode!.textContent = name
@@ -1249,7 +1249,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       if (!image || !nameNode) return
 
       const { id, opponentId } = thumb.dataset
-      if (!id || !thumb.dataset.photoPng) return
+      if (!id || !thumb.dataset.photoFallback) return
 
       const wasDefault = root!.dataset.state === 'default'
 

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -14,8 +14,8 @@ export interface Boxer {
 
 /**
  * Los `id` coinciden exactamente con:
- *  - `/public/character-select/{id}.png` (miniatura del selector)
- *  - `/public/character-hero/{id}.png` (recorte grande mostrado en el
+ *  - `/public/character-select/{id}.webp` (miniatura fallback del selector)
+ *  - `/public/character-hero/{id}.webp` (recorte grande fallback mostrado en el
  *    hero al hacer hover sobre la miniatura del selector)
  *  - `/public/photos/{id}/01.webp` (foto principal usada en la ficha
  *    del combate)
@@ -340,12 +340,13 @@ export const BOXERS: Boxer[] = [
 ]
 
 /** Conjunto de variantes de una imagen del boxeador. Las versiones
- *  `avif` y `webp` están optimizadas (mucho más pequeñas que el PNG)
+ *  `avif` y `webp` están optimizadas y `fallback` apunta al formato
+ *  de respaldo realmente disponible para el `<img>`.
  *  y se generan con `pnpm generate:character-images`. */
 export interface BoxerImageVariants {
   avif: string
   webp: string
-  png: string
+  fallback: string
 }
 
 /** Variantes de la miniatura del selector (carpeta `character-select`). */
@@ -353,14 +354,14 @@ export function getBoxerSelectImages(boxer: Boxer): BoxerImageVariants {
   return {
     avif: `/character-select/${boxer.id}.avif`,
     webp: `/character-select/${boxer.id}.webp`,
-    png: `/character-select/${boxer.id}.png`,
+    fallback: `/character-select/${boxer.id}.webp`,
   }
 }
 
-/** Devuelve la ruta a la imagen de selección (miniatura) de un boxeador,
- *  formato PNG. Para mejor rendimiento, prefiere `getBoxerSelectImages`. */
+/** Devuelve la ruta fallback de selección (miniatura) de un boxeador.
+ *  Para mejor rendimiento, prefiere `getBoxerSelectImages`. */
 export function getBoxerSelectImage(boxer: Boxer): string {
-  return getBoxerSelectImages(boxer).png
+  return getBoxerSelectImages(boxer).fallback
 }
 
 /** Variantes del recorte grande para el hero (carpeta `character-hero`). */
@@ -368,17 +369,17 @@ export function getBoxerHeroImages(boxer: Boxer): BoxerImageVariants {
   return {
     avif: `/character-hero/${boxer.id}.avif`,
     webp: `/character-hero/${boxer.id}.webp`,
-    png: `/character-hero/${boxer.id}.png`,
+    fallback: `/character-hero/${boxer.id}.webp`,
   }
 }
 
 /**
- * Devuelve la ruta al recorte grande del boxeador usado en el hero al
- * hacer hover sobre la miniatura del selector, formato PNG. Para mejor
+ * Devuelve la ruta fallback al recorte grande del boxeador usado en el
+ * hero al hacer hover sobre la miniatura del selector. Para mejor
  * rendimiento, prefiere `getBoxerHeroImages`.
  */
 export function getBoxerHeroImage(boxer: Boxer): string {
-  return getBoxerHeroImages(boxer).png
+  return getBoxerHeroImages(boxer).fallback
 }
 
 /** Devuelve la ruta a la foto principal del boxeador (01.webp). */

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -217,7 +217,7 @@ const rescueBoxers = [
                   <source type="image/avif" srcset={boxer.thumbs.avif} />
                   <source type="image/webp" srcset={boxer.thumbs.webp} />
                   <img
-                    src={boxer.thumbs.png}
+                    src={boxer.thumbs.fallback}
                     alt=""
                     role="presentation"
                     loading="lazy"

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -294,7 +294,7 @@ const totalBoxers = BOXERS.length
                   <source type="image/avif" srcset={b.heroImages.avif} />
                   <source type="image/webp" srcset={b.heroImages.webp} />
                   <img
-                    src={b.heroImages.png}
+                    src={b.heroImages.fallback}
                     alt={`Recorte fotográfico de ${b.name}`}
                     loading="lazy"
                     decoding="async"

--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -198,7 +198,7 @@ const breadcrumbJsonLd = {
             <source type="image/avif" srcset={heroImages.avif} />
             <source type="image/webp" srcset={heroImages.webp} />
             <img
-              src={heroImages.png}
+              src={heroImages.fallback}
               alt={`Foto principal de ${boxer.name}`}
               transition:name={`boxer-hero-${boxer.id}`}
               class="boxer-detail-portrait relative z-10 h-auto w-auto max-w-full object-contain object-top"
@@ -248,7 +248,7 @@ const breadcrumbJsonLd = {
                   <source type="image/avif" srcset={opponentSelectImages.avif} />
                   <source type="image/webp" srcset={opponentSelectImages.webp} />
                   <img
-                    src={opponentSelectImages.png}
+                    src={opponentSelectImages.fallback}
                     alt=""
                     role="presentation"
                     decoding="async"


### PR DESCRIPTION
Closes #1448

## Summary
- replace boxer image `.png` fallbacks with a real WebP fallback that exists in `public/character-select` and `public/character-hero`
- keep AVIF as the preferred source in `<picture>` while removing runtime 404s from missing boxer image assets
- update boxer selector, boxer list, boxer detail, and 404 rescue cards to use the new fallback contract consistently

## Verification
- verified locally in development against `/`, `/boxeadores`, and `/boxeadores/alondrissa`
- confirmed boxer-image 404s disappeared from the browser console after the change

## Notes
- `test-results/` was left untracked and is not part of this PR
