### PR TITLE
feat(venue): replace hero map link with smooth scroll to venue section

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -160,15 +160,14 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
             class="font-cinzel text-xs font-bold tracking-[0.28em] text-theme-cream sm:text-sm"
           >
             <a
-              href="https://maps.app.goo.gl/73mfDNVvhK3Y5Kq66"
-              target="_blank"
-              rel="noopener noreferrer"
-              class="relative inline-block
+              href="#sede"
+              class="relative inline-block cursor-pointer
                         after:content-[''] after:absolute after:left-0 after:-bottom-1
                         after:h-[1px] after:w-full after:bg-current
                         after:scale-x-0 after:origin-left
                         after:transition-transform after:duration-300
                         hover:after:scale-x-100 focus-visible:after:scale-x-100 px-4"
+              onclick="event.preventDefault();document.getElementById('sede')?.scrollIntoView({behavior:window.matchMedia('(prefers-reduced-motion:reduce)').matches?'instant':'smooth'})"
             >
               ESTADIO DE LA CARTUJA, SEVILLA
             </a>


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

N/A

## Changes

- src/components/BoxerSelector.astro: Replace the external Google Maps shortlink (\"ESTADIO DE LA CARTUJA, SEVILLA\") in the hero with an internal smooth scroll anchor to #sede. Instead of sending users away from the site to open a map link, clicking the venue name now smoothly scrolls to the existing venue section with the embedded interactive map. Respects prefers-reduced-motion: reduce.

## Dependencies

- Added: None
- Removed: None

## Screenshots

N/A — no visual diff.

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None