### PR TITLE
feat(venue): replace map shortlinks with universal URLs

### DIFF
--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -204,7 +204,7 @@ import SectionHeader from '@/components/SectionHeader.astro'
            <div class="flex flex-col items-center gap-4">
 
           <a
-            href="https://maps.app.goo.gl/73mfDNVvhK3Y5Kq66"
+            href="https://www.google.com/maps/search/?api=1&query=Estadio+de+La+Cartuja,Sevilla,Spain"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 rounded border border-theme-gold/35 px-4 py-[0.6rem] font-cinzel text-[0.65rem] font-bold tracking-[0.25em] text-theme-gold uppercase no-underline transition-all duration-300 outline-none hover:-translate-y-px hover:border-theme-gold hover:bg-theme-gold/10 hover:text-theme-cream focus-visible:-translate-y-px focus-visible:border-theme-gold focus-visible:bg-theme-gold/10 focus-visible:text-theme-cream focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight motion-reduce:transition-none motion-reduce:hover:translate-y-0"
@@ -226,7 +226,7 @@ import SectionHeader from '@/components/SectionHeader.astro'
             Ver en Google Maps
           </a>
           <a
-            href="https://maps.apple/p/qe5msb_Npnw-HK"
+            href="http://maps.apple.com/?q=Estadio+de+La+Cartuja,Sevilla,Spain"
             target="_blank"
             rel="noopener noreferrer"
             class="inline-flex items-center gap-2 rounded border border-theme-gold/35 px-4 py-[0.6rem] font-cinzel text-[0.65rem] font-bold tracking-[0.25em] text-theme-gold uppercase no-underline transition-all duration-300 outline-none hover:-translate-y-px hover:border-theme-gold hover:bg-theme-gold/10 hover:text-theme-cream focus-visible:-translate-y-px focus-visible:border-theme-gold focus-visible:bg-theme-gold/10 focus-visible:text-theme-cream focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight motion-reduce:transition-none motion-reduce:hover:translate-y-0"


### PR DESCRIPTION
## Cambios
Replace \goo.gl\ and \maps.apple/p/\ shortlinks in Map.astro with universal, maintainable URLs.

## Details
- **Google Maps**: \https://www.google.com/maps/search/?api=1&query=Estadio+de+La+Cartuja,Sevilla,Spain\
- **Apple Maps**: \http://maps.apple.com/?q=Estadio+de+La+Cartuja,Sevilla,Spain\
- Shortlinks are opaque and could break if the redirect service changes
- Universal URLs work across platforms without API keys
- Single file changed: \src/sections/Map.astro\ (2 lines)

## Screenshots
N/A (links only, visual layout unchanged)

## Breaking changes
None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Correcciones de errores**
  * Se actualizaron los enlaces de Google Maps y Apple Maps para proporcionar un acceso más directo y confiable a la ubicación del estadio. Los cambios optimizan la experiencia del usuario al consultar la ubicación a través de ambas plataformas de mapas, con parámetros de búsqueda mejorados y más consistentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->