### PR TITLE
fix(layout): adjust section order and spacing for FAQ and Podcast

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -193,7 +193,7 @@ export const prerender = true
     </ul>
   </aside>
 
-  <FAQ faqs={HOME_FAQS} />
   <Map />
+  <FAQ faqs={HOME_FAQS} />
   <Footer />
 </Layout>

--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -14,20 +14,6 @@ import SectionHeader from '@/components/SectionHeader.astro'
   class="relative w-full overflow-hidden px-4 py-20 sm:px-6 lg:py-28"
   aria-labelledby="map-title"
 >
-  <!-- Línea dorada superior -->
-  <div
-    aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 top-0 h-px bg-linear-to-r from-transparent via-theme-gold/30 to-transparent"
-  >
-  </div>
-
-  <!-- Brillo radial de fondo -->
-  <div
-    aria-hidden="true"
-    class="pointer-events-none absolute inset-x-0 top-0 -z-0 h-72 bg-[radial-gradient(ellipse_at_top,_var(--color-theme-gold)_0%,_transparent_70%)] opacity-[0.05]"
-  >
-  </div>
-
   <div class="relative mx-auto flex max-w-6xl flex-col items-center">
     <SectionHeader
       titleId="map-title"

--- a/src/sections/Podcast.astro
+++ b/src/sections/Podcast.astro
@@ -56,7 +56,7 @@ function formatRelative(date: Date) {
 
 <section
   id="podcast"
-  class="relative w-full px-4 pb-20 sm:px-6 lg:pb-28"
+  class="relative w-full px-4 py-20 sm:px-6 lg:py-28"
   aria-labelledby="podcast-title"
 >
   <div class="mx-auto flex max-w-7xl flex-col items-center">


### PR DESCRIPTION
Se ajusta el orden de las secciones, ubicando la sección de preguntas frecuentes (FAQ) al final de la página y la sección del lugar del evento antes de ella.

Además, se agrega espaciado vertical a la sección del podcast y se elimina el divisor visual de secciones presente en el mapa para mejorar la consistencia del layout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Reordenado el layout de la página de inicio: la sección de mapa ahora aparece antes que las preguntas frecuentes.
  * Eliminados elementos decorativos de la sección de mapa para una interfaz más limpia.
  * Ajustado el espaciado vertical en la sección de podcast para mejor consistencia visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->