### PR TITLE
feat(boxers): Show recent velada videos on profile

### DIFF
--- a/src/lib/youtube/rss.ts
+++ b/src/lib/youtube/rss.ts
@@ -1,0 +1,78 @@
+import type { VideoFilter, YoutubeVideo } from '@/lib/youtube/types'
+
+const FEED_ENDPOINT = (channelId: string) =>
+  `https://www.youtube.com/feeds/videos.xml?channel_id=${encodeURIComponent(channelId)}`
+
+const ENTRY_RE = /<entry>([\s\S]*?)<\/entry>/g
+const TAG_RE = (tag: string) => new RegExp(`<${tag}[^>]*>([\\s\\S]*?)<\\/${tag}>`)
+const VIDEO_ID_RE = /<yt:videoId>([^<]+)<\/yt:videoId>/
+const CHANNEL_TITLE_RE = /<author>\s*<name>([^<]+)<\/name>/
+const PUBLISHED_RE = /<published>([^<]+)<\/published>/
+const THUMBNAIL_RE = /<media:thumbnail\s+url="([^"]+)"/
+
+const FEED_TIMEOUT_MS = 8000
+
+function decodeXmlEntities(value: string): string {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}
+
+function parseEntry(raw: string, channelTitle: string): YoutubeVideo | null {
+  const idMatch = raw.match(VIDEO_ID_RE)
+  const titleMatch = raw.match(TAG_RE('title'))
+  const publishedMatch = raw.match(PUBLISHED_RE)
+  const thumbnailMatch = raw.match(THUMBNAIL_RE)
+  if (!idMatch || !titleMatch || !publishedMatch) return null
+
+  const id = idMatch[1].trim()
+  const title = decodeXmlEntities(titleMatch[1].trim())
+  const publishedAt = publishedMatch[1].trim()
+  const thumbnail = thumbnailMatch?.[1] ?? `https://i.ytimg.com/vi/${id}/hqdefault.jpg`
+
+  return {
+    id,
+    title,
+    url: `https://www.youtube.com/watch?v=${id}`,
+    thumbnail,
+    publishedAt,
+    channelTitle,
+  }
+}
+
+export async function fetchChannelFeed(channelId: string): Promise<YoutubeVideo[]> {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FEED_TIMEOUT_MS)
+  try {
+    const response = await fetch(FEED_ENDPOINT(channelId), { signal: controller.signal })
+    if (!response.ok) return []
+    const xml = await response.text()
+    const channelTitleMatch = xml.match(CHANNEL_TITLE_RE)
+    const channelTitle = channelTitleMatch ? decodeXmlEntities(channelTitleMatch[1].trim()) : ''
+    const videos: YoutubeVideo[] = []
+    for (const match of xml.matchAll(ENTRY_RE)) {
+      const entry = parseEntry(match[1], channelTitle)
+      if (entry) videos.push(entry)
+    }
+    return videos
+  } catch {
+    return []
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+export function filterVideos(videos: YoutubeVideo[], filter: VideoFilter): YoutubeVideo[] {
+  const sinceMs = Date.now() - filter.sinceDays * 24 * 60 * 60 * 1000
+  return videos
+    .filter((video) => {
+      if (!filter.pattern.test(video.title)) return false
+      const time = new Date(video.publishedAt).getTime()
+      return Number.isFinite(time) && time >= sinceMs
+    })
+    .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime())
+    .slice(0, filter.limit)
+}

--- a/src/lib/youtube/types.ts
+++ b/src/lib/youtube/types.ts
@@ -1,0 +1,14 @@
+export interface YoutubeVideo {
+  id: string
+  title: string
+  url: string
+  thumbnail: string
+  publishedAt: string
+  channelTitle: string
+}
+
+export interface VideoFilter {
+  pattern: RegExp
+  sinceDays: number
+  limit: number
+}

--- a/src/lib/youtube/velada.ts
+++ b/src/lib/youtube/velada.ts
@@ -1,0 +1,16 @@
+import { fetchChannelFeed, filterVideos } from '@/lib/youtube/rss'
+import type { YoutubeVideo } from '@/lib/youtube/types'
+
+const VELADA_PATTERN = /\bvelada\b/i
+const SINCE_DAYS = 90
+const LIMIT = 6
+
+export async function fetchVeladaVideos(channelId: string | undefined): Promise<YoutubeVideo[]> {
+  if (!channelId) return []
+  const all = await fetchChannelFeed(channelId)
+  return filterVideos(all, {
+    pattern: VELADA_PATTERN,
+    sinceDays: SINCE_DAYS,
+    limit: LIMIT,
+  })
+}

--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -17,6 +17,7 @@ import {
   getBoxerSelectImages,
 } from '@/consts/boxers'
 import Layout from '@/layouts/Layout.astro'
+import { fetchVeladaVideos } from '@/lib/youtube/velada'
 import Header from '@/sections/Header.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
@@ -49,6 +50,8 @@ const battle = battles.find((b) => b.boxerIds.includes(boxer.id))
 const opponentId = battle?.boxerIds.find((id) => id !== boxer.id)
 const opponent = opponentId ? BOXERS_BY_ID[opponentId] : null
 const opponentSelectImages = opponent ? getBoxerSelectImages(opponent) : null
+
+const veladaVideos = await fetchVeladaVideos(boxer.youtubeChannelId)
 
 const SITE_URL = 'https://www.infolavelada.com'
 const canonical = `${SITE_URL}/boxeadores/${boxer.id}`
