### PR TITLE
Fix/hero layout low height

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -137,7 +137,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         </div>
 
       <ul
-        class="boxer-default-info animate-fade-in-up animate-delay-500 flex flex-col items-center justify-center gap-1 -mt-12"
+        class="boxer-default-info animate-fade-in-up animate-delay-500 flex flex-col items-center justify-center gap-1 -mt-8 md:-mt-12"
       >
         <li class="flex items-baseline">
           <time
@@ -168,7 +168,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
                         after:h-[1px] after:w-full after:bg-current
                         after:scale-x-0 after:origin-left
                         after:transition-transform after:duration-300
-                        hover:after:scale-x-100 focus-visible:after:scale-x-100"
+                        hover:after:scale-x-100 focus-visible:after:scale-x-100 px-4"
             >
               ESTADIO DE LA CARTUJA, SEVILLA
             </a>
@@ -255,7 +255,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     </div>
   </div>
 
-  <div class="boxer-selector-foot mt-auto flex w-full shrink-0 flex-col items-center gap-3">
+  <div class="boxer-selector-foot mt-auto flex w-full shrink-0 flex-col items-center gap-1.5 md:gap-3">
     <div
       class="boxer-cta-bar relative z-20 flex w-full flex-col items-center gap-3 px-4 pt-2 transition-opacity duration-300 ease-out md:gap-4 md:pt-4"
     >
@@ -443,6 +443,10 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   }
 
   @media (max-width: 767px) {
+    [data-default-panel]{
+      justify-content: center;
+    }
+
     [data-boxer-selector][data-state='boxer'] [data-default-panel] {
       opacity: 1;
       pointer-events: auto;
@@ -471,7 +475,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     animation: boxer-default-logo-float 6s ease-in-out infinite;
   }
 
-  @media screen and (height <= 767px) {
+  @media screen and (height <= 767px) and (width >= 768px) {
     [data-boxer-selector]{
       min-height: 590px;
     }

--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -119,7 +119,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     >
       <div class="boxer-default-aura pointer-events-none absolute inset-0 -z-1" aria-hidden="true"></div>
 
-      <div class="boxer-default-lockup flex w-full max-w-full flex-col items-center px-4">
+      <div class="boxer-default-lockup flex w-full max-w-full flex-col items-center">
         <div class="animate-blurred-fade-in animate-delay-300 relative leading-none">
           <picture class="block">
             <source srcset="/logo.avif" type="image/avif" />
@@ -137,7 +137,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         </div>
 
       <ul
-        class="boxer-default-info boxer-default-info-spacing animate-fade-in-up animate-delay-500 flex flex-col items-center justify-center gap-1"
+        class="boxer-default-info animate-fade-in-up animate-delay-500 flex flex-col items-center justify-center gap-1 -mt-12"
       >
         <li class="flex items-baseline">
           <time
@@ -182,7 +182,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     <div
       data-boxer-panel
       aria-hidden="true"
-      class="boxer-panel relative flex w-full flex-col items-center -mb-10"
+      class="boxer-panel relative flex w-full flex-col items-center"
     >
       <span
         aria-hidden="true"
@@ -255,7 +255,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     </div>
   </div>
 
-  <div class="boxer-selector-foot mt-auto flex w-full shrink-0 flex-col items-center gap-4 md:gap-6">
+  <div class="boxer-selector-foot mt-auto flex w-full shrink-0 flex-col items-center gap-3">
     <div
       class="boxer-cta-bar relative z-20 flex w-full flex-col items-center gap-3 px-4 pt-2 transition-opacity duration-300 ease-out md:gap-4 md:pt-4"
     >
@@ -268,8 +268,8 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         <span class="h-px w-10 bg-linear-to-l from-transparent to-theme-gold/55 sm:w-20"></span>
       </div>
 
-      <p class="boxer-default-cta mb-2 text-center font-cinzel text-sm font-bold tracking-[0.3em] text-theme-cream sm:text-base">
-        ¡SELECCIONA TU BOXEADOR O BOXEADORA!
+      <p class="boxer-default-cta font-cinzel text-sm font-bold tracking-[0.3em] text-theme-cream uppercase">
+        ¡Selecciona tu boxeador o boxeadora!
       </p>
     </div>
 
@@ -464,17 +464,30 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     pointer-events: none;
   }
 
-  /* Lockup: eye-level offset here only. Logo → fechas: flex gap + .boxer-default-info-spacing. */
-  .boxer-default-lockup {
-    gap: clamp(0.625rem, 2vw, 1.125rem);
-    padding-top: clamp(2.5rem, 11vh, 7rem);
-  }
-
   .boxer-default-logo {
     filter:
       drop-shadow(0 12px 30px color-mix(in srgb, var(--color-theme-gold) 22%, transparent))
       drop-shadow(0 2px 0 rgba(0, 0, 0, 0.25));
     animation: boxer-default-logo-float 6s ease-in-out infinite;
+  }
+
+  @media screen and (height <= 767px) {
+    [data-boxer-selector]{
+      min-height: 590px;
+    }
+
+    .boxer-default-logo{
+      width: 24vw;
+    }
+
+    .boxer-default-panel{
+      margin-top: -2rem;
+    }
+
+    .boxer-default-cta{
+      font-size: 0.75rem;
+      max-width: 50ch;
+    }
   }
 
   .boxer-default-aura {
@@ -488,44 +501,11 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     mask-image: linear-gradient(to bottom, black 0%, black 80%, transparent 100%);
   }
 
-  .boxer-default-info-spacing {
-    margin-top: -0.75rem;
-  }
-
-  @media (min-width: 640px) {
-    .boxer-default-info-spacing {
-      margin-top: -1rem;
-    }
-  }
-
-  @media (min-width: 768px) {
-    .boxer-default-info-spacing {
-      margin-top: -1.25rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .boxer-default-info-spacing {
-      margin-top: -1.5rem;
-    }
-  }
-
   .boxer-default-info {
     text-shadow:
       0 0 1px color-mix(in srgb, var(--color-theme-cream) 60%, transparent),
       0 2px 14px color-mix(in srgb, var(--color-theme-gold) 45%, transparent),
       0 0 24px color-mix(in srgb, var(--color-theme-midnight) 70%, transparent);
-  }
-
-  @media (max-height: 920px) {
-    .boxer-default-lockup {
-      padding-top: clamp(2rem, 8vh, 4.25rem);
-      gap: 0.5rem;
-    }
-
-    .boxer-default-info-spacing {
-      margin-top: -0.5rem;
-    }
   }
 
   /* La cuadrícula del selector entra escalonada con un delay base de


### PR DESCRIPTION
Se ajusta el responsive para dispositivos con viewport de baja altura, restableciendo la estructura de layout existente antes de la PR #1486.

Antes desktop: 
<img width="1877" height="986" alt="image" src="https://github.com/user-attachments/assets/cd95eb84-4f66-4027-9d78-a1c2b3c38d12" />

Despúes desktop:
<img width="1875" height="991" alt="image" src="https://github.com/user-attachments/assets/1e2aa88e-3b25-41cd-ac70-6bced15d1295" />

Antes desktop viewport de baja altura:
<img width="1278" height="719" alt="image" src="https://github.com/user-attachments/assets/6b623075-ae78-45ac-afb4-5e89946fa698" />

Despúes desktop viewport de baja altura:
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/44810b9f-e6ff-45f9-bda2-5373d47dee3d" />