### PR TITLE
docs: update La Velada VI documentation branding

### DIFF
--- a/API_PREDICTIONS.md
+++ b/API_PREDICTIONS.md
@@ -1,6 +1,6 @@
-# API de Predicciones - La Velada del Año V
+# API de Predicciones - La Velada del Año VI
 
-Esta API permite gestionar las predicciones de los combates de La Velada del Año V usando Turso como base de datos. Incluye tracking de usuarios para evitar votos duplicados y permitir cambios de voto. El `user_id` se obtiene automáticamente de la sesión del usuario autenticado. La validación de combates se realiza usando los datos locales para mayor eficiencia.
+Esta API permite gestionar las predicciones de los combates de La Velada del Año VI usando Turso como base de datos. Incluye tracking de usuarios para evitar votos duplicados y permitir cambios de voto. El `user_id` se obtiene automáticamente de la sesión del usuario autenticado. La validación de combates se realiza usando los datos locales para mayor eficiencia.
 
 ## Endpoints
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # CONTRIBUTING.md
 
-## Bienvenido a 'La velada del año 5' 🌌
+## Bienvenido a 'La Velada del Año VI' 🌌
 
-¡Estamos encantados de que estés interesado en contribuir a nuestro proyecto! Este documento te guiará a través de los pasos necesarios para aportar tu valioso trabajo a 'La velada del año 5', un proyecto desarrollado con Astro. Queremos hacer de este proceso algo sencillo y transparente, así que aquí tienes una guía paso a paso.
+¡Estamos encantados de que estés interesado en contribuir a nuestro proyecto! Este documento te guiará a través de los pasos necesarios para aportar tu valioso trabajo a 'La Velada del Año VI', un proyecto desarrollado con Astro. Queremos hacer de este proceso algo sencillo y transparente, así que aquí tienes una guía paso a paso.
 
 ### Primeros pasos 🚀
 
@@ -35,7 +35,7 @@
 
 - **Commit de tus cambios**: Una vez estés satisfecho con tus cambios, haz commit de ellos con un mensaje claro y descriptivo.
 - **Push a tu fork**: Haz push de tu rama con los cambios a tu fork en GitHub utilizando `git push origin nombre-de-tu-rama`.
-- **Crea un Pull Request (PR)**: En GitHub, ve a tu fork de 'La velada del año 5' y haz clic en "Pull request" para iniciar uno. Asegúrate de describir claramente qué cambios has realizado y por qué son necesarios o útiles para el proyecto.
+- **Crea un Pull Request (PR)**: En GitHub, ve a tu fork de 'La Velada del Año VI' y haz clic en "Pull request" para iniciar uno. Asegúrate de describir claramente qué cambios has realizado y por qué son necesarios o útiles para el proyecto.
 
 ### Buenas prácticas 🌟
 
@@ -51,4 +51,4 @@
 
 Si tienes alguna pregunta o necesitas ayuda, no dudes en abrir un "issue" en el repositorio. Nuestro equipo y la comunidad estarán encantados de ayudarte.
 
-¡Gracias por contribuir a 'La velada del año 5'! Juntos estamos construyendo algo increíble. 🚀
+¡Gracias por contribuir a 'La Velada del Año VI'! Juntos estamos construyendo algo increíble. 🚀

--- a/DATABASE_PREDICTIONS.md
+++ b/DATABASE_PREDICTIONS.md
@@ -1,6 +1,6 @@
-# Base de Datos de Predicciones - La Velada del Año V
+# Base de Datos de Predicciones - La Velada del Año VI
 
-Esta documentación describe la configuración y uso de la base de datos de predicciones para La Velada del Año V.
+Esta documentación describe la configuración y uso de la base de datos de predicciones para La Velada del Año VI.
 
 ## Configuración
 

--- a/README.md
+++ b/README.md
@@ -8,21 +8,21 @@
 [![Issues][issues-shield]][issues-url]
 
 <a href="https://www.infolavelada.com/" target="_blank" rel="noopener noreferrer">