@@ -323,6 +326,55 @@ const breadcrumbJsonLd = {
       </div>
     </div>
   </section>
+
+  {veladaVideos.length > 0 && (
+    <section
+      class="boxer-videos relative isolate w-full bg-theme-midnight px-4 py-16 text-theme-cream sm:px-6 sm:py-20"
+      aria-labelledby="boxer-videos-title"
+    >
+      <div class="boxer-videos-inner mx-auto w-full max-w-6xl">
+        <header class="boxer-videos-header">
+          <p class="boxer-videos-eyebrow font-cinzel" aria-hidden="true">
+            Vídeos recientes
+          </p>
+          <h2 id="boxer-videos-title" class="boxer-videos-title font-cinzel">
+            {boxer.name} en La Velada
+          </h2>
+        </header>
+
+        <ul class="boxer-videos-grid">
+          {veladaVideos.map((video) => (
+            <li class="boxer-videos-card">
+              <a
+                href={video.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                class="boxer-videos-link"
+                aria-label={`Ver "${video.title}" en YouTube`}
+              >
+                <span class="boxer-videos-thumb">
+                  <img
+                    src={video.thumbnail}
+                    alt=""
+                    role="presentation"
+                    loading="lazy"
+                    decoding="async"
+                    width="320"
+                    height="180"
+                  />
+                  <span class="boxer-videos-play" aria-hidden="true">▶</span>
+                </span>
+                <span class="boxer-videos-meta">
+                  <span class="boxer-videos-channel">{video.channelTitle}</span>
+                  <span class="boxer-videos-vtitle">{video.title}</span>
+                </span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  )}
 
   <Sponsors />
   <Footer />
@@ -630,6 +682,153 @@ const breadcrumbJsonLd = {
     .boxer-detail-versus-photo,
     .boxer-detail-versus-arrow {
       animation: none !important;
+      transition: none !important;
+    }
+  }
+
+  /* ---------- Vídeos recientes de La Velada ---------- */
+  .boxer-videos-header {
+    text-align: center;
+    margin-bottom: 2.5rem;
+  }
+
+  .boxer-videos-eyebrow {
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.45em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-theme-gold) 85%, transparent);
+  }
+
+  .boxer-videos-title {
+    margin-top: 0.6rem;
+    font-size: 1.5rem;
+    font-weight: 900;
+    line-height: 1.1;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    color: var(--color-theme-cream);
+  }
+
+  @media (min-width: 640px) {
+    .boxer-videos-title {
+      font-size: 1.875rem;
+    }
+  }
+
+  .boxer-videos-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  @media (min-width: 640px) {
+    .boxer-videos-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .boxer-videos-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  .boxer-videos-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+    height: 100%;
+    color: inherit;
+    text-decoration: none;
+    transition: transform 250ms ease;
+  }
+
+  .boxer-videos-link:hover,
+  .boxer-videos-link:focus-visible {
+    outline: none;
+    transform: translateY(-2px);
+  }
+
+  .boxer-videos-thumb {
+    position: relative;
+    display: block;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-radius: 0.5rem;
+    background: color-mix(in srgb, var(--color-theme-midnight) 70%, black);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 25%, transparent);
+  }
+
+  .boxer-videos-thumb img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    transition: transform 400ms ease;
+  }
+
+  .boxer-videos-link:hover .boxer-videos-thumb img,
+  .boxer-videos-link:focus-visible .boxer-videos-thumb img {
+    transform: scale(1.04);
+  }
+
+  .boxer-videos-play {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    border-radius: 9999px;
+    background: color-mix(in srgb, var(--color-theme-midnight) 70%, black);
+    color: var(--color-theme-gold);
+    font-size: 0.95rem;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.55);
+    transition:
+      background-color 250ms ease,
+      color 250ms ease;
+  }
+
+  .boxer-videos-link:hover .boxer-videos-play,
+  .boxer-videos-link:focus-visible .boxer-videos-play {
+    background: var(--color-theme-gold);
+    color: var(--color-theme-midnight);
+  }
+
+  .boxer-videos-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .boxer-videos-channel {
+    font-family: 'Cinzel', var(--font-fallback);
+    font-size: 0.55rem;
+    font-weight: 700;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-theme-gold) 80%, transparent);
+  }
+
+  .boxer-videos-vtitle {
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1.4;
+    color: color-mix(in srgb, var(--color-theme-cream) 92%, transparent);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .boxer-videos-link,
+    .boxer-videos-thumb img,
+    .boxer-videos-play {
       transition: none !important;
     }
   }


### PR DESCRIPTION
Depende de #1489.

Añade sección "Vídeos recientes" en `boxeadores/[id].astro` con los últimos
vídeos del canal que mencionan "La Velada".

En `src/pages/boxeadores/[id].astro`:
- `const veladaVideos = await fetchVeladaVideos(boxer.youtubeChannelId)` (build-time)
- Nueva `<section class="boxer-videos">` después del hero, antes de Sponsors
- Grid responsive: 1 col móvil, 2 tablet, 3 desktop
- CSS scoped con tokens del sistema

Se omite si no hay `youtubeChannelId`, si falla el RSS o si no hay vídeos.
`prefers-reduced-motion` respetado. BoxerWinsBadge, BoxerSocials, CountryFlag
sin cambios.