### PR TITLE
Enhance: use border class rather than border generated by gap-px

### DIFF
--- a/src/sections/Podcast.astro
+++ b/src/sections/Podcast.astro
@@ -112,7 +112,7 @@ function formatRelative(date: Date) {
         ) : (
           <div
             class:list={[
-              '@container grid gap-px bg-white/10',
+              '@container grid gap-px bg-white/10 overflow-hidden',
               secondaryEpisodes.length > 0
                 ? 'lg:grid-cols-[minmax(0,1.12fr)_minmax(320px,0.88fr)]'
                 : 'lg:grid-cols-1',
@@ -125,7 +125,7 @@ function formatRelative(date: Date) {
                 data-video-id={featuredEpisode.videoId}
                 data-video-title={featuredEpisode.title}
                 aria-label={`Reproducir episodio destacado: ${featuredEpisode.title}`}
-                class="group relative isolate flex aspect-video w-full cursor-pointer self-start overflow-hidden border border-white/10 bg-theme-navy/40 text-left transition duration-500 outline-none hover:border-theme-gold/50 hover:shadow-[0_18px_60px_-20px_rgba(199,168,107,0.55)] focus-visible:border-theme-gold/70 focus-visible:ring-2 focus-visible:ring-theme-gold/60 lg:aspect-auto lg:h-[31.5cqw]"
+                class="group relative isolate flex aspect-video w-full cursor-pointer self-start overflow-hidden outline-white/10 bg-theme-navy/40 text-left transition duration-500 outline-none hover:border-theme-gold/50 hover:shadow-[0_18px_60px_-20px_rgba(199,168,107,0.55)] focus-visible:border-theme-gold/70 focus-visible:ring-2 focus-visible:ring-theme-gold/60 lg:aspect-auto lg:h-[31.4cqw]"
               >
                 <picture class="absolute inset-0 -z-10 scale-105 brightness-90 transition duration-700 ease-out group-hover:scale-110 group-hover:brightness-110 group-focus-visible:scale-110 group-focus-visible:brightness-110">
                   <source srcset={featuredEpisode.thumbnail.avif} type="image/avif" />
@@ -193,7 +193,7 @@ function formatRelative(date: Date) {
 
             {secondaryEpisodes.length > 0 && (
               <ul
-                class="podcast-scroll grid max-h-[34rem] gap-px overflow-y-auto sm:grid-cols-2 lg:max-h-[31.5cqw] lg:grid-cols-1"
+                class="podcast-scroll grid max-h-[34rem] overflow-y-auto sm:grid-cols-2 lg:max-h-[31.4cqw] lg:grid-cols-1"
                 data-podcast-list
               >
                 {secondaryEpisodes.map((episode, index) => (
@@ -204,7 +204,7 @@ function formatRelative(date: Date) {
                       data-video-id={episode.videoId}
                       data-video-title={episode.title}
                       aria-label={`Reproducir episodio: ${episode.title}`}
-                      class="group grid h-full w-full grid-cols-[5rem_1fr] gap-3 bg-theme-midnight/60 p-3 text-left transition duration-300 outline-none hover:bg-theme-navy/55 focus-visible:bg-theme-navy/55 focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-inset sm:grid-cols-[6rem_1fr] sm:p-4 lg:grid-cols-[7.5rem_1fr]"
+                      class={`group grid h-full w-full grid-cols-[5rem_1fr] gap-3 bg-theme-midnight/60 p-3 text-left transition duration-300 outline-none hover:bg-theme-navy/55 focus-visible:bg-theme-navy/55 focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-inset sm:grid-cols-[6rem_1fr] sm:p-4 lg:grid-cols-[7.5rem_1fr] ${index !== secondaryEpisodes.length - 1 && 'border-b border-white/10'}`}
                     >
                       <span class="relative block aspect-video overflow-hidden rounded-lg border border-white/10 bg-black/30">
                         <picture class="absolute inset-0 transition duration-500 group-hover:scale-105 group-focus-visible:scale-105">


### PR DESCRIPTION
**One only change for this PR**

### Type
- [x] refactor

### Changes
* **src/components/Podcast.astro**:
  * Se removió el uso de `gap-px` en el contenedor de la rejilla que provocaba artefactos visuales.
  * Se eliminaron los bordes fijos de los botones y se reemplazaron por bordes inferiores condicionales (`border-b`) basados en el índice del elemento para evitar líneas duplicadas.
  * Ajuste de precisión en la altura del contenedor (`lg:h-[31.4cqw]`) para garantizar una alineación simétrica y limpia.
  * Se solucionó el problema estético de "doble borde" que ocurría al alejar la pantalla (zoom out) debido al redondeo de subpíxeles del navegador.

### Dependencies
* **Added:** None
* **Removed:** None

### Screenshots

| Before | After |
| :---: | :---: |
| <img width="1626" height="527" alt="before_remove_gap_border" src="https://github.com/user-attachments/assets/4420ab34-3389-45ec-9531-4e1ce7c2a08c" /> | <img width="1626" height="527" alt="after_remove_gap_border" src="https://github.com/user-attachments/assets/13ff530e-704b-4897-a6d2-87c16bceb285" /> |
| <img width="450" height="924" alt="before_remove_gap_border_mobile" src="https://github.com/user-attachments/assets/3f5a0826-6075-4e16-95b4-14003c2d2212" /> | <img width="450" height="948" alt="after_remove_gap_border_mobile" src="https://github.com/user-attachments/assets/f1208035-4f81-4576-b891-3c67107c7fce" /> |

### Checklist
- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Podcast section layout and styling for featured and secondary episodes
  * Refined visual spacing, borders, and overflow handling in the episode list display
  * Adjusted responsive sizing for improved large-screen viewing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/midudev/la-velada-web-oficial/pull/1480?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->