### PR TITLE
feat(combates): página con la cartelera de todos los combates

### DIFF
--- a/src/components/CombatCard.astro
+++ b/src/components/CombatCard.astro
@@ -3,114 +3,114 @@ import CountryFlag from '@/components/CountryFlag.astro'
 import type { BoxerImageVariants } from '@/consts/boxers'
 
 interface CardBoxer {
-  id: string
-  name: string
-  country: string
-  countryName: string
-  heroImages: BoxerImageVariants
+    id: string
+    name: string
+    country: string
+    countryName: string
+    heroImages: BoxerImageVariants
 }
 
 interface Props {
-  number: number
-  url: string // /combate/[id] → el cara a cara
-  featured?: boolean
-  badge?: string
-  a: CardBoxer
-  b: CardBoxer
+    number: number
+    url: string // /combate/[id] → el cara a cara
+    featured?: boolean
+    badge?: string
+    a: CardBoxer
+    b: CardBoxer
 }
 
 const { number, url, featured = false, badge, a, b } = Astro.props
 const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
-  { ...a, side: 'a' },
-  { ...b, side: 'b' },
+    { ...a, side: 'a' },
+    { ...b, side: 'b' },
 ]
 ---
 
 <article class:list={['combat', { 'is-featured': featured }]}>
-  {badge && <span class="combat-badge font-cinzel">{badge}</span>}
+    {badge && <span class="combat-badge font-cinzel">{badge}</span>}
 
-  <span aria-hidden="true" class="combat-corner tl"></span>
-  <span aria-hidden="true" class="combat-corner tr"></span>
-  <span aria-hidden="true" class="combat-corner bl"></span>
-  <span aria-hidden="true" class="combat-corner br"></span>
+    <span aria-hidden="true" class="combat-corner tl"></span>
+    <span aria-hidden="true" class="combat-corner tr"></span>
+    <span aria-hidden="true" class="combat-corner bl"></span>
+    <span aria-hidden="true" class="combat-corner br"></span>
 
-  <div class="combat-stage">
+    <div class="combat-stage">
     {
-      boxers.map((boxer) => (
+        boxers.map((boxer) => (
         <a
-          class:list={['boxer', boxer.side]}
-          href={`/boxeadores/${boxer.id}`}
-          aria-label={`Ver perfil de ${boxer.name}`}
+            class:list={['boxer', boxer.side]}
+            href={`/boxeadores/${boxer.id}`}
+            aria-label={`Ver perfil de ${boxer.name}`}
         >
-          <span aria-hidden="true" class="boxer-spot" />
-          <picture>
+            <span aria-hidden="true" class="boxer-spot" />
+            <picture>
             <source type="image/avif" srcset={boxer.heroImages.avif} />
             <source type="image/webp" srcset={boxer.heroImages.webp} />
             <img
-              src={boxer.heroImages.webp}
-              alt={`Recorte fotográfico de ${boxer.name}`}
-              loading="lazy"
-              decoding="async"
-              class="boxer-img"
+                src={boxer.heroImages.webp}
+                alt={`Recorte fotográfico de ${boxer.name}`}
+                loading="lazy"
+                decoding="async"
+                class="boxer-img"
             />
-          </picture>
-          <span aria-hidden="true" class="boxer-veil" />
-          <div class="boxer-caption">
+            </picture>
+            <span aria-hidden="true" class="boxer-veil" />
+            <div class="boxer-caption">
             <h3 class="boxer-name font-cinzel">{boxer.name}</h3>
             <p class="boxer-country font-cinzel">
-              <CountryFlag country={boxer.country} size={14} decorative class="boxer-flag" />
-              <span>{boxer.countryName}</span>
+                <CountryFlag country={boxer.country} size={14} decorative class="boxer-flag" />
+                <span>{boxer.countryName}</span>
             </p>
-          </div>
+            </div>
         </a>
-      ))
+        ))
     }
 
     <a class="vslink" href={url} aria-label={`Ver el cara a cara: ${a.name} contra ${b.name}`}>
-      <span class="vsmedal font-cinzel"><b>VS</b></span>
+        <span class="vsmedal font-cinzel"><b>VS</b></span>
     </a>
-  </div>
+    </div>
 
-  <a class="combat-foot" href={url} aria-label={`Ver combate: ${a.name} contra ${b.name}`}>
+    <a class="combat-foot" href={url} aria-label={`Ver combate: ${a.name} contra ${b.name}`}>
     <span class="combat-no font-cinzel">Combate {String(number).padStart(2, '0')}</span>
     <span class="combat-cta font-cinzel">Ver cara a cara <span aria-hidden="true">&rarr;</span></span>
-  </a>
+    </a>
 </article>
 
 <style>
-  .combat {
+.combat {
     position: relative;
     display: block;
     overflow: hidden;
     border-radius: 6px;
     background: linear-gradient(180deg, #0c1330 0%, #060a1d 100%);
     box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 24%, transparent),
-      0 16px 40px rgba(0, 0, 0, 0.45);
+    0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 24%, transparent),
+    0 16px 40px rgba(0, 0, 0, 0.45);
     transition: transform 400ms ease, box-shadow 400ms ease;
-  }
+}
 
-  .combat:hover {
+.combat:hover {
     transform: translateY(-4px);
     box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 45%, transparent),
-      0 28px 60px rgba(0, 0, 0, 0.6);
-  }
+    0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 45%, transparent),
+    0 28px 60px rgba(0, 0, 0, 0.6);
+}
 
   /* glow dorado fuerte cuando el cursor está sobre el link del COMBATE */
-  .combat:has(.vslink:hover),
-  .combat:has(.combat-foot:hover) {
+.combat:has(.vslink:hover),
+.combat:has(.combat-foot:hover) {
     box-shadow:
-      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 75%, transparent),
-      0 28px 60px rgba(0, 0, 0, 0.6),
-      0 0 36px color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
-  }
-  .combat:has(.vslink:hover) .boxer-img,
-  .combat:has(.combat-foot:hover) .boxer-img {
+    0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 75%, transparent),
+    0 28px 60px rgba(0, 0, 0, 0.6),
+    0 0 36px color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
+}
+.combat:has(.vslink:hover) .boxer-img,
+.combat:has(.combat-foot:hover) .boxer-img {
     filter: saturate(1.08) brightness(1.04);
-  }
+}
 
-  .combat-badge {
+.combat-badge {
     position: absolute;
     top: 0;
     left: 50%;
@@ -125,9 +125,9 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     background: linear-gradient(180deg, color-mix(in srgb, var(--color-theme-gold) 18%, transparent), transparent);
     border-bottom: 1px solid var(--color-theme-gold);
     text-shadow: 0 1px 8px rgba(0, 0, 0, 0.6);
-  }
+}
 
