### PR TITLE
fix(hero): adjust background opacity and saturation for improved cont…

### DIFF
--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -10,7 +10,7 @@ const timestamp = EVENT_DATE.getTime()
     class="relative w-full overflow-hidden bg-theme-midnight"
     aria-label="Presentación de La Velada del Año VI"
   >
-    <picture data-hero-background class="absolute inset-0 z-0">
+    <picture data-hero-background class="absolute inset-0 opacity-90 saturate-130">
       <source
         type="image/avif"
         srcset="/background-1280.avif 1280w, /background-2048.avif 2048w, /background.avif 3840w"


### PR DESCRIPTION
Se ajusta la imagen de fondo del hero-background, reduciendo su opacidad en un 10% y aumentando su saturación en un 30%, con el objetivo de mejorar el contraste con los elementos de contenido.

Este ajuste incrementa un poco la legibilidad de los textos superpuestos, especialmente el mensaje ubicado en la parte inferior: ¡Selecciona tu boxeador o boxeadora!

Antes:
<img width="1876" height="982" alt="image" src="https://github.com/user-attachments/assets/42537ab2-10d7-4f1d-8fc9-99b7ffb79963" />

Despúes:
<img width="1875" height="984" alt="image" src="https://github.com/user-attachments/assets/0c6ec7c7-d367-4bdc-b1e3-2250b20fadaf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilos**
  * Actualización visual de la sección principal con ajustes en opacidad y saturación del fondo para mejorar la presentación visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->