### PR TITLE
Active links header desktop

### DIFF
--- a/src/components/HeaderNav.astro
+++ b/src/components/HeaderNav.astro
@@ -13,6 +13,9 @@ const NAV_ITEMS = [
 
 const shouldReloadNavItem = (href: string) => Astro.url.pathname === '/' && href === '/boxeadores'
 
+const isActiveNavItem = (href: string) =>
+  Astro.url.pathname === href || Astro.url.pathname.startsWith(href + '/')
+
 const desktopColClass = 'flex flex-col items-center justify-center gap-1 px-3 sm:px-4'
 const desktopLabelClass =
   'relative inline-flex items-center font-cinzel text-[0.65rem] font-bold leading-none tracking-[0.25em] sm:text-xs'
@@ -53,8 +56,13 @@ const mobileLinkClass =
               <a
                 href={item.href}
                 data-astro-reload={shouldReloadNavItem(item.href) ? true : undefined}
+                aria-current={isActiveNavItem(item.href) ? 'page' : undefined}
                 class:list={[desktopLabelClass, desktopLinkClass]}
               >
+                <span aria-hidden="true" class="pointer-events-none absolute top-1 left-1 size-2 border-t border-l border-theme-gold/0 transition duration-300 [a[aria-current=page]_&]:border-theme-gold/80" />
+                <span aria-hidden="true" class="pointer-events-none absolute top-1 right-1 size-2 border-t border-r border-theme-gold/0 transition duration-300 [a[aria-current=page]_&]:border-theme-gold/80" />
+                <span aria-hidden="true" class="pointer-events-none absolute bottom-1 left-1 size-2 border-b border-l border-theme-gold/0 transition duration-300 [a[aria-current=page]_&]:border-theme-gold/80" />
+                <span aria-hidden="true" class="pointer-events-none absolute bottom-1 right-1 size-2 border-b border-r border-theme-gold/0 transition duration-300 [a[aria-current=page]_&]:border-theme-gold/80" />
                 <span aria-hidden="true" class={desktopUnderlineClass} />
                 {item.label}
               </a>
@@ -82,6 +90,7 @@ const mobileLinkClass =
               <a
                 href={item.href}
                 data-astro-reload={shouldReloadNavItem(item.href) ? true : undefined}
+                aria-current={isActiveNavItem(item.href) ? 'page' : undefined}
                 data-mobile-menu-link
                 class={mobileLinkClass}
               >
@@ -94,3 +103,16 @@ const mobileLinkClass =
     </nav>
   )
 }
+
+<style>
+  a[aria-current='page'] {
+    color: var(--color-theme-cream);
+    padding: 0.6rem 1.1rem;
+  }
+
+  /* Enlace activo en mobile: borde dorado más vivo. */
+  a[aria-current='page'].flex {
+    border-color: color-mix(in srgb, var(--color-theme-gold) 75%, transparent);
+    color: var(--color-theme-cream);
+  }
+</style>


### PR DESCRIPTION
…ication

> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

<!-- List each file changed with a one-line description. -->

- `src/components/HeaderNav.astro`: Añadido recuadro en los enlaces del Header cuando el usuario está en la página correspondiente

## Screenshots

<!-- Delete if not applicable. -->

| View | Before | After |
|------|--------|-------|
| Desktop |<img width="1423" height="67" alt="image" src="https://github.com/user-attachments/assets/2bc5f4e9-54e8-47df-b417-ef7535e86ce8" />| <img width="1415" height="56" alt="image" src="https://github.com/user-attachments/assets/973c9e73-111d-4cc8-8046-0a9afdd6b8f7" />|

## Checklist

- [ ] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [ ] No console errors
- [ ] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Header navigation now clearly highlights the currently active page on both desktop and mobile views
  * Enhanced visual and accessibility indicators for navigation links to help users easily identify their current location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->