-  .combat-corner {
+.combat-corner {
     position: absolute;
     width: 14px;
     height: 14px;
@@ -136,52 +136,52 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     opacity: 0.65;
     transition: opacity 400ms ease, width 400ms ease, height 400ms ease;
     pointer-events: none;
-  }
-  .combat:hover .combat-corner { opacity: 1; width: 20px; height: 20px; }
-  .combat-corner.tl { top: 10px; left: 10px; border-right: 0; border-bottom: 0; }
-  .combat-corner.tr { top: 10px; right: 10px; border-left: 0; border-bottom: 0; }
-  .combat-corner.bl { bottom: 10px; left: 10px; border-right: 0; border-top: 0; }
-  .combat-corner.br { bottom: 10px; right: 10px; border-left: 0; border-top: 0; }
+}
+.combat:hover .combat-corner { opacity: 1; width: 20px; height: 20px; }
+.combat-corner.tl { top: 10px; left: 10px; border-right: 0; border-bottom: 0; }
+.combat-corner.tr { top: 10px; right: 10px; border-left: 0; border-bottom: 0; }
+.combat-corner.bl { bottom: 10px; left: 10px; border-right: 0; border-top: 0; }
+.combat-corner.br { bottom: 10px; right: 10px; border-left: 0; border-top: 0; }
 
-  .combat-stage {
+.combat-stage {
     position: relative;
     display: grid;
     grid-template-columns: 1fr 1fr;
-  }
+}
 
   /* ── cada boxeador es un link a su perfil ── */
-  .boxer {
+.boxer {
     position: relative;
     display: block;
     aspect-ratio: 3 / 4;
     overflow: hidden;
     text-decoration: none;
     transition: opacity 350ms ease, filter 350ms ease;
-  }
-  .is-featured .boxer { aspect-ratio: 4 / 5; }
-  .boxer:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
+}
+.is-featured .boxer { aspect-ratio: 4 / 5; }
+.boxer:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
 
   /* al señalar un boxeador, el OTRO se atenúa (efecto foco) */
-  .combat-stage:has(.boxer:hover) .boxer:not(:hover) {
+.combat-stage:has(.boxer:hover) .boxer:not(:hover) {
     opacity: 0.45;
     filter: saturate(0.5) brightness(0.7);
-  }
+}
 
-  .boxer-spot {
+.boxer-spot {
     position: absolute;
     inset: 0;
     z-index: 1;
     background: radial-gradient(70% 60% at 50% 18%, color-mix(in srgb, var(--color-theme-gold) 26%, transparent), transparent 62%);
     opacity: 0.5;
     transition: opacity 500ms ease;
-  }
-  .boxer.b .boxer-spot {
+}
+.boxer.b .boxer-spot {
     background: radial-gradient(70% 60% at 50% 18%, color-mix(in srgb, var(--color-velada-navy) 80%, var(--color-theme-cream)), transparent 62%);
     opacity: 0.4;
-  }
-  .boxer:hover .boxer-spot { opacity: 0.95; }
+}
+.boxer:hover .boxer-spot { opacity: 0.95; }
 
-  .boxer-img {
+.boxer-img {
     position: absolute;
     inset: 0;
     width: 100%;
@@ -191,29 +191,29 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     z-index: 2;
     filter: saturate(0.92) brightness(0.92);
     transition: scale 600ms ease, filter 500ms ease;
-  }
+}
   .boxer.b .boxer-img { transform: scaleX(-1); } /* que "miren" al centro */
-  .boxer:hover .boxer-img { scale: 1.06; filter: saturate(1.1) brightness(1.05); }
+.boxer:hover .boxer-img { scale: 1.06; filter: saturate(1.1) brightness(1.05); }
 
-  .boxer-veil {
+.boxer-veil {
     position: absolute;
     inset: 0;
     z-index: 3;
     background: linear-gradient(180deg, transparent 42%, rgba(5, 8, 15, 0.55) 72%, rgba(5, 8, 15, 0.95) 100%);
-  }
+}
 
-  .boxer-caption {
+.boxer-caption {
     position: absolute;
     inset-inline: 0;
     bottom: 0;
     z-index: 4;
     padding: 0.6rem 0.7rem 1rem;
     text-align: center;
-  }
-  .boxer.a .boxer-caption { padding-right: 1.7rem; }
-  .boxer.b .boxer-caption { padding-left: 1.7rem; }
+}
+.boxer.a .boxer-caption { padding-right: 1.7rem; }
+.boxer.b .boxer-caption { padding-left: 1.7rem; }
 
-  .boxer-name {
+.boxer-name {
     font-size: clamp(0.8rem, 0.6rem + 0.9vw, 1.25rem);
     font-weight: 700;
     letter-spacing: 0.04em;
@@ -221,8 +221,8 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     text-transform: uppercase;
     color: var(--color-theme-cream);
     text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9), 0 2px 12px rgba(0, 0, 0, 0.7);
-  }
-  .boxer-country {
+}
+.boxer-country {
     display: inline-flex;
     align-items: center;
     gap: 0.4rem;
@@ -233,11 +233,11 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     text-transform: uppercase;
     color: color-mix(in srgb, var(--color-theme-cream) 78%, transparent);
     text-shadow: 0 1px 3px rgba(0, 0, 0, 0.85);
-  }
-  :global(.boxer-flag) { width: 14px; height: 14px; flex-shrink: 0; }
+}
+:global(.boxer-flag) { width: 14px; height: 14px; flex-shrink: 0; }
 
   /* ── link del COMBATE: medallón VS centrado entre los dos boxeadores ── */
-  .vslink {
+.vslink {
     position: absolute;
     left: 50%;
     top: 50%;
@@ -261,24 +261,24 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     transition: box-shadow 300ms ease, background 300ms ease;
   }
   .is-featured .vsmedal { width: 56px; height: 56px; }
-  .vsmedal b {
+.vsmedal b {
     transform: rotate(-45deg);
     font-weight: 900;
     font-size: 0.9rem;
     color: color-mix(in srgb, var(--color-theme-gold) 92%, white);
-  }
+}
   .is-featured .vsmedal b { font-size: 1.05rem; }
-  .vslink:hover .vsmedal {
+.vslink:hover .vsmedal {
     background: radial-gradient(circle, color-mix(in srgb, var(--color-theme-gold) 40%, transparent), rgba(5, 8, 15, 0.85));
     animation: vspulse 1.3s ease infinite;
-  }
-  @keyframes vspulse {
+}
+@keyframes vspulse {
     0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-theme-gold) 45%, transparent); }
     50% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-theme-gold) 0%, transparent); }
-  }
+}
 
   /* ── barra inferior: también link al combate ── */
-  .combat-foot {
+.combat-foot {
     position: relative;
     z-index: 4;
     display: flex;
@@ -290,32 +290,32 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     background: rgba(5, 8, 15, 0.55);
     text-decoration: none;
     transition: background 300ms ease;
-  }
-  .combat-foot:hover { background: rgba(5, 8, 15, 0.75); }
-  .combat-foot:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
-  .combat-no {
+}
+.combat-foot:hover { background: rgba(5, 8, 15, 0.75); }
+.combat-foot:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
+.combat-no {
     font-size: 0.58rem;
     font-weight: 700;
     letter-spacing: 0.26em;
     text-transform: uppercase;
     color: var(--color-theme-gold);
-  }
-  .combat-cta {
+}
+.combat-cta {
     font-size: 0.55rem;
     font-weight: 700;
     letter-spacing: 0.22em;
     text-transform: uppercase;
     color: color-mix(in srgb, var(--color-theme-cream) 72%, transparent);
     transition: color 250ms ease;
-  }
-  .combat-foot:hover .combat-cta { color: color-mix(in srgb, var(--color-theme-gold) 92%, white); }
+}
+.combat-foot:hover .combat-cta { color: color-mix(in srgb, var(--color-theme-gold) 92%, white); }
 