-  <img width="300px" src="https://github.com/user-attachments/assets/9cb3d500-8b37-400a-a983-6a6d1a9356a2" alt="Logo" width="800" />
+  <img width="300px" src="./public/logo.webp" alt="Logo de La Velada del Año VI" />
 </a>
 
-## Web oficial de La Velada V
+## Web oficial de La Velada VI
 
-La Velada V es una competición de boxeo que enfrenta a streamers, creadores de contenido y otras celebridades sobre un ring· [Reportar error](https://github.com/midudev/la-velada-web-oficial/issues) · [Sugerir algo](https://github.com/midudev/la-velada-web-oficial/issues)
+La Velada VI es una competición de boxeo que enfrenta a streamers, creadores de contenido y otras celebridades sobre un ring. [Reportar error](https://github.com/midudev/la-velada-web-oficial/issues) · [Sugerir algo](https://github.com/midudev/la-velada-web-oficial/issues)
 
 </div>
 
 <details>
 <summary>Tabla de contenidos</summary>
 
-- [Web oficial de La Velada V](#web-oficial-de-la-velada-v)
+- [Web oficial de La Velada VI](#web-oficial-de-la-velada-vi)
 - [Características principales](#características-principales)
-  - [Capturas de pantalla de la web de La Velada V](#capturas-de-pantalla-de-la-web-de-la-velada-v)
+  - [Capturas de pantalla de la web de La Velada VI](#capturas-de-pantalla-de-la-web-de-la-velada-vi)
 - [Para empezar](#para-empezar)
   - [Prerequisitos](#prerequisitos)
   - [Instalación](#instalación)
@@ -38,9 +38,9 @@ La Velada V es una competición de boxeo que enfrenta a streamers, creadores de 
 - **Compra de boletos**: Permite a los usuarios dirigirlos a la compra de boletos fácilmente.
 - **Redes sociales**: Conoce las redes oficiales donde podrás informarte sobre el evento.
 
-### Capturas de pantalla de la web de La Velada V
+### Capturas de pantalla de la web de La Velada VI
 
-![Captura de pantalla](https://github.com/user-attachments/assets/9c63299b-db80-49e5-a566-2b99405230e3)
+![Captura de pantalla de la home de La Velada VI](https://github.com/tonyblu331/la-velada-web-oficial/releases/download/readme-homepage-vi-assets/readme-homepage-vi.png)
 
 <p align="right">(<a href="#readme-top">volver arriba</a>)</p>
 

--- a/README_PREDICTIONS.md
+++ b/README_PREDICTIONS.md
@@ -1,6 +1,6 @@
-# 🥊 Sistema de Predicciones - La Velada del Año V
+# 🥊 Sistema de Predicciones - La Velada del Año VI
 
-Este documento te guía paso a paso para configurar y usar el sistema de predicciones para La Velada del Año V.
+Este documento te guía paso a paso para configurar y usar el sistema de predicciones para La Velada del Año VI.
 
 ## 🚀 Configuración Inicial
 
@@ -254,4 +254,4 @@ Si encuentras algún problema:
 
 ---
 
-¡El sistema de predicciones está listo para La Velada del Año V! 🥊✨
+¡El sistema de predicciones está listo para La Velada del Año VI! 🥊✨


### PR DESCRIPTION
## Describe your changes
- Updated README branding from La Velada V to La Velada VI, including the current local logo reference.
- Updated CONTRIBUTING.md and prediction docs that still referred to La Velada V / Año 5.
- Replaced the old README homepage screenshot reference with a current La Velada VI homepage capture hosted outside the branch.

## Include a screenshot/video where applicable
![Captura de pantalla de la home de La Velada VI](https://github.com/tonyblu331/la-velada-web-oficial/releases/download/readme-homepage-vi-assets/readme-homepage-vi.png)

## Type of change
- [x] Documentation update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated site branding and homepage copy to reference La Velada VI, including refreshed logo and event screenshots.
  * Revised API and database docs headings to La Velada VI.
  * Updated contribution guide and prediction README to reference La Velada VI throughout.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->