### PR TITLE
fix: ajustar altura maxima del logo en resoluciones landscape

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -115,7 +115,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   <div class="boxer-stage relative w-full flex-1">
     <div
       data-default-panel
-      class="boxer-default-panel relative flex w-full flex-col items-center justify-center text-center md:justify-start"
+      class="boxer-default-panel relative flex w-full flex-col items-center justify-center text-center landscape:justify-center md:justify-start"
     >
       <div class="boxer-default-aura pointer-events-none absolute inset-0 -z-1" aria-hidden="true"></div>
 
@@ -130,7 +130,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
           <img
             src="/logo.webp"
             alt="La Velada del Año VI"
-            class="boxer-default-logo relative h-auto w-[58vw] max-w-[360px] sm:w-[44vw] md:w-[36vw] lg:w-[28vw]"
+            class="boxer-default-logo relative h-auto w-[58vw] max-w-[360px] sm:w-[44vw] md:w-[36vw] lg:w-[28vw] landscape:max-h-[35vh] landscape:w-auto"
             width="512"
             height="512"
             decoding="async"
@@ -140,12 +140,12 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       </div>
 
       <ul
-        class="boxer-default-info animate-fade-in-up animate-delay-500 -mt-8 flex flex-col items-center justify-center gap-1 px-4 sm:-mt-12 md:-mt-16"
+        class="boxer-default-info animate-fade-in-up animate-delay-500 -mt-6 flex flex-col items-center justify-center gap-1 px-4 landscape:mt-2 sm:-mt-10 md:-mt-12 lg:-mt-14"
       >
         <li class="flex items-baseline">
           <time
             datetime="2026-07-25"
-            class="font-cinzel text-xs font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
+            class="font-cinzel text-[min(3vw,0.875rem)] font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
           >
             25 DE JULIO
           </time>
@@ -153,14 +153,14 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         <li class="flex items-baseline">
           <time
             datetime="2026-07-25T20:00:00+02:00"
-            class="font-cinzel text-xs font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
+            class="font-cinzel text-[min(3vw,0.875rem)] font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
           >
             20:00H CET
           </time>
         </li>
         <li class="flex items-baseline">
           <span
-            class="font-cinzel text-xs font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
+            class="font-cinzel text-[min(3.2vw,0.875rem)] font-bold tracking-[0.22em] text-theme-cream sm:text-sm sm:tracking-[0.28em]"
           >
             ESTADIO DE LA CARTUJA, SEVILLA
           </span>


### PR DESCRIPTION
## Describe your changes
Se ajustó la altura máxima del logo principal dentro de la sección hero, en pantallas con orientación landscape

### ¿Por qué?

En dispositivos con una relación de aspecto más horizontal que vertical, el logo principal podía ocupar demasiado espacio vertical, provocando que la cuadrícula de **“¡SELECCIONA TU BOXEADOR O BOXEADORA!”** terminara ocultando contenido importante del hero, como:

- El logo del evento
- La fecha
- La hora
- La ubicación

Este cambio permite que todo el contenido de la sección hero sea visible en todo momento, sin alterar otros componentes existentes

## Include a screenshot/video where applicable

| Antes | Después |
|--------|----------|
| <img width="100%" alt="SSAntes" src="https://github.com/user-attachments/assets/f9edaf59-b29b-498c-95d1-5602cf484686" /> | <img width="100%" alt="SSDespues" src="https://github.com/user-attachments/assets/0cad61a7-c1db-4b54-bbd4-137ca08da61d" /> |

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized boxer panel layout and styling for landscape and desktop breakpoints with improved alignment.
  * Enhanced event time and venue typography using viewport-aware sizing for improved readability across screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->