### PR TITLE
fix(index.astro): remove focusable elements from SEO and screen reade…

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -171,9 +171,9 @@ export const prerender = true
           return (
             <li>
               Combate {battle.number}:{' '}
-              <a href={`/boxeadores/${a.id}`}>{a.name}</a> ({COUNTRY_NAMES[a.country] ?? a.country})
+              <a href={`/boxeadores/${a.id}`} tabindex="-1">{a.name}</a> ({COUNTRY_NAMES[a.country] ?? a.country})
               {' vs '}
-              <a href={`/boxeadores/${b.id}`}>{b.name}</a> ({COUNTRY_NAMES[b.country] ?? b.country})
+              <a href={`/boxeadores/${b.id}`} tabindex="-1">{b.name}</a> ({COUNTRY_NAMES[b.country] ?? b.country})
             </li>
           )
         })
@@ -185,7 +185,7 @@ export const prerender = true
       {
         BOXERS.map((boxer) => (
           <li>
-            <a href={`/boxeadores/${boxer.id}`}>{boxer.name}</a> —{' '}
+            <a href={`/boxeadores/${boxer.id}`} tabindex="-1">{boxer.name}</a> —{' '}
             {COUNTRY_NAMES[boxer.country] ?? boxer.country}
           </li>
         ))


### PR DESCRIPTION
Se remueven del flujo de navegación por teclado los elementos utilizados exclusivamente para SEO y lectores de pantalla.

Antes de esta PR, estos enlaces formaban parte de la secuencia de navegación por teclado, ya que, aunque se encuentran visualmente ocultos mediante la clase `sr-only`, pueden recibir foco. Sin embargo, no proporcionan una experiencia de interacción significativa para usuarios que navegan mediante teclado y generan ruido adicional dentro del flujo de navegación.

Dado que los mismos destinos ya son accesibles a través de los enlaces visibles de la interfaz, excluir estos elementos de la secuencia de tabulación permite reducir pasos innecesarios durante la navegación sin afectar el acceso al contenido ni la estructura semántica de los Screen readers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved keyboard navigation on the home page event details section. Boxer profile links in the combat and boxers lists now have adjusted focus behavior to streamline keyboard navigation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->