### PR TITLE
style(ui): replace divider diamond with logo mark

### DIFF
--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -1,4 +1,6 @@
 ---
+import VeladaLogo from '@/assets/svg/logo.svg'
+
 interface Props {
   titleId: string
   title: string
@@ -24,7 +26,7 @@ const {
 
 <div class:list={['mb-8 flex items-center gap-4', dividerClass]} aria-hidden="true">
   <span class="h-px w-12 bg-linear-to-r from-transparent to-theme-gold/40 sm:w-24"></span>
-  <span class="size-1.5 rotate-45 bg-theme-gold/70"></span>
+  <VeladaLogo class="h-[1.125rem] w-[1.125rem] shrink-0 text-theme-gold [&_path]:stroke-current [&_path]:stroke-[9] [&_path]:stroke-linejoin-round" />
   <span class="h-px w-12 bg-linear-to-l from-transparent to-theme-gold/40 sm:w-24"></span>
 </div>
 


### PR DESCRIPTION
## Describe your changes
- Replaced the global section divider diamond with the existing La Velada SVG logo mark.
- Kept the update centralized in `SectionHeader.astro` so every section using the shared header gets the same divider treatment.
- Removed center-icon opacity and tuned the mark slightly larger/thicker for better visual balance.

## Include a screenshot/video where applicable
Before:

![Before divider](https://github.com/tonyblu331/la-velada-web-oficial/releases/download/pr-1457-divider-screenshots/dividers-before.png)

After:

![After divider](https://github.com/tonyblu331/la-velada-web-oficial/releases/download/pr-1457-divider-screenshots/dividers-after.png)

## Type of change
- [x] New feature (non-breaking change which adds functionality)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the section header divider to use a centered Velada logo icon, refreshing the visual divider for improved presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1457?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->