-  @media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
     .combat, .boxer, .boxer-img, .boxer-spot, .combat-corner, .combat-cta, .combat-foot, .vsmedal {
-      transition: none;
+    transition: none;
     }
     .combat:hover { transform: none; }
     .combat:hover .boxer-img, .boxer:hover .boxer-img { scale: 1; }
     .vslink:hover .vsmedal { animation: none; }
-  }
+}
 </style>

--- a/src/components/CombatCard.astro
+++ b/src/components/CombatCard.astro
@@ -1,0 +1,321 @@
+---
+import CountryFlag from '@/components/CountryFlag.astro'
+import type { BoxerImageVariants } from '@/consts/boxers'
+
+interface CardBoxer {
+  id: string
+  name: string
+  country: string
+  countryName: string
+  heroImages: BoxerImageVariants
+}
+
+interface Props {
+  number: number
+  url: string // /combate/[id] → el cara a cara
+  featured?: boolean
+  badge?: string
+  a: CardBoxer
+  b: CardBoxer
+}
+
+const { number, url, featured = false, badge, a, b } = Astro.props
+const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
+  { ...a, side: 'a' },
+  { ...b, side: 'b' },
+]
+---
+
+<article class:list={['combat', { 'is-featured': featured }]}>
+  {badge && <span class="combat-badge font-cinzel">{badge}</span>}
+
+  <span aria-hidden="true" class="combat-corner tl"></span>
+  <span aria-hidden="true" class="combat-corner tr"></span>
+  <span aria-hidden="true" class="combat-corner bl"></span>
+  <span aria-hidden="true" class="combat-corner br"></span>
+
+  <div class="combat-stage">
+    {
+      boxers.map((boxer) => (
+        <a
+          class:list={['boxer', boxer.side]}
+          href={`/boxeadores/${boxer.id}`}
+          aria-label={`Ver perfil de ${boxer.name}`}
+        >
+          <span aria-hidden="true" class="boxer-spot" />
+          <picture>
+            <source type="image/avif" srcset={boxer.heroImages.avif} />
+            <source type="image/webp" srcset={boxer.heroImages.webp} />
+            <img
+              src={boxer.heroImages.webp}
+              alt={`Recorte fotográfico de ${boxer.name}`}
+              loading="lazy"
+              decoding="async"
+              class="boxer-img"
+            />
+          </picture>
+          <span aria-hidden="true" class="boxer-veil" />
+          <div class="boxer-caption">
+            <h3 class="boxer-name font-cinzel">{boxer.name}</h3>
+            <p class="boxer-country font-cinzel">
+              <CountryFlag country={boxer.country} size={14} decorative class="boxer-flag" />
+              <span>{boxer.countryName}</span>
+            </p>
+          </div>
+        </a>
+      ))
+    }
+
+    <a class="vslink" href={url} aria-label={`Ver el cara a cara: ${a.name} contra ${b.name}`}>
+      <span class="vsmedal font-cinzel"><b>VS</b></span>
+    </a>
+  </div>
+
+  <a class="combat-foot" href={url} aria-label={`Ver combate: ${a.name} contra ${b.name}`}>
+    <span class="combat-no font-cinzel">Combate {String(number).padStart(2, '0')}</span>
+    <span class="combat-cta font-cinzel">Ver cara a cara <span aria-hidden="true">&rarr;</span></span>
+  </a>
+</article>
+
+<style>
+  .combat {
+    position: relative;
+    display: block;
+    overflow: hidden;
+    border-radius: 6px;
+    background: linear-gradient(180deg, #0c1330 0%, #060a1d 100%);
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 24%, transparent),
+      0 16px 40px rgba(0, 0, 0, 0.45);
+    transition: transform 400ms ease, box-shadow 400ms ease;
+  }
+
+  .combat:hover {
+    transform: translateY(-4px);
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 45%, transparent),
+      0 28px 60px rgba(0, 0, 0, 0.6);
+  }
+
+  /* glow dorado fuerte cuando el cursor está sobre el link del COMBATE */
+  .combat:has(.vslink:hover),
+  .combat:has(.combat-foot:hover) {
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 75%, transparent),
+      0 28px 60px rgba(0, 0, 0, 0.6),
+      0 0 36px color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
+  }
+  .combat:has(.vslink:hover) .boxer-img,
+  .combat:has(.combat-foot:hover) .boxer-img {
+    filter: saturate(1.08) brightness(1.04);
+  }
+
+  .combat-badge {
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 7;
+    padding: 0.4rem 1.4rem;
+    font-size: 0.55rem;
+    font-weight: 700;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-theme-gold) 92%, white);
+    background: linear-gradient(180deg, color-mix(in srgb, var(--color-theme-gold) 18%, transparent), transparent);
+    border-bottom: 1px solid var(--color-theme-gold);
+    text-shadow: 0 1px 8px rgba(0, 0, 0, 0.6);
+  }
+
+  .combat-corner {
+    position: absolute;
+    width: 14px;
+    height: 14px;
+    z-index: 6;
+    border: 1.5px solid color-mix(in srgb, var(--color-theme-gold) 70%, transparent);
+    opacity: 0.65;
+    transition: opacity 400ms ease, width 400ms ease, height 400ms ease;
+    pointer-events: none;
+  }
+  .combat:hover .combat-corner { opacity: 1; width: 20px; height: 20px; }
+  .combat-corner.tl { top: 10px; left: 10px; border-right: 0; border-bottom: 0; }
+  .combat-corner.tr { top: 10px; right: 10px; border-left: 0; border-bottom: 0; }
+  .combat-corner.bl { bottom: 10px; left: 10px; border-right: 0; border-top: 0; }
+  .combat-corner.br { bottom: 10px; right: 10px; border-left: 0; border-top: 0; }
+
+  .combat-stage {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+  }
+
+  /* ── cada boxeador es un link a su perfil ── */
+  .boxer {
+    position: relative;
+    display: block;
+    aspect-ratio: 3 / 4;
+    overflow: hidden;
+    text-decoration: none;
+    transition: opacity 350ms ease, filter 350ms ease;
+  }
+  .is-featured .boxer { aspect-ratio: 4 / 5; }
+  .boxer:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
+
+  /* al señalar un boxeador, el OTRO se atenúa (efecto foco) */
+  .combat-stage:has(.boxer:hover) .boxer:not(:hover) {
+    opacity: 0.45;
+    filter: saturate(0.5) brightness(0.7);
+  }
+
+  .boxer-spot {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    background: radial-gradient(70% 60% at 50% 18%, color-mix(in srgb, var(--color-theme-gold) 26%, transparent), transparent 62%);
+    opacity: 0.5;
+    transition: opacity 500ms ease;
+  }
+  .boxer.b .boxer-spot {
+    background: radial-gradient(70% 60% at 50% 18%, color-mix(in srgb, var(--color-velada-navy) 80%, var(--color-theme-cream)), transparent 62%);
+    opacity: 0.4;
+  }
+  .boxer:hover .boxer-spot { opacity: 0.95; }
+
+  .boxer-img {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: top center;
+    z-index: 2;
+    filter: saturate(0.92) brightness(0.92);
+    transition: scale 600ms ease, filter 500ms ease;
+  }
+  .boxer.b .boxer-img { transform: scaleX(-1); } /* que "miren" al centro */
+  .boxer:hover .boxer-img { scale: 1.06; filter: saturate(1.1) brightness(1.05); }
+
+  .boxer-veil {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    background: linear-gradient(180deg, transparent 42%, rgba(5, 8, 15, 0.55) 72%, rgba(5, 8, 15, 0.95) 100%);
+  }
+
+  .boxer-caption {
+    position: absolute;
+    inset-inline: 0;
+    bottom: 0;
+    z-index: 4;
+    padding: 0.6rem 0.7rem 1rem;
+    text-align: center;
+  }
+  .boxer.a .boxer-caption { padding-right: 1.7rem; }
+  .boxer.b .boxer-caption { padding-left: 1.7rem; }
+
+  .boxer-name {
+    font-size: clamp(0.8rem, 0.6rem + 0.9vw, 1.25rem);
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    line-height: 1.05;
+    text-transform: uppercase;
+    color: var(--color-theme-cream);
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.9), 0 2px 12px rgba(0, 0, 0, 0.7);
+  }
+  .boxer-country {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    margin-top: 0.4rem;
+    font-size: 0.55rem;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-theme-cream) 78%, transparent);
+    text-shadow: 0 1px 3px rgba(0, 0, 0, 0.85);
+  }
+  :global(.boxer-flag) { width: 14px; height: 14px; flex-shrink: 0; }
+
+  /* ── link del COMBATE: medallón VS centrado entre los dos boxeadores ── */
+  .vslink {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    z-index: 5;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-decoration: none;
+  }
+  .vslink:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: 4px; }
+  .vsmedal {
+    width: 46px;
+    height: 46px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transform: rotate(45deg);
+    border: 1px solid var(--color-theme-gold);
+    background: radial-gradient(circle, color-mix(in srgb, var(--color-theme-gold) 22%, transparent), rgba(5, 8, 15, 0.85));
+    transition: box-shadow 300ms ease, background 300ms ease;
+  }
+  .is-featured .vsmedal { width: 56px; height: 56px; }
+  .vsmedal b {
+    transform: rotate(-45deg);
+    font-weight: 900;
+    font-size: 0.9rem;
+    color: color-mix(in srgb, var(--color-theme-gold) 92%, white);
+  }
+  .is-featured .vsmedal b { font-size: 1.05rem; }
+  .vslink:hover .vsmedal {
+    background: radial-gradient(circle, color-mix(in srgb, var(--color-theme-gold) 40%, transparent), rgba(5, 8, 15, 0.85));
+    animation: vspulse 1.3s ease infinite;
+  }
+  @keyframes vspulse {
+    0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-theme-gold) 45%, transparent); }
+    50% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-theme-gold) 0%, transparent); }
+  }
+
+  /* ── barra inferior: también link al combate ── */
+  .combat-foot {
+    position: relative;
+    z-index: 4;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.85rem 1.1rem;
+    border-top: 1px solid color-mix(in srgb, var(--color-theme-gold) 20%, transparent);
+    background: rgba(5, 8, 15, 0.55);
+    text-decoration: none;
+    transition: background 300ms ease;
+  }
+  .combat-foot:hover { background: rgba(5, 8, 15, 0.75); }
+  .combat-foot:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
+  .combat-no {
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: var(--color-theme-gold);
+  }
+  .combat-cta {
+    font-size: 0.55rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-theme-cream) 72%, transparent);
+    transition: color 250ms ease;
+  }
+  .combat-foot:hover .combat-cta { color: color-mix(in srgb, var(--color-theme-gold) 92%, white); }
+
+  @media (prefers-reduced-motion: reduce) {
+    .combat, .boxer, .boxer-img, .boxer-spot, .combat-corner, .combat-cta, .combat-foot, .vsmedal {
+      transition: none;
+    }
+    .combat:hover { transform: none; }
+    .combat:hover .boxer-img, .boxer:hover .boxer-img { scale: 1; }
+    .vslink:hover .vsmedal { animation: none; }
+  }
+</style>

