### PR TITLE
style(faq): change horizontal padding for faq

### DIFF
--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -49,7 +49,7 @@ const { faqs } = Astro.props
               itemtype="https://schema.org/Question"
               open={index === 0}
             >
-              <summary class="flex min-h-20 cursor-pointer list-none items-center justify-between gap-5 px-1 py-5 outline-none marker:hidden focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight sm:min-h-24 sm:px-4 sm:py-6 [&::-webkit-details-marker]:hidden">
+              <summary class="flex min-h-20 cursor-pointer list-none items-center justify-between gap-5 px-2.5 py-5 outline-none marker:hidden focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight sm:min-h-24 sm:px-4 sm:py-6 [&::-webkit-details-marker]:hidden">
                 <h3
                   itemprop="name"
                   class="font-cinzel text-xl leading-tight font-bold tracking-[0.02em] text-balance text-theme-cream transition duration-300 group-open:text-theme-gold sm:text-2xl"
@@ -66,7 +66,7 @@ const { faqs } = Astro.props
               </summary>
 
               <div
-                class="px-1 pb-6 pr-14 sm:px-4 sm:pr-20"
+                class="px-2.5 pb-6 pr-14 sm:px-4 sm:pr-20"
                 itemprop="acceptedAnswer"
                 itemscope
                 itemtype="https://schema.org/Answer"


### PR DESCRIPTION
Fix FAQ section content being too close to screen edges on mobile by increasing horizontal padding.

Before:

<img width="356" height="386" alt="faq-padding-before" src="https://github.com/user-attachments/assets/2325af20-d0f5-4b65-a6a3-75a73c309496" />

After:

<img width="354" height="428" alt="faq-padding-after" src="https://github.com/user-attachments/assets/39a98998-4734-4049-9d3d-a15c37f49d90" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved padding and spacing in the FAQ section for better visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->