### PR TITLE
fix(map): update event coordinates and Google Maps link

### DIFF
--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -202,7 +202,7 @@ import SectionHeader from '@/components/SectionHeader.astro'
 
           <!-- CTA Google Maps -->
           <a
-            href="https://maps.google.com/?q=Estadio+de+La+Cartuja,+Sevilla"
+            href="https://maps.app.goo.gl/73mfDNVvhK3Y5Kq66"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 rounded border border-theme-gold/35 px-4 py-[0.6rem] font-cinzel text-[0.65rem] font-bold tracking-[0.25em] text-theme-gold uppercase no-underline transition-all duration-300 outline-none hover:-translate-y-px hover:border-theme-gold hover:bg-theme-gold/10 hover:text-theme-cream focus-visible:-translate-y-px focus-visible:border-theme-gold focus-visible:bg-theme-gold/10 focus-visible:text-theme-cream focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight motion-reduce:transition-none motion-reduce:hover:translate-y-0"
@@ -308,8 +308,8 @@ import SectionHeader from '@/components/SectionHeader.astro'
 </style>
 
 <script>
-  const LAT = 37.40942
-  const LNG = -5.97617
+  const LAT = 37.41745253261154
+  const LNG = -6.004464222177984
   const ZOOM = 15
 
   const PIN_SVG = `


### PR DESCRIPTION
Se actualizan las coordenadas del evento en el Mapa y se utiliza el mismo link de google maps que se usa en el hero

Antes:

<img width="1186" height="708" alt="image" src="https://github.com/user-attachments/assets/dc56f1f6-a43f-4fff-91bd-81d80e4de0ba" />

Después:

<img width="1255" height="713" alt="image" src="https://github.com/user-attachments/assets/573cf05d-15d3-48f9-9437-de6d3d32f485" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved Google Maps integration by updating the link format for more reliable direct navigation to the location
  * Adjusted the interactive map's center point and marker position coordinates for accurate location display
  * Enhanced map functionality to ensure consistent location data across navigation methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->