### PR TITLE
fix(boxeadores): adjust shadow effect in main boxer picture

### DIFF
--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -559,6 +559,7 @@ const breadcrumbJsonLd = {
     display: flex;
     align-items: start;
     justify-content: center;
+    filter: drop-shadow(0 24px 40px rgba(0, 0, 0, 0.55));
   }
 
   /* Badge de "Campeón previo" en la ficha individual: arriba a la
@@ -611,7 +612,6 @@ const breadcrumbJsonLd = {
       color-mix(in srgb, black 60%, transparent) 90%,
       transparent 100%
     );
-    filter: drop-shadow(0 24px 40px rgba(0, 0, 0, 0.55));
   }
 
   @media (max-width: 1023px) {


### PR DESCRIPTION
Se corrige la sombra (drop-shadow) aplicada a la imagen principal del boxeador en la página de detalles para que no se vea cortada.

Antes:
<img width="516" height="735" alt="image" src="https://github.com/user-attachments/assets/55bfc730-cd9d-4fcb-bc20-b89fa43fd014" />

Depués:
<img width="482" height="726" alt="image" src="https://github.com/user-attachments/assets/ac2050b7-f703-436b-a3b2-ef7338fe7084" />