--- a/src/components/CombatCard.astro
+++ b/src/components/CombatCard.astro
@@ -12,7 +12,7 @@ interface CardBoxer {
 
 interface Props {
     number: number
-    url: string // /combate/[id] → el cara a cara
+    url: string // /combate/[id] → destino real cuando la landing esté lista
     featured?: boolean
     badge?: string
     a: CardBoxer
@@ -20,6 +20,13 @@ interface Props {
 }
 
 const { number, url, featured = false, badge, a, b } = Astro.props
+
+// TEMPORAL: la landing individual de cada combate (/combate/[id]) todavía
+// no está hecha, así que el enlace del combate apunta al 404 a propósito.
+// Cuando esas vistas estén listas, cambiá `combatHref` por `url`.
+const combatHref = '/404'
+void url // (se conserva en props para reactivar el enlace real más adelante)
+
 const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     { ...a, side: 'a' },
     { ...b, side: 'b' },
@@ -66,12 +73,13 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
         ))
     }
 
-    <a class="vslink" href={url} aria-label={`Ver el cara a cara: ${a.name} contra ${b.name}`}>
+    {/* Enlace del combate → 404 temporal (ver nota arriba: cambiar combatHref por url). */}
+    <a class="vslink" href={combatHref} aria-label={`Combate: ${a.name} contra ${b.name} (próximamente)`}>
         <span class="vsmedal font-cinzel"><b>VS</b></span>
     </a>
     </div>
 
-    <a class="combat-foot" href={url} aria-label={`Ver combate: ${a.name} contra ${b.name}`}>
+    <a class="combat-foot" href={combatHref} aria-label={`Combate: ${a.name} contra ${b.name} (próximamente)`}>
     <span class="combat-no font-cinzel">Combate {String(number).padStart(2, '0')}</span>
     <span class="combat-cta font-cinzel">Ver cara a cara <span aria-hidden="true">&rarr;</span></span>
     </a>
@@ -85,25 +93,23 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     border-radius: 6px;
     background: linear-gradient(180deg, #0c1330 0%, #060a1d 100%);
     box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 24%, transparent),
-    0 16px 40px rgba(0, 0, 0, 0.45);
+        0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 24%, transparent),
+        0 16px 40px rgba(0, 0, 0, 0.45);
     transition: transform 400ms ease, box-shadow 400ms ease;
 }
