### PR TITLE
feat(components): add hideDivider prop to SectionHeader

### DIFF
--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -10,6 +10,7 @@ interface Props {
   titleClass?: string
   subtitleClass?: string
   eyebrowClass?: string
+  hideDivider?: boolean
 }
 
 const {
@@ -21,10 +22,15 @@ const {
   titleClass = 'mb-3',
   subtitleClass = 'mb-10 max-w-xl tracking-[0.25em] sm:text-sm',
   eyebrowClass,
+  hideDivider,
 } = Astro.props
 ---
 
-<SectionDivider class:list={['mb-8', dividerClass]} />
+{
+  !hideDivider && (
+    <SectionDivider class:list={['mb-8', dividerClass]} />
+  )
+}
 
 {
   eyebrow && (


### PR DESCRIPTION
## Summary

Adds an optional `hideDivider` prop to `SectionHeader` so composed sections can opt out of the diamond mark divider when they already render their own separator.

## Changes

- `src/components/SectionHeader.astro`:
  - Adds `hideDivider?: boolean` to the `Props` interface.
  - Wraps `<SectionDivider>` in `{!hideDivider && (...)}`.

## Related

- Split from #1467.
- The `Sponsors` section will consume this prop in PR-3 to avoid a duplicated top divider.

## Verification

- [x] Existing `<SectionHeader>` usages remain unchanged and still render the divider.
- [x] Passing `hideDivider={true}` suppresses the divider.
- [x] No visual regressions in other sections.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas Características**
  * Se añadió una nueva opción para ocultar el divisor visual en los encabezados de sección, proporcionando mayor flexibilidad en el diseño y presentación del contenido de las páginas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->