### PR TITLE
feat(pronosticos): UI de votación de pronósticos

### DIFF
--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -8,7 +8,7 @@ const { variant } = Astro.props
 const NAV_ITEMS = [
   { label: 'BOXEADORES', href: '/boxeadores', disabled: false },
   { label: 'COMBATES', href: '/combates', disabled: false },
-  { label: 'PRONÓSTICOS', href: '/pronosticos', disabled: true, note: 'PRÓXIMAMENTE' },
+  { label: 'PRONÓSTICOS', href: '/pronosticos', disabled: false },
 ] as const
 
 const shouldReloadNavItem = (href: string) => Astro.url.pathname === '/' && href === '/boxeadores'

--- a/src/components/PredictionFight.astro
+++ b/src/components/PredictionFight.astro
@@ -1,0 +1,224 @@
+---
+import ArrowRightIcon from '@/assets/svg/arrow-right.svg'
+import PredictionOption from '@/components/PredictionOption.astro'
+import { formatPredictionPercent, type PredictionBattle } from '@/consts/predictions'
+
+interface Props {
+  prediction: PredictionBattle
+}
+
+const { prediction } = Astro.props
+const { battle, options, leader, isClose } = prediction
+---
+
+<li id={battle.id} class="scroll-mt-28">
+  <article
+    class="prediction-fight relative overflow-hidden rounded-lg border border-theme-gold/18 bg-theme-midnight/82 shadow-[0_24px_70px_rgba(0,0,0,0.34)] backdrop-blur-md backdrop-saturate-150"
+    data-battle-id={battle.id}
+    data-prediction-fight
+  >
+    <div aria-hidden="true" class="prediction-fight-sheen pointer-events-none absolute inset-0">
+    </div>
+
+    <header
+      class="prediction-fight-header relative z-10 grid gap-4 border-b border-theme-gold/14 px-4 py-4 sm:px-5 md:grid-cols-[1fr_auto] md:items-center md:px-6"
+    >
+      <div>
+        <p
+          class="font-cinzel text-[0.58rem] font-bold tracking-[0.4em] text-theme-gold/85 sm:text-[0.68rem]"
+        >
+          COMBATE {String(battle.number).padStart(2, '0')}
+        </p>
+        <h2
+          class="mt-2 font-cinzel text-xl font-black tracking-[0.08em] text-balance text-theme-cream uppercase sm:text-2xl md:text-3xl"
+        >
+          {battle.title}
+        </h2>
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2 md:justify-end">
+        <span
+          class:list={[
+            'prediction-badge',
+            isClose ? 'prediction-badge-hot' : 'prediction-badge-calm',
+          ]}
+        >
+          {isClose ? 'A cara de perro' : `Favorito: ${leader.boxer.name}`}
+        </span>
+        <a
+          href={battle.url}
+          class="prediction-fight-link group inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-white/12 px-3 py-2 font-cinzel text-[0.58rem] font-bold tracking-[0.24em] text-white/78 transition duration-300 hover:border-theme-gold/55 hover:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold sm:text-[0.65rem]"
+        >
+          Combate
+          <ArrowRightIcon
+            class="size-3 transition-transform duration-300 group-hover:translate-x-0.5"
+            aria-hidden="true"
+          />
+        </a>
+      </div>
+    </header>
+
+    <div
+      class="prediction-body relative z-10 grid items-stretch gap-4 p-3 sm:gap-5 sm:p-5 md:p-6 lg:grid-cols-[minmax(0,1fr)_10rem_minmax(0,1fr)] lg:items-center"
+    >
+      {
+        options.map((option, optionIndex) => (
+          <>
+            {optionIndex === 1 && (
+              <div
+                class="duel-versus"
+                role="img"
+                aria-label={`${options[0].boxer.name}: ${formatPredictionPercent(options[0].percentage)}. ${options[1].boxer.name}: ${formatPredictionPercent(options[1].percentage)}.`}
+              >
+                <span aria-hidden="true" class="duel-versus-text">
+                  VS
+                </span>
+              </div>
+            )}
+
+            <PredictionOption battleId={battle.id} option={option} />
+          </>
+        ))
+      }
+    </div>
+  </article>
+</li>
+
+<style>
+  .prediction-fight {
+    opacity: 0;
+    translate: 0 2rem;
+    animation: prediction-reveal linear both;
+    animation-timeline: view();
+    animation-range: entry 0% cover 30%;
+    transition:
+      border-color 360ms ease,
+      box-shadow 360ms ease,
+      transform 360ms ease;
+  }
+
+  .prediction-fight:hover {
+    transform: translateY(-2px);
+    border-color: color-mix(in srgb, var(--color-theme-gold) 42%, transparent);
+    box-shadow:
+      0 28px 84px rgba(0, 0, 0, 0.44),
+      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 18%, transparent);
+  }
+
+  .prediction-fight-sheen {
+    background:
+      radial-gradient(
+        ellipse 42% 70% at 0% 50%,
+        color-mix(in srgb, #c63030 16%, transparent),
+        transparent 66%
+      ),
+      radial-gradient(
+        ellipse 42% 70% at 100% 50%,
+        color-mix(in srgb, var(--color-theme-gold) 14%, transparent),
+        transparent 68%
+      ),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.04), transparent 42%);
+  }
+
+  .prediction-badge {
+    display: inline-flex;
+    min-height: 2.5rem;
+    align-items: center;
+    border-radius: 0.5rem;
+    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 24%, transparent);
+    padding: 0.55rem 0.75rem;
+    font-family: var(--font-cinzel);
+    font-size: 0.58rem;
+    font-weight: 800;
+    letter-spacing: 0.24em;
+    text-transform: uppercase;
+  }
+
+  .prediction-badge-hot {
+    background: color-mix(in srgb, var(--color-theme-maroon) 45%, transparent);
+    color: var(--color-theme-gold);
+  }
+
+  .prediction-badge-calm {
+    background: color-mix(in srgb, var(--color-theme-midnight) 68%, #c63030);
+    color: rgba(244, 228, 201, 0.82);
+  }
+
+  .duel-versus {
+    display: grid;
+    place-items: center;
+  }
+
+  .duel-versus-text {
+    display: grid;
+    width: 4rem;
+    height: 4rem;
+    place-items: center;
+    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 62%, transparent);
+    border-radius: 0.5rem;
+    background:
+      radial-gradient(
+        circle at 50% 0%,
+        color-mix(in srgb, var(--color-theme-gold) 18%, transparent),
+        transparent 68%
+      ),
+      color-mix(in srgb, var(--color-theme-midnight) 90%, black);
+    box-shadow:
+      0 10px 28px rgba(0, 0, 0, 0.48),
+      0 0 22px color-mix(in srgb, var(--color-theme-gold) 18%, transparent);
+    color: var(--color-theme-gold);
+    font-family: var(--font-cinzel);
+    font-size: 0.82rem;
+    font-weight: 900;
+    letter-spacing: 0.12em;
+  }
+
+  @keyframes prediction-reveal {
+    to {
+      opacity: 1;
+      translate: 0 0;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .prediction-badge {
+      width: 100%;
+      justify-content: center;
+      text-align: center;
+    }
+
+    .prediction-fight-link {
+      width: 100%;
+    }
+
+    .duel-versus {
+      margin-block: -0.15rem;
+    }
+
+    .duel-versus-text {
+      width: 3.65rem;
+      height: 3.65rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .prediction-fight,
+    .prediction-fight-link {
+      animation: none;
+      transition: none;
+    }
+
+    .prediction-fight {
+      opacity: 1;
+      translate: 0 0;
+    }
+  }
+
+  @supports not (animation-timeline: view()) {
+    .prediction-fight {
+      opacity: 1;
+      translate: 0 0;
+      animation: none;
+    }
+  }
+</style>

--- a/src/components/PredictionHero.astro
+++ b/src/components/PredictionHero.astro
@@ -1,0 +1,56 @@
+---
+import ArrowRightIcon from '@/assets/svg/arrow-right.svg'
+import SectionDivider from '@/components/SectionDivider.astro'
+import PredictionStats from '@/components/PredictionStats.astro'
+
+interface Props {
+  firstBattleId?: string
+  totalCombats: number
+  totalVotes: number
+  closeBattles: number
+}
+
+const { firstBattleId, totalCombats, totalVotes, closeBattles } = Astro.props
+---
+
+<header class="predictions-hero mx-auto flex w-full max-w-5xl flex-col items-center text-center">
+  <SectionDivider size="lg" class="mb-8" />
+  <p
+    class="mb-3 font-cinzel text-[0.6rem] font-bold tracking-[0.45em] text-theme-gold/85 sm:text-xs"
+  >
+    LA VELADA VI
+  </p>
+  <h1
+    id="predictions-title"
+    class="font-cinzel text-4xl leading-[0.95] font-black tracking-[0.14em] text-theme-cream uppercase sm:text-5xl md:text-7xl"
+  >
+    Pronósticos
+  </h1>
+  <p
+    class="mt-5 max-w-3xl font-cinzel text-xs leading-7 font-medium tracking-[0.18em] text-balance text-white/62 sm:text-sm sm:tracking-[0.24em]"
+  >
+    Elige ganador en cada combate con una votación rápida, visual y pensada para comparar tendencias
+    de un vistazo.
+  </p>
+
+  <PredictionStats
+    totalCombats={totalCombats}
+    totalVotes={totalVotes}
+    closeBattles={closeBattles}
+  />
+
+  {
+    firstBattleId && (
+      <a
+        href={`#${firstBattleId}`}
+        class="prediction-jump group mt-8 inline-flex min-h-11 items-center justify-center gap-2 rounded-md border border-theme-gold/35 bg-theme-gold/10 px-5 py-3 font-cinzel text-[0.65rem] font-bold tracking-[0.28em] text-theme-cream transition duration-300 hover:border-theme-gold hover:bg-theme-gold/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
+      >
+        Ver cartelera
+        <ArrowRightIcon
+          class="size-3.5 transition-transform duration-300 group-hover:translate-x-1"
+          aria-hidden="true"
+        />
+      </a>
+    )
+  }
+</header>

--- a/src/components/PredictionOption.astro
+++ b/src/components/PredictionOption.astro
@@ -1,0 +1,215 @@
+---
+import CountryFlag from '@/components/CountryFlag.astro'
+import {
+  formatPredictionPercent,
+  formatPredictionVotes,
+  type PredictionOption,
+} from '@/consts/predictions'
+
+interface Props {
+  battleId: string
+  option: PredictionOption
+}
+
+const { battleId, option } = Astro.props
+---
+
+<button
+  type="button"
+  class="poll-option group relative min-h-[8.75rem] w-full overflow-hidden rounded-lg border border-white/10 bg-white/[0.035] p-0 text-left text-theme-cream transition duration-300 hover:-translate-y-0.5 hover:border-theme-gold/55 hover:bg-white/[0.06] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
+  data-battle-id={battleId}
+  data-boxer-id={option.boxer.id}
+  data-prediction-option
+  data-side={option.side}
+  aria-label={`Pronosticar victoria de ${option.boxer.name}`}
+  aria-pressed="false"
+  style={`--vote-share: ${option.percentage.toFixed(2)}%; --vote-color: ${option.color}; --vote-delay: ${option.delay}ms;`}
+>
+  <span aria-hidden="true" class="poll-vote-tag">Tu voto</span>
+
+  <span class="relative z-10 flex min-h-[8.75rem] items-stretch gap-3 p-3 sm:gap-4 sm:p-4">
+    <span
+      class="poll-portrait relative flex w-24 shrink-0 items-end justify-center overflow-hidden rounded-md border border-white/10 bg-theme-navy/60 sm:w-28"
+    >
+      <picture>
+        <source type="image/avif" srcset={option.heroImages.avif} />
+        <source type="image/webp" srcset={option.heroImages.webp} />
+        <img
+          src={option.heroImages.webp}
+          alt={`Recorte de ${option.boxer.name}`}
+          loading="lazy"
+          decoding="async"
+          width="320"
+          height="420"
+          class="poll-portrait-img h-full w-full object-cover object-top transition duration-500 group-hover:scale-105 group-hover:saturate-125"
+        />
+      </picture>
+    </span>
+
+    <span class="flex min-w-0 flex-1 flex-col justify-between gap-4 py-1">
+      <span>
+        <span
+          class="flex items-center gap-2 font-cinzel text-[0.6rem] font-bold tracking-[0.3em] text-white/60 sm:text-[0.68rem]"
+        >
+          <CountryFlag country={option.boxer.country} size={14} decorative />
+          {option.countryName}
+        </span>
+        <span
+          class="mt-2 block font-cinzel text-2xl leading-tight font-black tracking-[0.06em] text-balance text-theme-cream uppercase sm:text-3xl"
+        >
+          {option.boxer.name}
+        </span>
+      </span>
+
+      <span class="grid gap-2">
+        <span class="flex items-end justify-between gap-3">
+          <span class="font-cinzel text-[0.6rem] font-bold tracking-[0.28em] text-white/58">
+            Pronosticar
+          </span>
+          <span class="font-cinzel text-3xl leading-none font-black text-theme-cream sm:text-4xl">
+            {formatPredictionPercent(option.percentage)}
+          </span>
+        </span>
+        <span class="h-1.5 overflow-hidden rounded-full bg-black/34">
+          <span aria-hidden="true" class="poll-mini-bar block h-full rounded-full"></span>
+        </span>
+        <span
+          class="font-cinzel text-[0.58rem] font-semibold tracking-[0.24em] text-white/48 sm:text-[0.62rem]"
+        >
+          {formatPredictionVotes(option.votes)} apoyos
+        </span>
+      </span>
+    </span>
+  </span>
+</button>
+
+<style>
+  .poll-option::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: radial-gradient(
+      ellipse 52% 80% at 0% 0%,
+      color-mix(in srgb, var(--vote-color) 14%, transparent),
+      transparent 72%
+    );
+    opacity: 0.72;
+    transition: opacity 300ms ease;
+  }
+
+  .poll-option[data-side='b']::before {
+    background: radial-gradient(
+      ellipse 52% 80% at 100% 0%,
+      color-mix(in srgb, var(--vote-color) 12%, transparent),
+      transparent 74%
+    );
+  }
+
+  .poll-option[data-selected='true'] {
+    border-color: color-mix(in srgb, var(--color-theme-gold) 82%, transparent);
+    background: color-mix(in srgb, var(--color-theme-midnight) 72%, black);
+    box-shadow:
+      0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 34%, transparent),
+      0 0 32px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+  }
+
+  .poll-option[data-muted='true'] {
+    opacity: 0.58;
+    filter: saturate(0.72);
+  }
+
+  .poll-option[data-selected='true']::before,
+  .poll-option:hover::before,
+  .poll-option:focus-visible::before {
+    opacity: 1;
+  }
+
+  .poll-vote-tag {
+    position: absolute;
+    top: 0.85rem;
+    right: 0.85rem;
+    z-index: 20;
+    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 64%, transparent);
+    border-radius: 0.35rem;
+    background: color-mix(in srgb, var(--color-theme-midnight) 88%, black);
+    padding: 0.32rem 0.48rem;
+    color: var(--color-theme-gold);
+    font-family: var(--font-cinzel);
+    font-size: 0.52rem;
+    font-weight: 900;
+    letter-spacing: 0.22em;
+    opacity: 0;
+    transform: translateY(-0.4rem);
+    transition:
+      opacity 260ms ease,
+      transform 260ms ease;
+    text-transform: uppercase;
+  }
+
+  .poll-option[data-selected='true'] .poll-vote-tag {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .poll-portrait {
+    box-shadow:
+      inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+      0 12px 28px rgba(0, 0, 0, 0.28);
+  }
+
+  .poll-portrait::after {
+    position: absolute;
+    inset: auto 0 0;
+    height: 48%;
+    content: '';
+    background: linear-gradient(180deg, transparent, rgba(0, 0, 0, 0.72));
+  }
+
+  .poll-mini-bar {
+    width: var(--vote-share);
+    transform-origin: left;
+    animation: poll-grow 900ms cubic-bezier(0.19, 1, 0.22, 1) both;
+    animation-delay: calc(var(--vote-delay) + 120ms);
+    background: var(--vote-color);
+    box-shadow: 0 0 16px color-mix(in srgb, var(--vote-color) 42%, transparent);
+  }
+
+  .poll-option[data-side='b'] .poll-mini-bar {
+    margin-left: auto;
+    transform-origin: right;
+    background: var(--vote-color);
+  }
+
+  @keyframes poll-grow {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+
+  @media (max-width: 639px) {
+    .poll-option {
+      min-height: 8rem;
+    }
+
+    .poll-option > span:last-child {
+      min-height: 8.75rem;
+    }
+
+    .poll-portrait {
+      width: 5.3rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .poll-option,
+    .poll-mini-bar,
+    .poll-portrait-img {
+      animation: none;
+      transition: none;
+    }
+  }
+</style>

--- a/src/components/PredictionStats.astro
+++ b/src/components/PredictionStats.astro
@@ -1,0 +1,66 @@
+---
+import { formatPredictionVotes } from '@/consts/predictions'
+
+interface Props {
+  totalCombats: number
+  totalVotes: number
+  closeBattles: number
+}
+
+const { totalCombats, totalVotes, closeBattles } = Astro.props
+---
+
+<dl class="prediction-stats mt-9 grid w-full max-w-3xl grid-cols-3 border-y border-theme-gold/20">
+  <div>
+    <dt>Combates</dt>
+    <dd>{totalCombats}</dd>
+  </div>
+  <div>
+    <dt>Apoyos</dt>
+    <dd>{formatPredictionVotes(totalVotes)}</dd>
+  </div>
+  <div>
+    <dt>Ajustados</dt>
+    <dd>{closeBattles}</dd>
+  </div>
+</dl>
+
+<style>
+  .prediction-stats div {
+    padding: 0.85rem 0.35rem;
+    border-inline-end: 1px solid color-mix(in srgb, var(--color-theme-gold) 18%, transparent);
+  }
+
+  .prediction-stats div:last-child {
+    border-inline-end: 0;
+  }
+
+  .prediction-stats dt {
+    margin-bottom: 0.35rem;
+    font-family: var(--font-cinzel);
+    font-size: 0.58rem;
+    font-weight: 700;
+    letter-spacing: 0.24em;
+    color: rgba(255, 255, 255, 0.48);
+    text-transform: uppercase;
+  }
+
+  .prediction-stats dd {
+    font-family: var(--font-cinzel);
+    font-size: 1.65rem;
+    font-weight: 900;
+    line-height: 1;
+    color: var(--color-theme-cream);
+  }
+
+  @media (max-width: 639px) {
+    .prediction-stats dt {
+      font-size: 0.5rem;
+      letter-spacing: 0.18em;
+    }
+
+    .prediction-stats dd {
+      font-size: 1.25rem;
+    }
+  }
+</style>

--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -1,0 +1,62 @@
+<script>
+  import { $, $$ } from '@/lib/dom-selector'
+
+  const PREDICTION_STORAGE_KEY = 'velada-vi-prediction-votes'
+  let predictionsAbort: AbortController | null = null
+
+  function readStoredVotes(): Record<string, string> {
+    try {
+      const rawVotes = window.localStorage.getItem(PREDICTION_STORAGE_KEY)
+      if (!rawVotes) return {}
+
+      const parsedVotes = JSON.parse(rawVotes)
+      return parsedVotes && typeof parsedVotes === 'object' ? parsedVotes : {}
+    } catch {
+      return {}
+    }
+  }
+
+  function writeStoredVotes(votes: Record<string, string>) {
+    window.localStorage.setItem(PREDICTION_STORAGE_KEY, JSON.stringify(votes))
+  }
+
+  function setBattleVote(battleId: string, boxerId: string) {
+    const fight = $<HTMLElement>(`[data-prediction-fight][data-battle-id="${battleId}"]`)
+    if (!fight) return
+
+    $$<HTMLButtonElement>('[data-prediction-option]', fight).forEach((option) => {
+      const isSelected = option.dataset.boxerId === boxerId
+      option.dataset.selected = String(isSelected)
+      option.dataset.muted = String(!isSelected)
+      option.setAttribute('aria-pressed', String(isSelected))
+    })
+  }
+
+  function setupPredictionVotes() {
+    predictionsAbort?.abort()
+    predictionsAbort = new AbortController()
+
+    const storedVotes = readStoredVotes()
+    Object.entries(storedVotes).forEach(([battleId, boxerId]) => {
+      setBattleVote(battleId, boxerId)
+    })
+
+    $$<HTMLButtonElement>('[data-prediction-option]').forEach((option) => {
+      option.addEventListener(
+        'click',
+        () => {
+          const { battleId, boxerId } = option.dataset
+          if (!battleId || !boxerId) return
+
+          const nextVotes = readStoredVotes()
+          nextVotes[battleId] = boxerId
+          writeStoredVotes(nextVotes)
+          setBattleVote(battleId, boxerId)
+        },
+        { signal: predictionsAbort?.signal },
+      )
+    })
+  }
+
+  document.addEventListener('astro:page-load', setupPredictionVotes)
+</script>

--- a/src/components/PredictionsBackground.astro
+++ b/src/components/PredictionsBackground.astro
@@ -1,0 +1,58 @@
+<picture aria-hidden="true" class="pointer-events-none absolute inset-0 -z-30 block">
+  <source
+    type="image/avif"
+    srcset="/background-1280.avif 1280w, /background-2048.avif 2048w, /background.avif 3840w"
+    sizes="100vw"
+  />
+  <source
+    type="image/webp"
+    srcset="/background-1280.webp 1280w, /background-2048.webp 2048w, /background.webp 3840w"
+    sizes="100vw"
+  />
+  <img
+    src="/background.webp"
+    srcset="/background-1280.webp 1280w, /background-2048.webp 2048w, /background.webp 3840w"
+    sizes="100vw"
+    alt=""
+    role="presentation"
+    class="h-full w-full object-cover object-center opacity-45"
+    fetchpriority="high"
+    decoding="async"
+  />
+</picture>
+
+<div aria-hidden="true" class="predictions-backdrop absolute inset-0 -z-20"></div>
+<div aria-hidden="true" class="predictions-grid absolute inset-0 -z-10"></div>
+
+<style>
+  .predictions-backdrop {
+    background:
+      linear-gradient(180deg, rgba(10, 16, 36, 0.78) 0%, rgba(10, 16, 36, 0.92) 36%, #050816 100%),
+      radial-gradient(
+        ellipse 62% 38% at 18% 18%,
+        color-mix(in srgb, #c63030 22%, transparent),
+        transparent 62%
+      ),
+      radial-gradient(
+        ellipse 54% 34% at 82% 8%,
+        color-mix(in srgb, var(--color-theme-gold) 16%, transparent),
+        transparent 64%
+      );
+  }
+
+  .predictions-grid {
+    background-image:
+      linear-gradient(
+        color-mix(in srgb, var(--color-theme-gold) 12%, transparent) 1px,
+        transparent 1px
+      ),
+      linear-gradient(
+        90deg,
+        color-mix(in srgb, var(--color-theme-gold) 10%, transparent) 1px,
+        transparent 1px
+      );
+    background-size: 36px 36px;
+    mask-image: linear-gradient(180deg, black 0%, black 58%, transparent 100%);
+    opacity: 0.22;
+  }
+</style>

--- a/src/consts/predictions.ts
+++ b/src/consts/predictions.ts
@@ -1,0 +1,119 @@
+import { battles, type Battle } from '@/consts/battles'
+import {
+  BOXERS_BY_ID,
+  COUNTRY_NAMES,
+  getBoxerHeroImages,
+  type Boxer,
+  type BoxerImageVariants,
+} from '@/consts/boxers'
+
+const compactFormatter = new Intl.NumberFormat('es-ES', {
+  notation: 'compact',
+  maximumFractionDigits: 1,
+})
+
+const percentFormatter = new Intl.NumberFormat('es-ES', {
+  maximumFractionDigits: 1,
+})
+
+export type PredictionSide = 'a' | 'b'
+
+export interface PredictionOption {
+  boxer: Boxer
+  countryName: string
+  heroImages: BoxerImageVariants
+  percentage: number
+  votes: number
+  side: PredictionSide
+  color: string
+  delay: number
+}
+
+export interface PredictionBattle {
+  battle: Battle
+  options: readonly [PredictionOption, PredictionOption]
+  totalVotes: number
+  leader: PredictionOption
+  isClose: boolean
+}
+
+export function formatPredictionVotes(votes: number) {
+  return compactFormatter.format(votes)
+}
+
+export function formatPredictionPercent(percentage: number) {
+  return `${percentFormatter.format(percentage)}%`
+}
+
+function getAudienceScore(boxer: Boxer) {
+  return boxer.socials.reduce(
+    (total, social) => total + (social.followers ?? 0) + (social.monthlyListeners ?? 0),
+    0,
+  )
+}
+
+function getSeedScore(value: string) {
+  return Array.from(value).reduce((total, char, index) => {
+    return total + char.charCodeAt(0) * (index + 3)
+  }, 0)
+}
+
+function getPreviewVotes(boxer: Boxer, battle: Battle, sideIndex: number) {
+  const audience = Math.max(getAudienceScore(boxer), 180_000)
+  const socialWeight = Math.sqrt(audience) * 12
+  const legacyWeight = boxer.previousVeladaWins.length * 2_400
+  const seedWeight = (getSeedScore(`${battle.id}-${boxer.id}`) % 19) * 210
+  const sidePush = sideIndex === 0 ? 950 : 1_250
+
+  return Math.round(socialWeight + legacyWeight + seedWeight + sidePush)
+}
+
+const sideStyles: Record<PredictionSide, { color: string }> = {
+  a: {
+    color: '#c63030',
+  },
+  b: {
+    color: 'var(--color-theme-gold)',
+  },
+}
+
+export const predictionBattles: PredictionBattle[] = battles.map((battle, battleIndex) => {
+  const [boxerAId, boxerBId] = battle.boxerIds
+  const boxers = [BOXERS_BY_ID[boxerAId], BOXERS_BY_ID[boxerBId]] as const
+  const voteCounts = boxers.map((boxer, sideIndex) => getPreviewVotes(boxer, battle, sideIndex))
+  const totalVotes = voteCounts.reduce((total, votes) => total + votes, 0)
+
+  const options = boxers.map((boxer, sideIndex) => {
+    const side = sideIndex === 0 ? 'a' : 'b'
+    const style = sideStyles[side]
+
+    return {
+      boxer,
+      countryName: COUNTRY_NAMES[boxer.country] ?? boxer.country,
+      heroImages: getBoxerHeroImages(boxer),
+      percentage: (voteCounts[sideIndex] / totalVotes) * 100,
+      votes: voteCounts[sideIndex],
+      side,
+      color: style.color,
+      delay: battleIndex * 70 + sideIndex * 90,
+    } satisfies PredictionOption
+  }) as [PredictionOption, PredictionOption]
+
+  const leader = options[0].percentage >= options[1].percentage ? options[0] : options[1]
+  const difference = Math.abs(options[0].percentage - options[1].percentage)
+
+  return {
+    battle,
+    options,
+    totalVotes,
+    leader,
+    isClose: difference <= 8,
+  }
+})
+
+export const totalPreviewVotes = predictionBattles.reduce(
+  (total, prediction) => total + prediction.totalVotes,
+  0,
+)
+
+export const closeBattles = predictionBattles.filter(({ isClose }) => isClose).length

--- a/src/pages/pronosticos.astro
+++ b/src/pages/pronosticos.astro
@@ -1,66 +1,50 @@
 ---
+import PredictionFight from '@/components/PredictionFight.astro'
+import PredictionHero from '@/components/PredictionHero.astro'
+import PredictionVoteController from '@/components/PredictionVoteController.astro'
+import PredictionsBackground from '@/components/PredictionsBackground.astro'
+import { closeBattles, predictionBattles, totalPreviewVotes } from '@/consts/predictions'
 import Layout from '@/layouts/Layout.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
 
 const title = 'Pronósticos - La Velada del Año VI'
 const description =
-  'La página de pronósticos de La Velada del Año VI estará disponible más adelante para votar los resultados de los combates.'
+  'Pronostica los ganadores de los combates de La Velada del Año VI con una interfaz de votación por barras.'
 const canonical = 'https://www.infolavelada.com/pronosticos'
+const firstBattleId = predictionBattles[0]?.battle.id
 
 export const prerender = true
 ---
 
-<Layout
-  title={title}
-  description={description}
-  canonical={canonical}
-  robots="noindex, nofollow"
->
+<Layout title={title} description={description} canonical={canonical} robots="noindex, nofollow">
   <section
-    class="relative isolate flex min-h-screen w-full items-center justify-center overflow-hidden px-4 py-24 text-center text-theme-cream sm:px-6"
+    class="predictions-page relative isolate w-full overflow-x-clip bg-theme-midnight px-4 pt-24 pb-20 text-theme-cream sm:px-6 sm:pt-32 sm:pb-24 md:pt-36"
+    aria-labelledby="predictions-title"
   >
-    <div
-      aria-hidden="true"
-      class="absolute inset-0 -z-20 bg-[radial-gradient(circle_at_50%_20%,rgba(199,168,107,0.24),transparent_32%),linear-gradient(180deg,var(--color-theme-midnight)_0%,#050816_100%)]"
-    >
-    </div>
-    <div
-      aria-hidden="true"
-      class="absolute left-1/2 top-1/2 -z-10 size-[22rem] -translate-x-1/2 -translate-y-1/2 rounded-full border border-theme-gold/20 shadow-[0_0_80px_rgba(199,168,107,0.14)] sm:size-[34rem]"
-    >
-    </div>
+    <PredictionsBackground />
 
-    <div class="mx-auto flex w-full max-w-3xl flex-col items-center">
-      <p class="mb-5 text-xs font-bold tracking-[0.45em] text-theme-gold/85 sm:text-sm">
-        PRÓXIMAMENTE
-      </p>
-      <h1
-        class="font-fantasy text-6xl leading-[0.88] tracking-wide text-theme-cream drop-shadow-[0_12px_35px_rgba(0,0,0,0.55)] sm:text-8xl md:text-9xl"
-      >
-        Pronósticos
-      </h1>
-      <p class="mt-7 max-w-2xl text-balance text-base leading-7 tracking-wide text-white/75 sm:text-lg">
-        Estamos preparando una página para que puedas votar tus predicciones de los combates.
-        Por ahora la votación está desactivada.
-      </p>
+    <div class="mx-auto flex w-full max-w-7xl flex-col">
+      <PredictionHero
+        firstBattleId={firstBattleId}
+        totalCombats={predictionBattles.length}
+        totalVotes={totalPreviewVotes}
+        closeBattles={closeBattles}
+      />
 
-      <div
-        class="mt-10 rounded-2xl border border-theme-gold/25 bg-theme-midnight/70 px-6 py-5 shadow-[0_18px_60px_rgba(0,0,0,0.28)] backdrop-blur backdrop-saturate-150 backdrop-contrast-125 sm:px-8"
-      >
-        <p class="text-sm font-semibold tracking-[0.28em] text-theme-gold/90">
-          EL RING TODAVÍA ESTÁ CERRADO
-        </p>
-      </div>
-
-      <a
-        href="/"
-        class="mt-10 inline-flex min-h-12 items-center justify-center rounded-lg bg-theme-cream px-8 py-4 text-sm font-bold tracking-widest text-theme-midnight transition-all duration-300 ease-out hover:rotate-[2deg] hover:bg-white active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-      >
-        Volver al inicio
-      </a>
+      <ol class="prediction-list mt-14 grid gap-5 sm:mt-16 md:gap-6" role="list">
+        {predictionBattles.map((prediction) => <PredictionFight prediction={prediction} />)}
+      </ol>
     </div>
   </section>
+
+  <PredictionVoteController />
   <Sponsors />
   <Footer />
 </Layout>
+
+<style>
+  .predictions-page {
+    min-height: 100svh;
+  }
+</style>


### PR DESCRIPTION
## Type

- [x] feat

## Related Issue

Refs #1496

## Changes

Parte **front** (maquetación/UI) separada de #1501. Añade la interfaz de la página de pronósticos, sin lógica de autenticación (esa va en una PR aparte de backend):

- `src/components/PredictionHero.astro`, `PredictionFight.astro`, `PredictionOption.astro`, `PredictionStats.astro`, `PredictionsBackground.astro`: tarjetas de combate con barras de votos en vivo y resumen.
- `src/components/PredictionVoteController.astro`: selección de voto en cliente (persistida en `localStorage`).
- `src/consts/predictions.ts`: deriva los porcentajes de voto de `battles`/`boxers` (datos de preview deterministas, sin backend).
- `src/pages/pronosticos.astro`: página de pronósticos (estática, `prerender`).
- `src/components/HeaderNav.astro`: habilita el enlace PRONÓSTICOS.

## Notas

- Esta PR es solo UI; la votación se guarda en `localStorage` (sin persistencia ni voto único todavía).
- El inicio de sesión con Twitch/Google (Better Auth) va en una PR de backend separada que se apila sobre esta.
- Build de Astro verificado en local (todas las páginas se generan, incluida `/pronosticos`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Predictions section is now live and accessible in the navigation menu.
  * Users can vote on boxing match predictions with an interactive voting interface.
  * Votes are persisted locally and reflected in real-time visual feedback.
  * Added predictions page displaying combats, total votes, and close-match statistics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->