-
 .combat:hover {
     transform: translateY(-4px);
     box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 45%, transparent),
-    0 28px 60px rgba(0, 0, 0, 0.6);
+        0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 45%, transparent),
+        0 28px 60px rgba(0, 0, 0, 0.6);
 }
 
-  /* glow dorado fuerte cuando el cursor está sobre el link del COMBATE */
 .combat:has(.vslink:hover),
 .combat:has(.combat-foot:hover) {
     box-shadow:
-    0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 75%, transparent),
-    0 28px 60px rgba(0, 0, 0, 0.6),
-    0 0 36px color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
+        0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 75%, transparent),
+        0 28px 60px rgba(0, 0, 0, 0.6),
+        0 0 36px color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
 }
 .combat:has(.vslink:hover) .boxer-img,
 .combat:has(.combat-foot:hover) .boxer-img {
@@ -149,7 +155,6 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     grid-template-columns: 1fr 1fr;
 }
 
-  /* ── cada boxeador es un link a su perfil ── */
 .boxer {
     position: relative;
     display: block;
@@ -161,7 +166,6 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
 .is-featured .boxer { aspect-ratio: 4 / 5; }
 .boxer:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: -3px; }
 
-  /* al señalar un boxeador, el OTRO se atenúa (efecto foco) */
 .combat-stage:has(.boxer:hover) .boxer:not(:hover) {
     opacity: 0.45;
     filter: saturate(0.5) brightness(0.7);
@@ -192,7 +196,7 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     filter: saturate(0.92) brightness(0.92);
     transition: scale 600ms ease, filter 500ms ease;
 }
-  .boxer.b .boxer-img { transform: scaleX(-1); } /* que "miren" al centro */
+.boxer.b .boxer-img { transform: scaleX(-1); }
 .boxer:hover .boxer-img { scale: 1.06; filter: saturate(1.1) brightness(1.05); }
 
 .boxer-veil {
@@ -236,7 +240,6 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
 }
 :global(.boxer-flag) { width: 14px; height: 14px; flex-shrink: 0; }
 
-  /* ── link del COMBATE: medallón VS centrado entre los dos boxeadores ── */
 .vslink {
     position: absolute;
     left: 50%;
@@ -247,9 +250,9 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     align-items: center;
     justify-content: center;
     text-decoration: none;
-  }
-  .vslink:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: 4px; }
-  .vsmedal {
+}
+.vslink:focus-visible { outline: 2px solid var(--color-theme-gold); outline-offset: 4px; }
+.vsmedal {
     width: 46px;
     height: 46px;
     display: flex;
@@ -259,15 +262,15 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     border: 1px solid var(--color-theme-gold);
     background: radial-gradient(circle, color-mix(in srgb, var(--color-theme-gold) 22%, transparent), rgba(5, 8, 15, 0.85));
     transition: box-shadow 300ms ease, background 300ms ease;
-  }
-  .is-featured .vsmedal { width: 56px; height: 56px; }
+}
+.is-featured .vsmedal { width: 56px; height: 56px; }
 .vsmedal b {
     transform: rotate(-45deg);
     font-weight: 900;
     font-size: 0.9rem;
     color: color-mix(in srgb, var(--color-theme-gold) 92%, white);
 }
-  .is-featured .vsmedal b { font-size: 1.05rem; }
+.is-featured .vsmedal b { font-size: 1.05rem; }
 .vslink:hover .vsmedal {
     background: radial-gradient(circle, color-mix(in srgb, var(--color-theme-gold) 40%, transparent), rgba(5, 8, 15, 0.85));
     animation: vspulse 1.3s ease infinite;
@@ -277,7 +280,6 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     50% { box-shadow: 0 0 0 8px color-mix(in srgb, var(--color-theme-gold) 0%, transparent); }
 }
 
