### PR TITLE
fix: faq details icon alignment

### DIFF
--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -57,11 +57,11 @@ const { faqs } = Astro.props
                   {question}
                 </h3>
                 <span
-                  class="relative flex size-10 shrink-0 items-center justify-center rounded-full border border-theme-gold/30 bg-black/25 text-theme-gold transition duration-300 group-open:rotate-45 group-open:border-theme-gold/70 group-open:bg-theme-gold/15 sm:size-11"
+                  class="relative flex size-10.25 shrink-0 items-center justify-center rounded-full border border-theme-gold/30 bg-black/25 text-theme-gold transition duration-300 group-open:rotate-45 group-open:border-theme-gold/70 group-open:bg-theme-gold/15 sm:size-11.25"
                   aria-hidden="true"
                 >
-                  <span class="absolute h-px w-4 bg-current"></span>
-                  <span class="absolute h-4 w-px bg-current"></span>
+                  <span class="absolute h-px w-4.25 bg-current"></span>
+                  <span class="absolute h-4.25 w-px bg-current"></span>
                 </span>
               </summary>
 


### PR DESCRIPTION
Se agrega un píxel al tamaño tanto del círculo como de las líneas que forman el ícono “plus”, para que las dimensiones sean impares y queden completamente centradas.

Antes:
<img width="400" height="398" alt="before" src="https://github.com/user-attachments/assets/562fc93e-2c35-45ae-a43d-3d632e72f7ac" />

Después: 
<img width="400" height="399" alt="after" src="https://github.com/user-attachments/assets/cfd926e8-c0f8-47e4-b314-2c6be64ec497" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual sizing and appearance of the FAQ accordion expand/collapse icons for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->