### PR TITLE
style: remove border-radius from boxers page container

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -850,7 +850,6 @@ const totalBoxers = BOXERS.length
       inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 26%, transparent),
       0 24px 60px rgba(0, 0, 0, 0.45),
       0 0 60px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
-    border-radius: 6px;
   }
 
   @media (max-width: 639px) {
@@ -1042,7 +1041,6 @@ const totalBoxers = BOXERS.length
     gap: 0.75rem 1.25rem;
     margin-bottom: 1.25rem;
     padding: 0.75rem 1rem;
-    border-radius: 6px;
     background:
       radial-gradient(
         ellipse 90% 100% at 50% 0%,


### PR DESCRIPTION
Se eliminan los bordes redondeados de los contenedores de los filtros, ya que no aportaban valor visual al diseño y generaban ruido innecesario.

Este ajuste mejora la coherencia visual con las decoraciones laterales, cuya geometría recta encaja mejor con contenedores sin `border-radius`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Ajustes en la estilización del panel de filtros y barra de ordenación para mejorar su presentación visual en diferentes dispositivos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->