### PR TITLE
chore(sponsors): widen dom-selector context to Element

### DIFF
--- a/src/lib/dom-selector.ts
+++ b/src/lib/dom-selector.ts
@@ -7,9 +7,9 @@
  * @param context
  * @returns  HTMLElement
  */
-export const $ = <T extends HTMLElement>(
+export const $ = <T extends Element>(
   selector: string,
-  context: Document | HTMLElement = document,
+  context: Document | Element = document,
 ) => {
   const element = context.querySelector<T>(selector)
   return element
@@ -23,9 +23,9 @@ export const $ = <T extends HTMLElement>(
  * @param context
  * @returns  NodeList
  */
-export const $$ = <T extends HTMLElement>(
+export const $$ = <T extends Element>(
   selector: string,
-  context: Document | HTMLElement = document,
+  context: Document | Element = document,
 ) => {
   const elements = context.querySelectorAll<T>(selector)
   return elements


### PR DESCRIPTION
## Summary

Widens the `$` and `$$` selector helpers to accept any `Element` as context, not just `HTMLElement`.

This unblocks the upcoming sponsor motion PRs that pass Motion-driven SVG elements and grid containers as context.

## Changes

- `src/lib/dom-selector.ts`: generic constraint changed from `HTMLElement` to `Element` and context parameter widened accordingly.

## Related

- Split from #1467.
- PR-3 and PR-4 in this split depend on this change.

## Verification

- [x] Type change is backwards-compatible for existing `HTMLElement` callers.
- [x] No runtime behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Ampliada la compatibilidad de selectores DOM para trabajar con una variedad más genérica de tipos de elementos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->