### PR TITLE
fix(boxeadores): update animation styles and improve layout for boxer…

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -343,7 +343,7 @@ const totalBoxers = BOXERS.length
               data-default-order={index}
               data-followers={b.totalFollowers}
               data-battle={b.battleNumber}
-              style={`animation-delay: ${index * 35}ms`}
+              style={{"--animation-delay": `${index * 35}ms`}}
             >
               <a
                 href={`/boxeadores/${b.id}`}
@@ -1384,7 +1384,8 @@ const totalBoxers = BOXERS.length
      cards puedan encogerse y nunca desborden el viewport. */
   .boxer-card-wrap {
     min-width: 0;
-    transition: opacity 220ms ease;
+    transition: opacity 220ms ease ;
+    transition-delay: var(--transition-delay, 0ms);
   }
 
   .boxer-card-wrap[data-hidden='true'] {
@@ -1408,38 +1409,32 @@ const totalBoxers = BOXERS.length
 
   /* El rectángulo dorado agrupa a los dos boxeadores del combate. */
   :global(.combate-group) {
+    position: relative;
     display: flex;
     flex-direction: row;
     gap: 1rem;
-    padding: 1.5rem;
-    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 40%, transparent);
-    border-radius: 12px;
-    background: radial-gradient(
-      ellipse at top,
-      color-mix(in srgb, var(--color-theme-gold) 15%, transparent) 0%,
-      transparent 70%
-    );
-    box-shadow: 0 0 20px color-mix(in srgb, var(--color-theme-gold) 10%, transparent);
-    position: relative;
   }
 
   /* Etiqueta central de "VS" entre los boxeadores */
   :global(.combate-group::after) {
     content: 'VS';
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    width: 2.35em;
+    height: 2.1em;
+    display: grid;
+    place-items: center;
+    inset: 0;
+    margin: auto;
+    line-height: normal;
     font-family: var(--font-cinzel);
     font-weight: 700;
-    font-size: 1.2rem;
+    font-size: clamp(1rem, 0.954rem + 0.194vw, 1.188rem);
     color: var(--color-theme-gold);
-    text-shadow: 0 2px 10px rgba(0,0,0,0.5);
     background: var(--color-theme-midnight);
-    padding: 0.25rem 0.5rem;
     border-radius: 4px;
     border: 1px solid color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
     z-index: 10;
+    animation: fade-in-up 0.6s ease-in-out both var(--transition-delay, 0ms);
   }
 
   :global(.combate-group > .boxer-card-wrap) {
@@ -1451,9 +1446,6 @@ const totalBoxers = BOXERS.length
     :global(.combate-group) {
       padding: 1rem;
       gap: 0.75rem;
-    }
-    :global(.combate-group::after) {
-      font-size: 1rem;
     }
   }
 


### PR DESCRIPTION
Se remueven los estilos visuales aplicados al contenedor que agrupa a los boxeadores, se mantiene el badge `VS` y se agrega la misma animación de entrada utilizada por las cards, manteniendo el delay tanto en cards como en badge.

Antes:
<img width="1311" height="831" alt="image" src="https://github.com/user-attachments/assets/3ceae1a7-3824-4054-baca-e9aa5382349d" />

Después:
<img width="1304" height="829" alt="image" src="https://github.com/user-attachments/assets/b1831cf3-4ad8-4757-8a95-4d4faec96bdb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined animation timing and transition effects for boxer card displays.
  * Enhanced responsive layout for matchup displays with improved centering and responsive sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->