### PR TITLE
Link a google maps: Estadio la cartuja

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -162,13 +162,17 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
           <span
             class="font-cinzel text-xs font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
           >
-            <a href="https://maps.app.goo.gl/73mfDNVvhK3Y5Kq66" target="_blank" 
-                class="relative inline-block
+            <a
+              href="https://maps.app.goo.gl/73mfDNVvhK3Y5Kq66"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="relative inline-block
                         after:content-[''] after:absolute after:left-0 after:-bottom-1
                         after:h-[1px] after:w-full after:bg-current
                         after:scale-x-0 after:origin-left
                         after:transition-transform after:duration-300
-                        hover:after:scale-x-100">
+                        hover:after:scale-x-100 focus-visible:after:scale-x-100"
+            >
               ESTADIO DE LA CARTUJA, SEVILLA
             </a>
           </span>

--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -162,7 +162,15 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
           <span
             class="font-cinzel text-xs font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
           >
-            ESTADIO DE LA CARTUJA, SEVILLA
+            <a href="https://maps.app.goo.gl/73mfDNVvhK3Y5Kq66" target="_blank" 
+                class="relative inline-block
+                        after:content-[''] after:absolute after:left-0 after:-bottom-1
+                        after:h-[1px] after:w-full after:bg-current
+                        after:scale-x-0 after:origin-left
+                        after:transition-transform after:duration-300
+                        hover:after:scale-x-100">
+              ESTADIO DE LA CARTUJA, SEVILLA
+            </a>
           </span>
         </li>
       </ul>


### PR DESCRIPTION


## Type

<!-- Select exactly one. -->

- [X] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Changes

- `src\components\BoxerSelector.astro`: Link a google maps al darle click a "ESTADIO DE LA CARTUJA, SEVILLA"

## Dependencies

None

## Screenshots

https://github.com/user-attachments/assets/b83dc83e-1519-4510-b788-5cbebee9e375


## Checklist

- [X] Tested on mobile (<768px)
- [X] Tested on desktop (≥1024px)
- [X] No console errors
- [X] No regressions on affected routes

## Breaking Changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The venue location in the default panel is now a clickable link that opens the spot in Google Maps in a new tab.
  * Link includes improved hover and focus-visible styling (animated underline) for clearer affordance and better accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->