### PR TITLE
feat(boxeadores): galería de imágenes desde la CDN con lightbox

### DIFF
--- a/src/components/BoxerGallery.astro
+++ b/src/components/BoxerGallery.astro
@@ -1,0 +1,228 @@
+---
+import { getBoxerGallery } from '@/consts/boxer-gallery'
+
+interface Props {
+  boxerId: string
+  boxerName?: string
+}
+
+const { boxerId, boxerName } = Astro.props
+const images = getBoxerGallery(boxerId, boxerName)
+---
+
+{
+  images.length > 0 && (
+    <section
+      data-boxer-gallery
+      class="boxer-gallery animate-fade-in-up animate-delay-500 mt-10 w-full"
+    >
+      <div class="flex w-full items-center gap-3 sm:gap-4" aria-hidden="true">
+        <span class="size-1 rotate-45 bg-theme-gold/70" />
+        <span class="h-px flex-1 bg-linear-to-r from-theme-gold/45 to-transparent" />
+      </div>
+
+      <p class="mt-5 font-cinzel text-[0.55rem] font-bold tracking-[0.45em] text-theme-gold/80 sm:text-[0.65rem]">
+        GALERÍA
+      </p>
+
+      <ul class="mt-5 grid grid-cols-2 gap-2 sm:grid-cols-3 sm:gap-3 lg:grid-cols-4">
+        {images.map((image, i) => (
+          <li>
+            <button
+              type="button"
+              data-gallery-item
+              data-index={i}
+              data-md-avif={image.md.avif}
+              data-md-webp={image.md.webp}
+              data-alt={image.alt}
+              aria-label={`Ampliar ${image.alt}`}
+              class="group relative block aspect-[3/4] w-full overflow-hidden rounded-lg ring-1 ring-theme-cream/10 transition duration-300 hover:ring-theme-gold/50 focus-visible:ring-2 focus-visible:ring-theme-gold focus-visible:outline-none"
+            >
+              <picture>
+                <source type="image/avif" srcset={image.sm.avif} />
+                <source type="image/webp" srcset={image.sm.webp} />
+                <img
+                  src={image.sm.webp}
+                  alt={image.alt}
+                  loading="lazy"
+                  decoding="async"
+                  class="size-full object-cover transition duration-300 group-hover:scale-105"
+                />
+              </picture>
+            </button>
+          </li>
+        ))}
+      </ul>
+
+      <dialog data-gallery-dialog class="boxer-gallery-dialog" aria-label="Galería de fotos ampliada">
+        <div data-gallery-backdrop class="boxer-gallery-dialog-inner">
+          <button type="button" data-gallery-close class="boxer-gallery-btn boxer-gallery-close" aria-label="Cerrar">✕</button>
+          <button type="button" data-gallery-prev class="boxer-gallery-btn boxer-gallery-nav boxer-gallery-prev" aria-label="Foto anterior">‹</button>
+          <img data-gallery-dialog-img class="boxer-gallery-dialog-img" alt="" decoding="async" />
+          <button type="button" data-gallery-next class="boxer-gallery-btn boxer-gallery-nav boxer-gallery-next" aria-label="Foto siguiente">›</button>
+          <span data-gallery-counter class="boxer-gallery-counter" aria-hidden="true" />
+        </div>
+      </dialog>
+    </section>
+  )
+}
+
+<script>
+  function initBoxerGallery() {
+    const gallery = document.querySelector('[data-boxer-gallery]')
+    if (!gallery) return
+
+    const dialog = gallery.querySelector('[data-gallery-dialog]') as HTMLDialogElement | null
+    const dialogImg = gallery.querySelector('[data-gallery-dialog-img]') as HTMLImageElement | null
+    const counter = gallery.querySelector('[data-gallery-counter]') as HTMLElement | null
+    const items = Array.from(gallery.querySelectorAll('[data-gallery-item]')) as HTMLElement[]
+    if (!dialog || !dialogImg || items.length === 0) return
+
+    let current = 0
+
+    const show = (index: number) => {
+      current = (index + items.length) % items.length
+      const btn = items[current]
+      const webp = btn.dataset.mdWebp ?? ''
+      dialogImg.onerror = () => {
+        dialogImg.onerror = null
+        dialogImg.src = webp
+      }
+      dialogImg.src = btn.dataset.mdAvif ?? webp
+      dialogImg.alt = btn.dataset.alt ?? ''
+      if (counter) counter.textContent = `${current + 1} / ${items.length}`
+    }
+
+    items.forEach((btn, i) =>
+      btn.addEventListener('click', () => {
+        show(i)
+        dialog.showModal()
+        document.documentElement.style.overflow = 'hidden'
+      }),
+    )
+
+    gallery.querySelector('[data-gallery-prev]')?.addEventListener('click', () => show(current - 1))
+    gallery.querySelector('[data-gallery-next]')?.addEventListener('click', () => show(current + 1))
+    gallery.querySelector('[data-gallery-close]')?.addEventListener('click', () => dialog.close())
+
+    dialog.addEventListener('keydown', (e) => {
+      if (e.key === 'ArrowLeft') { e.preventDefault(); show(current - 1) }
+      if (e.key === 'ArrowRight') { e.preventDefault(); show(current + 1) }
+    })
+
+    dialog.addEventListener('click', (e) => {
+      const t = e.target as Element
+      if (t === dialog || t.hasAttribute('data-gallery-backdrop')) dialog.close()
+    })
+
+    dialog.addEventListener('close', () => {
+      document.documentElement.style.overflow = ''
+    })
+  }
+
+  document.addEventListener('astro:page-load', initBoxerGallery)
+</script>
+
+<style>
+  .boxer-gallery-dialog {
+    max-width: 100vw;
+    max-height: 100dvh;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    border: none;
+    background: transparent;
+    overflow: hidden;
+  }
+
+  .boxer-gallery-dialog::backdrop {
+    background: rgba(3, 6, 16, 0.82);
+    backdrop-filter: blur(6px);
+  }
+
+  .boxer-gallery-dialog-inner {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 100%;
+    padding: clamp(1rem, 4vw, 3rem);
+  }
+
+  .boxer-gallery-dialog-img {
+    max-width: 100%;
+    max-height: 85dvh;
+    width: auto;
+    height: auto;
+    object-fit: contain;
+    border-radius: 0.5rem;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.6);
+  }
+
+  .boxer-gallery-btn {
+    position: absolute;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    color: var(--color-theme-cream);
+    background: color-mix(in srgb, var(--color-theme-midnight) 70%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
+    border-radius: 9999px;
+    transition: background-color 250ms ease, box-shadow 250ms ease, transform 250ms ease;
+  }
+
+  .boxer-gallery-btn:hover,
+  .boxer-gallery-btn:focus-visible {
+    background: color-mix(in srgb, var(--color-theme-midnight) 90%, black);
+    box-shadow: inset 0 0 0 1px var(--color-theme-gold);
+    outline: none;
+  }
+
+  .boxer-gallery-close {
+    top: clamp(0.75rem, 3vw, 1.5rem);
+    right: clamp(0.75rem, 3vw, 1.5rem);
+    width: 2.75rem;
+    height: 2.75rem;
+    font-size: 1rem;
+  }
+
+  .boxer-gallery-nav {
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3rem;
+    height: 3rem;
+    font-size: 1.75rem;
+    line-height: 1;
+  }
+
+  .boxer-gallery-nav:hover,
+  .boxer-gallery-nav:focus-visible {
+    transform: translateY(-50%) scale(1.05);
+  }
+
+  .boxer-gallery-prev { left: clamp(0.5rem, 3vw, 2rem); }
+  .boxer-gallery-next { right: clamp(0.5rem, 3vw, 2rem); }
+
+  .boxer-gallery-counter {
+    position: absolute;
+    bottom: clamp(0.75rem, 3vw, 1.75rem);
+    left: 50%;
+    transform: translateX(-50%);
+    font-family: 'Cinzel', var(--font-fallback);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.25em;
+    color: color-mix(in srgb, var(--color-theme-cream) 80%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .boxer-gallery-btn,
+    .boxer-gallery-dialog-img,
+    .boxer-gallery img {
+      transition: none !important;
+    }
+  }
+</style>

--- a/src/consts/boxer-gallery.ts
+++ b/src/consts/boxer-gallery.ts
@@ -79,5 +79,5 @@ return Array.from({ length: entry.count }, (_, i) => {
 
 /** ¿Tiene galería este boxeador? */
 export function hasBoxerGallery(boxerId: string): boolean {
-    return boxerId in GALLERY
+    return Object.hasOwn(GALLERY, boxerId)
 }

--- a/src/consts/boxer-gallery.ts
+++ b/src/consts/boxer-gallery.ts
@@ -1,0 +1,83 @@
+
+const CDN = 'https://cdn.infolavelada.com/boxeadores'
+
+/**
+ * Galería de fotos de cada boxeador (bucket R2 de Cloudflare).
+ *
+ * La clave es el `id` del boxeador en `boxers.ts`. Guardamos solo la cantidad
+ * de fotos (la numeración es corrida 01..count) y, cuando la carpeta del CDN
+ * no coincide con el id, el `slug` real.
+ *
+ * Cada foto existe en sm / md / normal × avif / webp. Acá usamos:
+ *   - sm → miniatura de la galería (carga prioritaria)
+ *   - md → imagen ampliada (lightbox)
+ * El tamaño `normal` no se usa (muy pesado; con md alcanza).
+ */
+const GALLERY: Record<string, { count: number; slug?: string }> = {
+    alondrissa: { count: 18, slug: 'alondrisa' }, // slug del CDN != id
+    'angie-velasco': { count: 16 },
+    clersss: { count: 10, slug: 'clerss' }, // slug del CDN != id
+    'edu-aguirre': { count: 13 },
+    'fabiana-sevillano': { count: 10, slug: 'fabiana' }, // slug del CDN != id
+    fernanfloo: { count: 11 },
+    'gaston-edul': { count: 13 },
+    'gero-arias': { count: 17 },
+    illojuan: { count: 13 },
+    'kidd-keo': { count: 15 },
+    'la-parce': { count: 14 },
+    'lit-killah': { count: 16 },
+    'marta-diaz': { count: 11 },
+    'natalia-mx': { count: 13 },
+    'plex': { count: 15 },
+    'roro': { count: 13 },
+    'samy-rivers': { count: 15 },
+    'tatiana-kaer': { count: 12 },
+    'thegrefg': { count: 14 },
+    viruzz: { count: 14 },
+}
+
+/** Par de fuentes para un `<picture>` (avif preferido, webp de fallback). */
+export interface GalleryImageSources {
+    avif: string
+    webp: string
+}
+
+export interface GalleryImage {
+  /** Número de foto (1-based). */
+    index: number
+  /** Texto alternativo accesible. */
+    alt: string
+  /** Tamaño chico — miniatura de la galería. */
+    sm: GalleryImageSources
+  /** Tamaño mediano — imagen ampliada. */
+    md: GalleryImageSources
+}
+
+/**
+ * Devuelve la galería de un boxeador lista para renderizar.
+ * @param boxerId   id del boxeador (coincide con `boxers.ts`)
+ * @param boxerName nombre para el alt (opcional, recomendado)
+ */
+export function getBoxerGallery(boxerId: string, boxerName?: string): GalleryImage[] {
+    const entry = GALLERY[boxerId]
+    if (!entry) return []
+
+    const slug = entry.slug ?? boxerId
+    const label = boxerName ?? boxerId
+
+return Array.from({ length: entry.count }, (_, i) => {
+    const n = String(i + 1).padStart(2, '0')
+    const base = `${CDN}/${slug}/${n}`
+    return {
+        index: i + 1,
+        alt: `Foto ${i + 1} de ${label}`,
+        sm: { avif: `${base}-sm.avif`, webp: `${base}-sm.webp` },
+        md: { avif: `${base}-md.avif`, webp: `${base}-md.webp` },
+    }
+})
+}
+
+/** ¿Tiene galería este boxeador? */
+export function hasBoxerGallery(boxerId: string): boolean {
+    return boxerId in GALLERY
+}

--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -19,6 +19,7 @@ import {
 import Layout from '@/layouts/Layout.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
+import BoxerGallery from '@/components/BoxerGallery.astro'
 
 export const prerender = true
 
@@ -215,7 +216,7 @@ const breadcrumbJsonLd = {
             />
           </picture>
 
-          <div class="boxer-detail-socials relative z-10 mt-6 w-full">
+          <div class="boxer-detail-socias relative z-10 mt-6 w-full">
             <BoxerSocials boxer={boxer} />
           </div>
         </div>
@@ -283,6 +284,8 @@ const breadcrumbJsonLd = {
               />
             </a>
           )}
+
+          <BoxerGallery boxerId={boxer.id} boxerName={boxer.name} />
 
           <div
             class="boxer-detail-coming-soon animate-fade-in-up animate-delay-500 mt-10 w-full"


### PR DESCRIPTION
## Type

- [x] feat

## Related Issue

Closes #1535

## Changes

- `src/consts/boxer-gallery.ts`: nuevo. Define los datos de la galería (cantidad de fotos por boxeador, con el slug del CDN cuando difiere del id) y un helper `getBoxerGallery` que arma las URLs del bucket R2 en los tamaños `sm` (miniatura) y `md` (ampliada), en avif y webp. Así evitamos hardcodear ~1000 URLs.
- `src/components/BoxerGallery.astro`: nuevo. Galería para la ficha del boxeador: grilla de miniaturas (`sm`) que al hacer click abren un lightbox (`<dialog>` nativo) con la foto ampliada (`md`). Se navega con las flechas en pantalla y con el teclado (◀ ▶), se cierra con Escape / la X / click afuera, y tiene contador. Las `md` se cargan solo al abrir cada foto.
- `src/pages/boxeadores/[id].astro`: importa y renderiza `<BoxerGallery>` en la ficha (se muestra solo si el boxeador tiene fotos).

## Dependencies

- Added: ninguna
- Removed: ninguna

## Screenshots

| View | Before | After |
|------|--------|-------|
| Mobile |<img width="433" height="880" alt="Captura de pantalla 2026-06-12 a la(s) 2 21 43 p  m" src="https://github.com/user-attachments/assets/4a084515-2992-4200-b843-64fbf8d5b21a" /> |<img width="425" height="886" alt="Captura de pantalla 2026-06-12 a la(s) 2 27 55 p  m" src="https://github.com/user-attachments/assets/62797880-95a2-4ab3-895b-e6e60a72ad4b" /> |
| Desktop |<img width="1919" height="960" alt="Captura de pantalla 2026-06-12 a la(s) 2 21 26 p  m" src="https://github.com/user-attachments/assets/427b8278-600e-4761-ae78-1a5aa582aa71" /> |<img width="1916" height="961" alt="Captura de pantalla 2026-06-12 a la(s) 2 12 25 p  m" src="https://github.com/user-attachments/assets/e630a2a4-61b3-4247-a6f0-4619f4bf2be1" /> |

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Características**
  * Galería de imágenes por boxeador con miniaturas.
  * Previsualización ampliada en diálogo modal.
  * Navegación anterior/siguiente y contador de imágenes.
  * Cierre del diálogo por botón, clic en fondo o teclado.
  * Compatibilidad automática AVIF/WebP con fallback ante error.
  * Respeta la preferencia de movimiento reducido.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->