-  /* ── barra inferior: también link al combate ── */
 .combat-foot {
     position: relative;
     z-index: 4;

--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -7,7 +7,7 @@ const { variant } = Astro.props
 
 const NAV_ITEMS = [
   { label: 'BOXEADORES', href: '/boxeadores', disabled: false },
-  { label: 'COMBATES', href: '/#cartelera', disabled: true, note: 'PRÓXIMAMENTE' },
+  { label: 'COMBATES', href: '/#cartelera', disabled: false },
   { label: 'PRONÓSTICOS', href: '/pronosticos', disabled: true, note: 'PRÓXIMAMENTE' },
 ] as const
 

--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -7,7 +7,7 @@ const { variant } = Astro.props
 
 const NAV_ITEMS = [
   { label: 'BOXEADORES', href: '/boxeadores', disabled: false },
-  { label: 'COMBATES', href: '/#cartelera', disabled: false },
+  { label: 'COMBATES', href: '/combates', disabled: false },
   { label: 'PRONÓSTICOS', href: '/pronosticos', disabled: true, note: 'PRÓXIMAMENTE' },
 ] as const
 

--- a/src/pages/combates.astro
+++ b/src/pages/combates.astro
@@ -3,7 +3,7 @@ import Layout from '@/layouts/Layout.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
 import CombatCard from '@/components/CombatCard.astro'
-import { battlesById } from '@/consts/battles'
+import { battles } from '@/consts/battles'
 import { BOXERS_BY_ID, COUNTRY_NAMES, getBoxerHeroImages, type Boxer } from '@/consts/boxers'
 
 const SITE_URL = 'https://www.infolavelada.com'
@@ -14,20 +14,7 @@ const canonical = `${SITE_URL}/combates`
 
 export const prerender = true
 
-
-// ─────────────────────────────────────────────────────────────────────
-const CARTELERA_ORDER: string[] = [
-    'illojuan-vs-thegrefg',         // Main Event
-    'plex-vs-fernanfloo',           // Co-estelar
-    'marta-diaz-vs-tatiana-kaer',
-    'samy-rivers-vs-roro',
-    'viruzz-vs-gero-arias',
-    'alondrissa-vs-angie-velasco',
-    'lit-killah-vs-kidd-keo',
-    'clersss-vs-natalia-mx',
-    'la-parce-vs-fabiana-sevillano',
-    'edu-aguirre-vs-gaston-edul',
-]
+// Cuántos combates van en la sección de estelares (arriba).
 const MAIN_EVENT_COUNT = 2
 
 const toCard = (boxer: Boxer) => ({
@@ -38,9 +25,10 @@ const toCard = (boxer: Boxer) => ({
     heroImages: getBoxerHeroImages(boxer),
 })
 
-const combatCards = CARTELERA_ORDER.map((id) => battlesById[id])
-    .filter((battle): battle is NonNullable<typeof battle> => Boolean(battle))
-    .map((battle, index) => {
+// La cartelera va del Main Event al primer combate: es el orden inverso de
+// `battles` (única fuente de la verdad, en battles.ts). Usamos [...battles]
+// (una copia) para NO mutar el array original, que lo usan otras páginas.
+const combatCards = [...battles].reverse().map((battle, index) => {
     const [id1, id2] = battle.boxerIds
     return {
         position: battle.number,
@@ -49,7 +37,7 @@ const combatCards = CARTELERA_ORDER.map((id) => battlesById[id])
         a: toCard(BOXERS_BY_ID[id1]),
         b: toCard(BOXERS_BY_ID[id2]),
     }
-    })
+})
 
 const mainEvents = combatCards.filter((c) => c.featured)
 const undercard = combatCards.filter((c) => !c.featured)
@@ -58,88 +46,88 @@ const breadcrumbJsonLd = {
     '@context': 'https://schema.org',
     '@type': 'BreadcrumbList',
     itemListElement: [
-    { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${SITE_URL}/` },
-    { '@type': 'ListItem', position: 2, name: 'Combates', item: canonical },
+        { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${SITE_URL}/` },
+        { '@type': 'ListItem', position: 2, name: 'Combates', item: canonical },
     ],
 }
 ---
 
 <Layout title={title} description={description} canonical={canonical}>
     <script
-    type="application/ld+json"
-    is:inline
-    set:html={JSON.stringify(breadcrumbJsonLd)}
-    slot="head"
+        type="application/ld+json"
+        is:inline
+        set:html={JSON.stringify(breadcrumbJsonLd)}
+        slot="head"
     />
 
     <section
-    class="combates-page relative isolate w-full overflow-x-clip bg-theme-midnight px-3 pb-20 pt-24 text-theme-cream sm:px-6 sm:pb-24 sm:pt-32 md:pt-36"
+        class="combates-page relative isolate w-full overflow-x-clip bg-theme-midnight px-3 pb-20 pt-24 text-theme-cream sm:px-6 sm:pb-24 sm:pt-32 md:pt-36"
     >
-    <div aria-hidden="true" class="combates-bg absolute inset-0 -z-20"></div>
+        <div aria-hidden="true" class="combates-bg absolute inset-0 -z-20"></div>
 
-    <div class="mx-auto w-full max-w-7xl">
-        <header class="combates-header">
-        <div
-            class="mb-8 flex w-full items-center justify-center gap-4 sm:mb-12"
-            aria-hidden="true"
-        >
-            <span class="h-px w-12 bg-linear-to-r from-transparent to-theme-gold/40 sm:w-24"></span>
-            <span class="size-1.5 rotate-45 bg-theme-gold/70"></span>
-            <span class="h-px w-12 bg-linear-to-l from-transparent to-theme-gold/40 sm:w-24"></span>
+        <div class="mx-auto w-full max-w-7xl">
+            <header class="combates-header">
+                <div
+                    class="mb-8 flex w-full items-center justify-center gap-4 sm:mb-12"
+                    aria-hidden="true"
+                >
+                    <span class="h-px w-12 bg-linear-to-r from-transparent to-theme-gold/40 sm:w-24"></span>
+                    <span class="size-1.5 rotate-45 bg-theme-gold/70"></span>
+                    <span class="h-px w-12 bg-linear-to-l from-transparent to-theme-gold/40 sm:w-24"></span>
+                </div>
+                <h1
+                    class="mb-3 animate-fade-in-up font-cinzel text-3xl font-bold tracking-[0.12em] text-theme-cream sm:text-4xl sm:tracking-[0.18em] md:text-6xl"
+                >
+                    COMBATES
+                </h1>
+                <p
+                    class="animate-fade-in-up animate-delay-200 text-balance font-cinzel text-xs font-medium tracking-[0.16em] text-white/55 sm:text-sm sm:tracking-[0.25em]"
+                >
+                    La cartelera de La Velada del Año VI
+                </p>
+            </header>
+
+            {
+                mainEvents.length > 0 && (
+                    <>
+                        <div class="combates-seclabel">
+                            <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
+                        </div>
+                        <div class="combates-mains">
+                            {mainEvents.map((c, i) => (
+                                <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
+                                    <CombatCard
+                                        number={c.position}
+                                        url={c.url}
+                                        featured
+                                        badge={i === 0 ? 'Main Event' : 'Co-estelar'}
+                                        a={c.a}
+                                        b={c.b}
+                                    />
+                                </div>
+                            ))}
+                        </div>
+                    </>
+                )
+            }
+
+            {
+                undercard.length > 0 && (
+                    <>
+                        <div class="combates-seclabel">
+                            <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
+                        </div>
+                        <div class="combates-under">
+                            {undercard.map((c, i) => (
+                                <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
+                                    <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
+                                </div>
+                            ))}
+                        </div>
+                    </>
+                )
+            }
         </div>
-        <h1
-            class="mb-3 animate-fade-in-up font-cinzel text-3xl font-bold tracking-[0.12em] text-theme-cream sm:text-4xl sm:tracking-[0.18em] md:text-6xl"
-        >
-            COMBATES
-        </h1>
-        <p
-        class="animate-fade-in-up animate-delay-200 text-balance font-cinzel text-xs font-medium tracking-[0.16em] text-white/55 sm:text-sm sm:tracking-[0.25em]"
-        >
-            La cartelera de La Velada del Año VI
-        </p>
-        </header>
-
-        {
-        mainEvents.length > 0 && (
-            <>
-            <div class="combates-seclabel">
-                <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
-            </div>
-            <div class="combates-mains">
-                {mainEvents.map((c, i) => (
-                <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
-                    <CombatCard
-                    number={c.position}
-                    url={c.url}
-                    featured
-                    badge={i === 0 ? 'Main Event' : 'Co-estelar'}
-                    a={c.a}
-                    b={c.b}
-                    />
-                </div>
-            ))}
-            </div>
-            </>
-        )
-        }
-
-        {
-        undercard.length > 0 && (
-            <>
-            <div class="combates-seclabel">
-                <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
-            </div>
-            <div class="combates-under">
-                {undercard.map((c, i) => (
-                <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
-                    <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
-                </div>
-                ))}
-            </div>
-            </>
-        )
-        }
-    </div>
     </section>
 
     <Sponsors />
@@ -147,60 +135,51 @@ const breadcrumbJsonLd = {
 </Layout>
 
 <style>
-.combates-page { min-height: 100svh; }
+    .combates-page { min-height: 100svh; }
 
-.combates-header {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    text-align: center;
-}
+    .combates-header {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        text-align: center;
+    }
 
-.combates-bg {
-    background:
-        radial-gradient(
-        ellipse 70% 45% at 50% 0%,
-        color-mix(in srgb, var(--color-theme-gold) 16%, transparent) 0%,
-        transparent 65%
-        ),
-        linear-gradient(180deg, var(--color-theme-midnight) 0%, #050816 100%);
-}
+    .combates-bg {
+        background:
+            radial-gradient(
+                ellipse 70% 45% at 50% 0%,
+                color-mix(in srgb, var(--color-theme-gold) 16%, transparent) 0%,
+                transparent 65%
+            ),
+            linear-gradient(180deg, var(--color-theme-midnight) 0%, #050816 100%);
+    }
 
-.combates-seclabel {
-    display: flex;
-    align-items: center;
-    gap: 0.7rem;
-    margin: 3.5rem 0 1.5rem;
-    font-family: var(--font-cinzel, 'Cinzel', serif);
-    font-size: 0.72rem;
-    font-weight: 700;
-    letter-spacing: 0.34em;
-    text-transform: uppercase;
-    color: var(--color-theme-gold);
-}
-.combates-seclabel.under {
-    color: color-mix(in srgb, var(--color-theme-cream) 70%, transparent);
-}
-.combates-seclabel::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-    background: linear-gradient(90deg, color-mix(in srgb, var(--color-theme-gold) 28%, transparent), transparent);
-}
+    .combates-seclabel {
+        display: flex;
+        align-items: center;
+        gap: 0.7rem;
+        margin: 3.5rem 0 1.5rem;
+    }
+    .combates-seclabel::after {
+        content: '';
+        flex: 1;
+        height: 1px;
+        background: linear-gradient(90deg, color-mix(in srgb, var(--color-theme-gold) 28%, transparent), transparent);
+    }
 
-.combates-mains,
-.combates-under {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1.4rem;
-}
+    .combates-mains,
+    .combates-under {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.4rem;
+    }
 
-@media (min-width: 900px) {
-    .combates-mains { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-    .combates-under { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
+    @media (min-width: 900px) {
+        .combates-mains { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+        .combates-under { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    }
 
-@media (prefers-reduced-motion: reduce) {
-    .animate-fade-in-up { animation: none; }
-}
+    @media (prefers-reduced-motion: reduce) {
+        .animate-fade-in-up { animation: none; }
+    }
 </style>

--- a/src/pages/combates.astro
+++ b/src/pages/combates.astro
@@ -93,80 +93,80 @@ const breadcrumbJsonLd = {
             COMBATES
         </h1>
         <p
-          class="animate-fade-in-up animate-delay-200 text-balance font-cinzel text-xs font-medium tracking-[0.16em] text-white/55 sm:text-sm sm:tracking-[0.25em]"
+        class="animate-fade-in-up animate-delay-200 text-balance font-cinzel text-xs font-medium tracking-[0.16em] text-white/55 sm:text-sm sm:tracking-[0.25em]"
         >
-          La cartelera de La Velada del Año VI
+            La cartelera de La Velada del Año VI
         </p>
-      </header>
+        </header>
 
-      {
+        {
         mainEvents.length > 0 && (
-          <>
+            <>
             <div class="combates-seclabel">
-              <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
+                <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
             </div>
             <div class="combates-mains">
-              {mainEvents.map((c, i) => (
+                {mainEvents.map((c, i) => (
                 <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
-                  <CombatCard
+                    <CombatCard
                     number={c.position}
                     url={c.url}
                     featured
                     badge={i === 0 ? 'Main Event' : 'Co-estelar'}
                     a={c.a}
                     b={c.b}
-                  />
+                    />
                 </div>
-              ))}
+            ))}
             </div>
-          </>
+            </>
         )
-      }
+        }
 
-      {
+        {
         undercard.length > 0 && (
-          <>
+            <>
             <div class="combates-seclabel">
-              <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
+                <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
             </div>
             <div class="combates-under">
-              {undercard.map((c, i) => (
+                {undercard.map((c, i) => (
                 <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
-                  <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
+                    <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
                 </div>
-              ))}
+                ))}
             </div>
-          </>
+            </>
         )
-      }
+        }
     </div>
-  </section>
+    </section>
 
-  <Sponsors />
-  <Footer />
+    <Sponsors />
+    <Footer />
 </Layout>
 
 <style>
-  .combates-page { min-height: 100svh; }
+.combates-page { min-height: 100svh; }
 
-  .combates-header {
+.combates-header {
     display: flex;
     flex-direction: column;
     align-items: center;
     text-align: center;
-  }
+}
 
-  .combates-bg {
+.combates-bg {
     background:
-      radial-gradient(
+        radial-gradient(
         ellipse 70% 45% at 50% 0%,
         color-mix(in srgb, var(--color-theme-gold) 16%, transparent) 0%,
         transparent 65%
-      ),
-      linear-gradient(180deg, var(--color-theme-midnight) 0%, #050816 100%);
-  }
+        ),
+        linear-gradient(180deg, var(--color-theme-midnight) 0%, #050816 100%);
+}
 
-  .combates-seclabel {
+.combates-seclabel {
     display: flex;
     align-items: center;
     gap: 0.7rem;
@@ -177,30 +177,30 @@ const breadcrumbJsonLd = {
     letter-spacing: 0.34em;
     text-transform: uppercase;
     color: var(--color-theme-gold);
-  }
-  .combates-seclabel.under {
+}
+.combates-seclabel.under {
     color: color-mix(in srgb, var(--color-theme-cream) 70%, transparent);
-  }
-  .combates-seclabel::after {
+}
+.combates-seclabel::after {
     content: '';
     flex: 1;
     height: 1px;
     background: linear-gradient(90deg, color-mix(in srgb, var(--color-theme-gold) 28%, transparent), transparent);
-  }
+}
 
-  .combates-mains,
-  .combates-under {
+.combates-mains,
+.combates-under {
     display: grid;
     grid-template-columns: 1fr;
     gap: 1.4rem;
-  }
+}
 
-  @media (min-width: 900px) {
+@media (min-width: 900px) {
     .combates-mains { grid-template-columns: repeat(2, minmax(0, 1fr)); }
     .combates-under { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-  }
+}
 
-  @media (prefers-reduced-motion: reduce) {
+@media (prefers-reduced-motion: reduce) {
     .animate-fade-in-up { animation: none; }
-  }
+}
 </style>

--- a/src/pages/combates.astro
+++ b/src/pages/combates.astro
@@ -1,0 +1,206 @@
+---
+import Layout from '@/layouts/Layout.astro'
+import Footer from '@/sections/Footer.astro'
+import Sponsors from '@/sections/Sponsors.astro'
+import CombatCard from '@/components/CombatCard.astro'
+import { battlesById } from '@/consts/battles'
+import { BOXERS_BY_ID, COUNTRY_NAMES, getBoxerHeroImages, type Boxer } from '@/consts/boxers'
+
+const SITE_URL = 'https://www.infolavelada.com'
+const title = 'Combates | La Velada del Año VI'
+const description =
+    'La cartelera completa de La Velada del Año VI: combates estelares y undercard del evento de Ibai Llanos en Sevilla.'
+const canonical = `${SITE_URL}/combates`
+
+export const prerender = true
+
+
+// ─────────────────────────────────────────────────────────────────────
+const CARTELERA_ORDER: string[] = [
+    'illojuan-vs-thegrefg',         // Main Event
+    'plex-vs-fernanfloo',           // Co-estelar
+    'marta-diaz-vs-tatiana-kaer',
+    'samy-rivers-vs-roro',
+    'viruzz-vs-gero-arias',
+    'alondrissa-vs-angie-velasco',
+    'lit-killah-vs-kidd-keo',
+    'clersss-vs-natalia-mx',
+    'la-parce-vs-fabiana-sevillano',
+    'edu-aguirre-vs-gaston-edul',
+]
+const MAIN_EVENT_COUNT = 2
+
+const toCard = (boxer: Boxer) => ({
+    id: boxer.id,
+    name: boxer.name,
+    country: boxer.country,
+    countryName: COUNTRY_NAMES[boxer.country] ?? boxer.country,
+    heroImages: getBoxerHeroImages(boxer),
+})
+
+const combatCards = CARTELERA_ORDER.map((id) => battlesById[id])
+    .filter((battle): battle is NonNullable<typeof battle> => Boolean(battle))
+    .map((battle, index) => {
+    const [id1, id2] = battle.boxerIds
+    return {
+        position: battle.number,
+        url: battle.url,
+        featured: index < MAIN_EVENT_COUNT,
+        a: toCard(BOXERS_BY_ID[id1]),
+        b: toCard(BOXERS_BY_ID[id2]),
+    }
+    })
+
+const mainEvents = combatCards.filter((c) => c.featured)
+const undercard = combatCards.filter((c) => !c.featured)
+
+const breadcrumbJsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+    { '@type': 'ListItem', position: 1, name: 'Inicio', item: `${SITE_URL}/` },
+    { '@type': 'ListItem', position: 2, name: 'Combates', item: canonical },
+    ],
+}
+---
+
+<Layout title={title} description={description} canonical={canonical}>
+    <script
+    type="application/ld+json"
+    is:inline
+    set:html={JSON.stringify(breadcrumbJsonLd)}
+    slot="head"
+    />
+
+    <section
+    class="combates-page relative isolate w-full overflow-x-clip bg-theme-midnight px-3 pb-20 pt-24 text-theme-cream sm:px-6 sm:pb-24 sm:pt-32 md:pt-36"
+    >
+    <div aria-hidden="true" class="combates-bg absolute inset-0 -z-20"></div>
+
+    <div class="mx-auto w-full max-w-7xl">
+        <header class="combates-header">
+        <div
+            class="mb-8 flex w-full items-center justify-center gap-4 sm:mb-12"
+            aria-hidden="true"
+        >
+            <span class="h-px w-12 bg-linear-to-r from-transparent to-theme-gold/40 sm:w-24"></span>
+            <span class="size-1.5 rotate-45 bg-theme-gold/70"></span>
+            <span class="h-px w-12 bg-linear-to-l from-transparent to-theme-gold/40 sm:w-24"></span>
+        </div>
+        <h1
+            class="mb-3 animate-fade-in-up font-cinzel text-3xl font-bold tracking-[0.12em] text-theme-cream sm:text-4xl sm:tracking-[0.18em] md:text-6xl"
+        >
+            COMBATES
+        </h1>
+        <p
+          class="animate-fade-in-up animate-delay-200 text-balance font-cinzel text-xs font-medium tracking-[0.16em] text-white/55 sm:text-sm sm:tracking-[0.25em]"
+        >
+          La cartelera de La Velada del Año VI
+        </p>
+      </header>
+
+      {
+        mainEvents.length > 0 && (
+          <>
+            <div class="combates-seclabel">
+              <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
+            </div>
+            <div class="combates-mains">
+              {mainEvents.map((c, i) => (
+                <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
+                  <CombatCard
+                    number={c.position}
+                    url={c.url}
+                    featured
+                    badge={i === 0 ? 'Main Event' : 'Co-estelar'}
+                    a={c.a}
+                    b={c.b}
+                  />
+                </div>
+              ))}
+            </div>
+          </>
+        )
+      }
+
+      {
+        undercard.length > 0 && (
+          <>
+            <div class="combates-seclabel">
+              <span class="size-1.5 rotate-45 bg-theme-gold/80" aria-hidden="true" />
+            </div>
+            <div class="combates-under">
+              {undercard.map((c, i) => (
+                <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
+                  <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
+                </div>
+              ))}
+            </div>
+          </>
+        )
+      }
+    </div>
+  </section>
+
+  <Sponsors />
+  <Footer />
+</Layout>
+
+<style>
+  .combates-page { min-height: 100svh; }
+
+  .combates-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+  }
+
+  .combates-bg {
+    background:
+      radial-gradient(
+        ellipse 70% 45% at 50% 0%,
+        color-mix(in srgb, var(--color-theme-gold) 16%, transparent) 0%,
+        transparent 65%
+      ),
+      linear-gradient(180deg, var(--color-theme-midnight) 0%, #050816 100%);
+  }
+
+  .combates-seclabel {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+    margin: 3.5rem 0 1.5rem;
+    font-family: var(--font-cinzel, 'Cinzel', serif);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.34em;
+    text-transform: uppercase;
+    color: var(--color-theme-gold);
+  }
+  .combates-seclabel.under {
+    color: color-mix(in srgb, var(--color-theme-cream) 70%, transparent);
+  }
+  .combates-seclabel::after {
+    content: '';
+    flex: 1;
+    height: 1px;
+    background: linear-gradient(90deg, color-mix(in srgb, var(--color-theme-gold) 28%, transparent), transparent);
+  }
+
+  .combates-mains,
+  .combates-under {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.4rem;
+  }
+
+  @media (min-width: 900px) {
+    .combates-mains { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+    .combates-under { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .animate-fade-in-up { animation: none; }
+  }
+</style>


### PR DESCRIPTION
Agrego la página de Combates (/combates), la cartelera con todos los combates.

Qué hace:
- Lista todos los combates, con los estelares arriba y el resto en el undercard.
- Reutiliza el layout que ya estaba: Header, Sponsors y Footer.
- Usa los datos reales de battles.ts y boxers.ts (fotos reales + el componente CountryFlag).
- Cada boxeador linkea a su perfil (/boxeadores/[id]).
- Sumé el link de "Combates" en el navbar.

Para tener en cuenta:
- El orden de la cartelera lo dejé en una constante editable arriba de combates.astro (por ahora marqué como main events los primeros 2). Si prefieren, se puede mover a battles.ts como un campo `mainEvent`.
- El VS y el "Ver cara a cara" por ahora van a /404, porque la landing individual de cada combate (/combate/[id]) todavía no está hecha. Es temporal: cuando esas vistas estén, se cambia el enlace por /combate/[id] (dejé un comentario en CombatCard.astro indicando cómo).

<img width="1910" height="1051" alt="Captura de pantalla 2026-06-09 a la(s) 5 50 53 p  m" src="https://github.com/user-attachments/assets/9d80f297-f2e4-43cd-92fe-3e4a4424b9cd" />
<img width="1910" height="1042" alt="Captura de pantalla 2026-06-09 a la(s) 5 51 02 p  m" src="https://github.com/user-attachments/assets/81f6bf99-ac3e-4325-bce0-3705442591f8" />
<img width="1913" height="1038" alt="Captura de pantalla 2026-06-09 a la(s) 5 51 10 p  m" src="https://github.com/user-attachments/assets/10eb912d-f83f-4a52-a1e6-9d323c4ff38d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched the Combates page with main-event and undercard sections showing scheduled matches.
  * Enabled the "COMBATES" navigation item.
  * Added combat cards displaying fighters, countries, responsive hero images, featured badges, and staggered entrance animations for highlighted fights.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->