### PR TITLE
fix(podcast): show pointer cursor on episode tiles

### DIFF
--- a/src/sections/Podcast.astro
+++ b/src/sections/Podcast.astro
@@ -204,7 +204,7 @@ function formatRelative(date: Date) {
                       data-video-id={episode.videoId}
                       data-video-title={episode.title}
                       aria-label={`Reproducir episodio: ${episode.title}`}
-                      class="group grid h-full w-full grid-cols-[5rem_1fr] gap-3 bg-theme-midnight/60 p-3 text-left transition duration-300 outline-none hover:bg-theme-navy/55 focus-visible:bg-theme-navy/55 focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-inset sm:grid-cols-[6rem_1fr] sm:p-4 lg:grid-cols-[7.5rem_1fr]"
+                      class="group grid h-full w-full grid-cols-[5rem_1fr] gap-3 bg-theme-midnight/60 p-3 text-left transition duration-300 outline-none hover:bg-theme-navy/55 focus-visible:bg-theme-navy/55 focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-inset sm:grid-cols-[6rem_1fr] sm:p-4 lg:grid-cols-[7.5rem_1fr] cursor-pointer"
                     >
                       <span class="relative block aspect-video overflow-hidden rounded-lg border border-white/10 bg-black/30">
                         <picture class="absolute inset-0 transition duration-500 group-hover:scale-105 group-focus-visible:scale-105">


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.
## Type
<!-- Select exactly one. -->
- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore
## Related Issue
Closes #N/A
## Changes
<!-- List each file changed with a one-line description. -->
- `src/sections/Podcast.astro`: se añadió `cursor-pointer` al `button` de cada episodio en la columna derecha (lista de episodios secundarios) para mejorar la señal visual de que toda la tarjeta es clicable.
- `src/sections/Podcast.astro`: no se modificó la estructura del componente, ni la lógica, ni la accesibilidad existente (`button`, `aria-label`, estados `hover/focus-visible`), solo la affordance visual del cursor.
- `src/sections/Podcast.astro`: se mantuvieron intactas las animaciones y transiciones actuales (thumbnail, iconos, colores hover/focus), limitando el cambio a una sola clase utilitaria.
> - **After:** los episodios de la derecha muestran cursor `pointer` al hover, dejando claro que son elementos 
## Checklist
- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes
## Breaking Changes
<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->
None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved cursor feedback on podcast episode buttons for better user experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1475?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->