### PR TITLE
fix(footer): typo fix and hover interaction

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -179,9 +179,13 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="edition-link inline-flex min-h-8 items-center justify-center px-1 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
+                    class="group/edition relative inline-flex min-h-8 items-center justify-center px-1 outline-none transition-colors duration-150 ease-out [@media(hover:hover)_and_(pointer:fine)]:hover:text-theme-cream [@media(hover:hover)_and_(pointer:fine)]:hover:delay-[125ms] focus-visible:text-theme-cream focus-visible:delay-[125ms] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
                     aria-label={`Ir a la web de La Velada del Año ${year}`}
                   >
+                    <span
+                      aria-hidden="true"
+                      class="pointer-events-none absolute inset-x-1 bottom-1 h-px origin-center scale-x-0 bg-theme-gold transition-transform duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:scale-x-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-[125ms] group-focus-visible/edition:scale-x-100 group-focus-visible/edition:delay-[125ms]"
+                    />
                     {year}
                   </a>
                 </li>
@@ -225,43 +229,5 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
   .footer-noise {
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
     mask-image: linear-gradient(to bottom, transparent 0%, #000 100%);
-  }
-
-  .edition-link {
-    position: relative;
-    transition: color 150ms ease-out;
-  }
-
-  .edition-link::after {
-    content: '';
-    position: absolute;
-    inset-inline: 0.25rem;
-    bottom: 0.25rem;
-    height: 1px;
-    background: var(--color-theme-gold);
-    transform: scaleX(0);
-    transition: transform 150ms ease-out;
-  }
-
-  @media (hover: hover) and (pointer: fine) {
-    .edition-link:hover {
-      color: var(--color-theme-cream);
-      transition-delay: 125ms;
-    }
-
-    .edition-link:hover::after {
-      transform: scaleX(1);
-      transition-delay: 125ms;
-    }
-  }
-
-  .edition-link:focus-visible {
-    color: var(--color-theme-cream);
-    transition-delay: 125ms;
-  }
-
-  .edition-link:focus-visible::after {
-    transform: scaleX(1);
-    transition-delay: 125ms;
   }
 </style>

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -179,9 +179,13 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="inline-flex min-h-8 items-center justify-center px-1 underline-offset-4 transition hover:text-theme-cream hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
+                    class="group/edition relative inline-flex min-h-8 items-center justify-center px-1 outline-none transition-colors duration-150 ease-out [@media(hover:hover)_and_(pointer:fine)]:hover:text-theme-cream [@media(hover:hover)_and_(pointer:fine)]:hover:delay-125 focus-visible:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
                     aria-label={`Ir a la web de La Velada del Año ${year}`}
                   >
+                    <span
+                      aria-hidden="true"
+                      class="pointer-events-none absolute inset-x-1 bottom-1 h-px origin-center scale-x-0 bg-theme-gold transition-transform duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:scale-x-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-125"
+                    />
                     {year}
                   </a>
                 </li>
@@ -200,7 +204,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
 
     <div class="pb-2 font-cinzel">
       <p class="text-center text-[0.7rem] tracking-[0.2em] text-white/60 sm:text-xs">
-        <span>© 2026 LA VELADA DEL AÑO</span>
+        <span>© 2026 LA VELADA VI</span>
         <span aria-hidden="true" class="mx-2 text-theme-gold/40">·</span>
         <span class="text-white/45">TODOS LOS DERECHOS RESERVADOS</span>
       </p>

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -179,12 +179,12 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="group/edition relative inline-flex min-h-8 items-center justify-center px-1 outline-none transition-colors duration-150 ease-out [@media(hover:hover)_and_(pointer:fine)]:hover:text-theme-cream [@media(hover:hover)_and_(pointer:fine)]:hover:delay-125 focus-visible:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
+                    class="group/edition relative inline-flex min-h-8 items-center justify-center px-1 outline-none transition-colors duration-150 ease-out [@media(hover:hover)_and_(pointer:fine)]:hover:text-theme-cream [@media(hover:hover)_and_(pointer:fine)]:hover:delay-[125ms] focus-visible:text-theme-cream focus-visible:delay-[125ms] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
                     aria-label={`Ir a la web de La Velada del Año ${year}`}
                   >
                     <span
                       aria-hidden="true"
-                      class="pointer-events-none absolute inset-x-1 bottom-1 h-px origin-center scale-x-0 bg-theme-gold transition-transform duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:scale-x-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-125"
+                      class="pointer-events-none absolute inset-x-1 bottom-1 h-px origin-center scale-x-0 bg-theme-gold transition-transform duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:scale-x-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-[125ms] group-focus-visible/edition:scale-x-100 group-focus-visible/edition:delay-[125ms]"
                     />
                     {year}
                   </a>

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -179,13 +179,9 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
                     href={url}
                     target="_blank"
                     rel="noopener noreferrer"
-                    class="group/edition relative inline-flex min-h-8 items-center justify-center px-1 outline-none transition-colors duration-150 ease-out [@media(hover:hover)_and_(pointer:fine)]:hover:text-theme-cream [@media(hover:hover)_and_(pointer:fine)]:hover:delay-[125ms] focus-visible:text-theme-cream focus-visible:delay-[125ms] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
+                    class="edition-link inline-flex min-h-8 items-center justify-center px-1 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
                     aria-label={`Ir a la web de La Velada del Año ${year}`}
                   >
-                    <span
-                      aria-hidden="true"
-                      class="pointer-events-none absolute inset-x-1 bottom-1 h-px origin-center scale-x-0 bg-theme-gold transition-transform duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:scale-x-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-[125ms] group-focus-visible/edition:scale-x-100 group-focus-visible/edition:delay-[125ms]"
-                    />
                     {year}
                   </a>
                 </li>
@@ -229,5 +225,43 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
   .footer-noise {
     background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 200'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
     mask-image: linear-gradient(to bottom, transparent 0%, #000 100%);
+  }
+
+  .edition-link {
+    position: relative;
+    transition: color 150ms ease-out;
+  }
+
+  .edition-link::after {
+    content: '';
+    position: absolute;
+    inset-inline: 0.25rem;
+    bottom: 0.25rem;
+    height: 1px;
+    background: var(--color-theme-gold);
+    transform: scaleX(0);
+    transition: transform 150ms ease-out;
+  }
+
+  @media (hover: hover) and (pointer: fine) {
+    .edition-link:hover {
+      color: var(--color-theme-cream);
+      transition-delay: 125ms;
+    }
+
+    .edition-link:hover::after {
+      transform: scaleX(1);
+      transition-delay: 125ms;
+    }
+  }
+
+  .edition-link:focus-visible {
+    color: var(--color-theme-cream);
+    transition-delay: 125ms;
+  }
+
+  .edition-link:focus-visible::after {
+    transform: scaleX(1);
+    transition-delay: 125ms;
   }
 </style>

--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -204,7 +204,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
 
     <div class="pb-2 font-cinzel">
       <p class="text-center text-[0.7rem] tracking-[0.2em] text-white/60 sm:text-xs">
-        <span>© 2026 LA VELADA VI</span>
+        <span>© 2026 LA VELADA DEL AÑO VI</span>
         <span aria-hidden="true" class="mx-2 text-theme-gold/40">·</span>
         <span class="text-white/45">TODOS LOS DERECHOS RESERVADOS</span>
       </p>


### PR DESCRIPTION
## Describe your changes

This PR keeps the footer copy and link interactions consistent with the current La Velada VI treatment.

- Updates the footer copyright from `LA VELADA DEL AÑO` to `LA VELADA DEL AÑO VI`.
- Replaces the static browser underline on previous-edition links with the same animated underline pattern used by the header navigation.
- Keeps the underline animation scoped to fine-pointer hover, matching the nav behavior and avoiding fake hover affordances on touch devices.
- Fixes invalid `delay-125` Tailwind class by replacing it with `delay-[125ms]`.
- Adds `focus-visible` underline animation for keyboard users, matching the hover experience.

## Include a screenshot/video where applicable

* Footer previous editions interaction:

**Before** (upstream/main — static browser underline, `LA VELADA DEL AÑO`):  
<img width="1440" alt="Footer before - static underline, LA VELADA DEL AÑO" src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/footer-fix-artifacts/pr-assets/footer-fix/before-default.png?v=2" />

**Before hover** (static browser underline on "2025"):  
<img width="1440" alt="Footer before hover - static underline" src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/footer-fix-artifacts/pr-assets/footer-fix/before-hover.png?v=2" />

**After** (footer-fix — animated gold underline, `LA VELADA DEL AÑO VI`):  
<img width="1440" alt="Footer after - animated gold underline, LA VELADA DEL AÑO VI" src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/footer-fix-artifacts/pr-assets/footer-fix/after-default.png?v=2" />

**After hover** (animated gold underline on "2025"):  
<img width="1440" alt="Footer after hover - animated gold underline" src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/footer-fix-artifacts/pr-assets/footer-fix/after-hover.png?v=2" />

Interaction video:

[pr-assets_footer-fix_footer-hover-interaction-trimmed-zoom.webm](https://github.com/user-attachments/assets/834cd049-18b1-4323-b264-6bcd7e48f56a)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification

- [x] Compared the footer interaction against `nav-patch` via `git show nav-patch:src/sections/Header.astro`
- [x] Captured before/after screenshots with Playwright
- [x] Captured a focused Playwright video of the footer hover interaction
- [x] Verified the footer DOM text reads `LA VELADA DEL AÑO VI`
- [x] Replaced invalid `delay-125` with `delay-[125ms]`
- [x] Added `focus-visible` underline animation for keyboard parity
- [x] No build was run, following project instructions
