### PR TITLE
style(BoxerSelector): improve text contrast for better readability

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -268,7 +268,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         <span class="h-px w-10 bg-linear-to-l from-transparent to-theme-gold/55 sm:w-20"></span>
       </div>
 
-      <p class="boxer-default-cta font-cinzel text-sm font-bold tracking-[0.3em] text-theme-cream uppercase">
+      <p class="boxer-default-cta font-cinzel text-sm font-bold tracking-[0.3em] text-[color-mix(var(--color-theme-cream),white_30%)] uppercase">
         ¡Selecciona tu boxeador o boxeadora!
       </p>
     </div>


### PR DESCRIPTION
Se mejora el contraste del CTA del componente BoxerSelector mediante una variante un 30% más clara del color --color-theme-cream.

Antes:
<img width="506" height="43" alt="image" src="https://github.com/user-attachments/assets/b7916cf0-278b-4bba-99f7-55bcb93b5f8e" />

Despúes:
<img width="506" height="37" alt="image" src="https://github.com/user-attachments/assets/953a828b-2781-4c6a-9ac4-5bb453f6fac9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilo**
  * Se actualizó el esquema de color del botón de llamada a la acción en el selector de boxeadores. El nuevo color mejora significativamente el contraste visual y la legibilidad del elemento interactivo, proporcionando una mejor experiencia visual para los usuarios y manteniendo la consistencia con el diseño actual de la aplicación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->