### PR TITLE
feat(sections): add sponsor card corner-lock hover interaction

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -189,22 +189,19 @@ const SPONSORS: Sponsor[] = [
     <div class="sponsors-promos mb-16 flex w-full max-w-[760px] flex-col gap-5 sm:mb-20">
       {
         PROMO_BANNERS.map(
-          (
-            {
-              name,
-              slug,
-              url,
-              label,
-              alt,
-              avifSrc,
-              webpSrc,
-              mobileAvifSrc,
-              mobileWebpSrc,
-              width,
-              height,
-            },
-            index,
-          ) => (
+          ({
+            name,
+            slug,
+            url,
+            label,
+            alt,
+            avifSrc,
+            webpSrc,
+            mobileAvifSrc,
+            mobileWebpSrc,
+            width,
+            height,
+          }) => (
             <a
               href={withUtm(url, { medium: 'promo_banner', content: slug })}
               target="_blank"
@@ -212,7 +209,6 @@ const SPONSORS: Sponsor[] = [
               aria-label={label}
               title={name}
               class="promo-banner motion-hidden group relative block w-full overflow-hidden rounded-md ring-1 ring-theme-gold/25 outline-none hover:ring-theme-gold/45 focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight"
-              style={`animation-delay:${850 + index * 90}ms`}
             >
               <picture>
                 <source srcset={mobileAvifSrc} media="(max-width: 639px)" type="image/avif" />
@@ -238,8 +234,8 @@ const SPONSORS: Sponsor[] = [
     <div class="sponsors-grid-wrap relative w-full" data-corner-grid>
       <ul class="sponsors-grid" role="list">
         {
-          SPONSORS.map(({ name, slug, url, label, Logo, logoClass }, index) => (
-            <li class="motion-hidden" style={`animation-delay:${1100 + index * 65}ms`}>
+          SPONSORS.map(({ name, slug, url, label, Logo, logoClass }) => (
+            <li class="motion-hidden">
               <a
                 href={withUtm(url, { medium: 'sponsor_card', content: slug })}
                 target="_blank"

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -232,7 +232,7 @@ const SPONSORS: Sponsor[] = [
       }
     </div>
 
-    <div class="relative w-full">
+    <div class="sponsors-grid-wrap relative w-full" data-corner-grid>
       <ul class="sponsors-grid" role="list">
         {
           SPONSORS.map(({ name, slug, url, label, Logo, logoClass }, index) => (
@@ -243,45 +243,87 @@ const SPONSORS: Sponsor[] = [
                 rel="sponsored noopener noreferrer"
                 aria-label={label}
                 title={name}
-                class="sponsor-card group relative isolate flex aspect-[16/10] w-full items-center justify-center rounded-md text-white outline-none transition duration-500 hover:-translate-y-1 focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight"
+                class="sponsor-card group"
               >
-                <span
-                  aria-hidden="true"
-                  class="pointer-events-none absolute top-1.5 left-1.5 size-2.5 border-t border-l border-theme-gold/35 transition duration-500 group-hover:border-theme-gold group-focus-visible:border-theme-gold sm:top-2 sm:left-2 sm:size-3"
-                />
-                <span
-                  aria-hidden="true"
-                  class="pointer-events-none absolute top-1.5 right-1.5 size-2.5 border-t border-r border-theme-gold/35 transition duration-500 group-hover:border-theme-gold group-focus-visible:border-theme-gold sm:top-2 sm:right-2 sm:size-3"
-                />
-                <span
-                  aria-hidden="true"
-                  class="pointer-events-none absolute bottom-1.5 left-1.5 size-2.5 border-b border-l border-theme-gold/35 transition duration-500 group-hover:border-theme-gold group-focus-visible:border-theme-gold sm:bottom-2 sm:left-2 sm:size-3"
-                />
-                <span
-                  aria-hidden="true"
-                  class="pointer-events-none absolute bottom-1.5 right-1.5 size-2.5 border-b border-r border-theme-gold/35 transition duration-500 group-hover:border-theme-gold group-focus-visible:border-theme-gold sm:bottom-2 sm:right-2 sm:size-3"
-                />
-
                 <Logo
+                  data-sponsor-logo
                   aria-hidden="true"
-                  class:list={[
-                    'h-auto drop-shadow-[0_8px_18px_rgba(0,0,0,0.45)] transition duration-500 group-hover:scale-[1.04] group-hover:brightness-110 group-focus-visible:scale-[1.04] group-focus-visible:brightness-110',
-                    logoClass,
-                  ]}
+                  class:list={['sponsor-logo', logoClass]}
                 />
-
                 <span class="sr-only">{name}</span>
               </a>
             </li>
-          ))
-        }
+          )
+        )
       </ul>
+
+      <div class="corner-grid" aria-hidden="true">
+        <svg class="corner-tl" viewBox="0 0 12 12">
+          <path d="M 1 9 L 1 1 L 9 1" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+        </svg>
+        <svg class="corner-tr" viewBox="0 0 12 12">
+          <path d="M 11 9 L 11 1 L 3 1" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+        </svg>
+        <svg class="corner-bl" viewBox="0 0 12 12">
+          <path d="M 1 3 L 1 11 L 9 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+        </svg>
+        <svg class="corner-br" viewBox="0 0 12 12">
+          <path d="M 11 3 L 11 11 L 3 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+        </svg>
+      </div>
     </div>
 
   </div>
 </section>
 
 <style>
+  .sponsor-card {
+    position: relative;
+    isolation: isolate;
+    display: flex;
+    aspect-ratio: 16 / 10;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0.375rem;
+    color: white;
+    outline: none;
+  }
+
+  .sponsor-card:focus-visible {
+    box-shadow:
+      0 0 0 2px color-mix(in srgb, var(--color-theme-gold) 60%, transparent),
+      0 0 0 4px var(--color-theme-midnight);
+  }
+
+  .sponsor-logo {
+    height: auto;
+    filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.45));
+  }
+
+  .corner-grid {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    color: var(--color-theme-gold);
+  }
+
+  .corner-grid svg {
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 0.75rem;
+    height: 0.75rem;
+    opacity: 0;
+  }
+
+  @media (min-width: 640px) {
+    .corner-grid svg {
+      width: 1rem;
+      height: 1rem;
+    }
+  }
+
   .sponsors-grid {
     display: grid;
     width: 100%;
@@ -320,17 +362,14 @@ const SPONSORS: Sponsor[] = [
 
   @media (prefers-reduced-motion: reduce) {
     .promo-banner,
-    .promo-banner img,
-    .sponsor-card {
+    .promo-banner img {
       transition: none;
     }
 
     .promo-banner:hover,
     .promo-banner:focus-visible,
     .promo-banner:hover img,
-    .promo-banner:focus-visible img,
-    .sponsor-card:hover,
-    .sponsor-card:focus-visible {
+    .promo-banner:focus-visible img {
       transform: none;
     }
 
@@ -340,4 +379,107 @@ const SPONSORS: Sponsor[] = [
       transform: none !important;
     }
   }
+
+  @media (hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference) {
+    .sponsor-card {
+      transition: transform 300ms;
+    }
+
+    .sponsor-card:hover,
+    .sponsor-card:focus-visible {
+      transform: translateY(-0.25rem);
+    }
+  }
 </style>
+
+<script>
+  import { $, $$ } from '@/lib/dom-selector'
+  import { animate, hover } from 'motion'
+
+  const canAnimateHover = window.matchMedia(
+    '(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)'
+  ).matches
+  const grid = $('[data-corner-grid]')
+  const corners = $$<SVGElement>('.corner-grid svg')
+
+  if (canAnimateHover && grid) {
+    const OUTWARD = [[-4, -16], [4, -16], [-4, 16], [4, 16]]
+    let activeCard: Element | null = null
+    let hoverId = 0
+    let cornersVisible = false
+    let hideTimer: ReturnType<typeof setTimeout> | null = null
+    const lockTimers: ReturnType<typeof setTimeout>[] = []
+    const revealFrames: number[] = []
+
+    hover('.sponsor-card', (card) => {
+      const currentHoverId = ++hoverId
+      activeCard = card
+      if (hideTimer) { clearTimeout(hideTimer); hideTimer = null }
+      lockTimers.forEach(clearTimeout); lockTimers.length = 0
+      revealFrames.forEach(cancelAnimationFrame); revealFrames.length = 0
+
+      const gridRect = grid.getBoundingClientRect()
+      const cardRect = card.getBoundingClientRect()
+      const sm = window.matchMedia('(min-width: 640px)').matches
+      const inset = sm ? 6 : 4
+      const size = sm ? 16 : 12
+
+      const x0 = cardRect.left - gridRect.left + inset
+      const y0 = cardRect.top - gridRect.top + inset
+      const x1 = cardRect.right - gridRect.left - inset - size
+      const y1 = cardRect.bottom - gridRect.top - inset - size
+
+      for (let i = 0; i < 4; i++) {
+        const corner = corners[i]
+        if (!corner) continue
+        const x = i % 2 === 0 ? x0 : x1
+        const y = i < 2 ? y0 : y1
+        const originX = x + OUTWARD[i][0]
+        const originY = y + OUTWARD[i][1]
+
+        if (cornersVisible) {
+          animate(corner, { opacity: 1 }, { duration: 0 })
+          animate(corner, { x: originX, y: originY }, { type: 'spring', stiffness: 700, damping: 60 })
+        } else {
+          animate(corner, { x: originX, y: originY, opacity: 0 }, { duration: 0 })
+          revealFrames.push(requestAnimationFrame(() => {
+            if (activeCard !== card || currentHoverId !== hoverId) return
+            animate(corner, { opacity: 1 }, { duration: 0.14, ease: 'ease-out' })
+          }))
+        }
+
+        lockTimers.push(setTimeout(() => {
+          if (activeCard !== card || currentHoverId !== hoverId) return
+          cornersVisible = true
+          animate(corner, { x, y }, { type: 'spring', stiffness: 700, damping: 60 })
+        }, 50 + i * 40))
+      }
+
+      const logo = $('[data-sponsor-logo]', card)
+      if (logo) animate(logo, { scale: 0.96 }, { type: 'spring', stiffness: 500, damping: 60 })
+
+      return () => {
+        if (logo) animate(logo, { scale: 1 }, { type: 'spring', stiffness: 500, damping: 60 })
+        if (activeCard !== card) return
+
+        activeCard = null
+        hoverId++
+        const exitHoverId = hoverId
+        lockTimers.forEach(clearTimeout); lockTimers.length = 0
+        revealFrames.forEach(cancelAnimationFrame); revealFrames.length = 0
+
+        hideTimer = setTimeout(() => {
+          if (activeCard || exitHoverId !== hoverId) return
+          for (let i = 0; i < 4; i++) {
+            const c = corners[i]
+            if (c) animate(c, { opacity: 0 }, { duration: 0.08, ease: 'ease-out' })
+          }
+          hideTimer = setTimeout(() => {
+            if (!activeCard && exitHoverId === hoverId) cornersVisible = false
+            hideTimer = null
+          }, 60)
+        }, 150)
+      }
+    })
+  }
+</script>

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -208,7 +208,7 @@ const SPONSORS: Sponsor[] = [
               rel="sponsored noopener noreferrer"
               aria-label={label}
               title={name}
-              class="promo-banner group relative block w-full overflow-hidden rounded-md bg-black shadow-[0_14px_40px_rgba(0,0,0,0.3)] ring-1 ring-white/10 outline-none transition duration-500 animate-fade-in-up hover:-translate-y-1 hover:ring-theme-gold/45 focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight"
+              class="promo-banner group relative block w-full animate-fade-in-up overflow-hidden rounded-md bg-black shadow-[0_14px_40px_rgba(0,0,0,0.3)] ring-1 ring-white/10 transition duration-500 outline-none hover:-translate-y-1 hover:ring-theme-gold/45 focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight"
               style={`animation-delay:${850 + index * 90}ms`}
             >
               <picture>
@@ -253,26 +253,45 @@ const SPONSORS: Sponsor[] = [
                 <span class="sr-only">{name}</span>
               </a>
             </li>
-          )
-        )
+          ))
+        }
       </ul>
 
       <div class="corner-grid" aria-hidden="true">
         <svg class="corner-tl" viewBox="0 0 12 12">
-          <path d="M 1 9 L 1 1 L 9 1" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+          <path
+            d="M 1 9 L 1 1 L 9 1"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="square"></path>
         </svg>
         <svg class="corner-tr" viewBox="0 0 12 12">
-          <path d="M 11 9 L 11 1 L 3 1" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+          <path
+            d="M 11 9 L 11 1 L 3 1"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="square"></path>
         </svg>
         <svg class="corner-bl" viewBox="0 0 12 12">
-          <path d="M 1 3 L 1 11 L 9 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+          <path
+            d="M 1 3 L 1 11 L 9 11"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="square"></path>
         </svg>
         <svg class="corner-br" viewBox="0 0 12 12">
-          <path d="M 11 3 L 11 11 L 3 11" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="square" />
+          <path
+            d="M 11 3 L 11 11 L 3 11"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="1.5"
+            stroke-linecap="square"></path>
         </svg>
       </div>
     </div>
-
   </div>
 </section>
 
@@ -397,13 +416,18 @@ const SPONSORS: Sponsor[] = [
   import { animate, hover } from 'motion'
 
   const canAnimateHover = window.matchMedia(
-    '(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)'
+    '(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)',
   ).matches
   const grid = $('[data-corner-grid]')
   const corners = $$<SVGElement>('.corner-grid svg')
 
   if (canAnimateHover && grid) {
-    const OUTWARD = [[-4, -16], [4, -16], [-4, 16], [4, 16]]
+    const OUTWARD = [
+      [-4, -16],
+      [4, -16],
+      [-4, 16],
+      [4, 16],
+    ]
     let activeCard: Element | null = null
     let hoverId = 0
     let cornersVisible = false
@@ -414,9 +438,14 @@ const SPONSORS: Sponsor[] = [
     hover('.sponsor-card', (card) => {
       const currentHoverId = ++hoverId
       activeCard = card
-      if (hideTimer) { clearTimeout(hideTimer); hideTimer = null }
-      lockTimers.forEach(clearTimeout); lockTimers.length = 0
-      revealFrames.forEach(cancelAnimationFrame); revealFrames.length = 0
+      if (hideTimer) {
+        clearTimeout(hideTimer)
+        hideTimer = null
+      }
+      lockTimers.forEach(clearTimeout)
+      lockTimers.length = 0
+      revealFrames.forEach(cancelAnimationFrame)
+      revealFrames.length = 0
 
       const gridRect = grid.getBoundingClientRect()
       const cardRect = card.getBoundingClientRect()
@@ -439,20 +468,31 @@ const SPONSORS: Sponsor[] = [
 
         if (cornersVisible) {
           animate(corner, { opacity: 1 }, { duration: 0 })
-          animate(corner, { x: originX, y: originY }, { type: 'spring', stiffness: 700, damping: 60 })
+          animate(
+            corner,
+            { x: originX, y: originY },
+            { type: 'spring', stiffness: 700, damping: 60 },
+          )
         } else {
           animate(corner, { x: originX, y: originY, opacity: 0 }, { duration: 0 })
-          revealFrames.push(requestAnimationFrame(() => {
-            if (activeCard !== card || currentHoverId !== hoverId) return
-            animate(corner, { opacity: 1 }, { duration: 0.14, ease: 'ease-out' })
-          }))
+          revealFrames.push(
+            requestAnimationFrame(() => {
+              if (activeCard !== card || currentHoverId !== hoverId) return
+              animate(corner, { opacity: 1 }, { duration: 0.14, ease: 'ease-out' })
+            }),
+          )
         }
 
-        lockTimers.push(setTimeout(() => {
-          if (activeCard !== card || currentHoverId !== hoverId) return
-          cornersVisible = true
-          animate(corner, { x, y }, { type: 'spring', stiffness: 700, damping: 60 })
-        }, 50 + i * 40))
+        lockTimers.push(
+          setTimeout(
+            () => {
+              if (activeCard !== card || currentHoverId !== hoverId) return
+              cornersVisible = true
+              animate(corner, { x, y }, { type: 'spring', stiffness: 700, damping: 60 })
+            },
+            50 + i * 40,
+          ),
+        )
       }
 
       const logo = $('[data-sponsor-logo]', card)
@@ -465,8 +505,10 @@ const SPONSORS: Sponsor[] = [
         activeCard = null
         hoverId++
         const exitHoverId = hoverId
-        lockTimers.forEach(clearTimeout); lockTimers.length = 0
-        revealFrames.forEach(cancelAnimationFrame); revealFrames.length = 0
+        lockTimers.forEach(clearTimeout)
+        lockTimers.length = 0
+        revealFrames.forEach(cancelAnimationFrame)
+        revealFrames.length = 0
 
         hideTimer = setTimeout(() => {
           if (activeCard || exitHoverId !== hoverId) return

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -427,22 +427,15 @@ const SPONSORS: Sponsor[] = [
   import { $, $$ } from '@/lib/dom-selector'
   import { animate, hover, inView } from 'motion'
 
-  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
-  const canAnimateHover = window.matchMedia(
-    '(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)',
-  ).matches
+  const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  const canUseHoverMotion = window.matchMedia('(hover: hover) and (pointer: fine)').matches
   const header = $('.sponsors-header')
   const promoBanners = $$('.sponsors-promos .promo-banner')
   const sponsorItems = $$('.sponsors-grid li')
   const grid = $('[data-corner-grid]')
   const corners = $$<SVGElement>('.corner-grid svg')
-  const smQuery = window.matchMedia('(min-width: 640px)')
-  let isSmScreen = smQuery.matches
-  smQuery.addEventListener('change', (event) => {
-    isSmScreen = event.matches
-  })
 
-  if (!reducedMotion.matches) {
+  if (!prefersReducedMotion) {
     const reveal = (elements: Element[], delayStep = 0.05) => {
       elements.forEach((el, i) => {
         animate(
@@ -462,118 +455,130 @@ const SPONSORS: Sponsor[] = [
     inView('.sponsors-promos', () => reveal(promoBanners, 0.08))
     inView('.sponsors-grid', () => reveal(sponsorItems, 0.045))
 
-    hover('.promo-banner', (banner) => {
-      const img = $<HTMLImageElement>('.banner-img', banner)
-      if (!img) return
-      animate(img, { scale: 1 }, { duration: 0.3 })
+    if (canUseHoverMotion) {
+      hover('.promo-banner', (banner) => {
+        const img = $<HTMLImageElement>('.banner-img', banner)
+        if (!img) return
+        animate(img, { scale: 1 }, { duration: 0.3 })
 
-      return () => {
-        animate(img, { scale: 1.02 }, { duration: 0.3 })
-      }
-    })
-  }
+        return () => {
+          animate(img, { scale: 1.02 }, { duration: 0.3 })
+        }
+      })
 
-  if (canAnimateHover && grid) {
-    const OUTWARD = [
-      [-4, -16],
-      [4, -16],
-      [-4, 16],
-      [4, 16],
-    ]
-    let activeCard: Element | null = null
-    let hoverId = 0
-    let cornersVisible = false
-    let hideTimer: ReturnType<typeof setTimeout> | null = null
-    const lockTimers: ReturnType<typeof setTimeout>[] = []
-    const revealFrames: number[] = []
+      if (grid) {
+        const smQuery = window.matchMedia('(min-width: 640px)')
+        let isSmScreen = smQuery.matches
+        smQuery.addEventListener('change', (event) => {
+          isSmScreen = event.matches
+        })
 
-    hover('.sponsor-card', (card) => {
-      const currentHoverId = ++hoverId
-      activeCard = card
-      if (hideTimer) {
-        clearTimeout(hideTimer)
-        hideTimer = null
-      }
-      lockTimers.forEach(clearTimeout)
-      lockTimers.length = 0
-      revealFrames.forEach(cancelAnimationFrame)
-      revealFrames.length = 0
+        const OUTWARD = [
+          [-4, -16],
+          [4, -16],
+          [-4, 16],
+          [4, 16],
+        ]
+        let activeCard: Element | null = null
+        let hoverId = 0
+        let cornersVisible = false
+        let hideTimer: ReturnType<typeof setTimeout> | null = null
+        const lockTimers: ReturnType<typeof setTimeout>[] = []
+        const revealFrames: number[] = []
 
-      const gridRect = grid.getBoundingClientRect()
-      const cardRect = card.getBoundingClientRect()
-      const sm = isSmScreen
-      const inset = sm ? 6 : 4
-      const size = sm ? 16 : 12
-
-      const x0 = cardRect.left - gridRect.left + inset
-      const y0 = cardRect.top - gridRect.top + inset
-      const x1 = cardRect.right - gridRect.left - inset - size
-      const y1 = cardRect.bottom - gridRect.top - inset - size
-
-      for (let i = 0; i < 4; i++) {
-        const corner = corners[i]
-        if (!corner) continue
-        const x = i % 2 === 0 ? x0 : x1
-        const y = i < 2 ? y0 : y1
-        const originX = x + OUTWARD[i][0]
-        const originY = y + OUTWARD[i][1]
-
-        if (cornersVisible) {
-          animate(corner, { opacity: 1 }, { duration: 0 })
-          animate(
-            corner,
-            { x: originX, y: originY },
-            { type: 'spring', stiffness: 700, damping: 60 },
-          )
-        } else {
-          animate(corner, { x: originX, y: originY, opacity: 0 }, { duration: 0 })
-          revealFrames.push(
-            requestAnimationFrame(() => {
-              if (activeCard !== card || currentHoverId !== hoverId) return
-              animate(corner, { opacity: 1 }, { duration: 0.14, ease: 'ease-out' })
-            }),
-          )
+        const clearCornerQueue = () => {
+          lockTimers.forEach(clearTimeout)
+          lockTimers.length = 0
+          revealFrames.forEach(cancelAnimationFrame)
+          revealFrames.length = 0
         }
 
-        lockTimers.push(
-          setTimeout(
-            () => {
-              if (activeCard !== card || currentHoverId !== hoverId) return
-              cornersVisible = true
-              animate(corner, { x, y }, { type: 'spring', stiffness: 700, damping: 60 })
-            },
-            50 + i * 40,
-          ),
-        )
-      }
-
-      const logo = $('[data-sponsor-logo]', card)
-      if (logo) animate(logo, { scale: 0.96 }, { type: 'spring', stiffness: 500, damping: 60 })
-
-      return () => {
-        if (logo) animate(logo, { scale: 1 }, { type: 'spring', stiffness: 500, damping: 60 })
-        if (activeCard !== card) return
-
-        activeCard = null
-        hoverId++
-        const exitHoverId = hoverId
-        lockTimers.forEach(clearTimeout)
-        lockTimers.length = 0
-        revealFrames.forEach(cancelAnimationFrame)
-        revealFrames.length = 0
-
-        hideTimer = setTimeout(() => {
-          if (activeCard || exitHoverId !== hoverId) return
-          for (let i = 0; i < 4; i++) {
-            const c = corners[i]
-            if (c) animate(c, { opacity: 0 }, { duration: 0.08, ease: 'ease-out' })
-          }
-          hideTimer = setTimeout(() => {
-            if (!activeCard && exitHoverId === hoverId) cornersVisible = false
+        hover('.sponsor-card', (card) => {
+          const currentHoverId = ++hoverId
+          activeCard = card
+          if (hideTimer) {
+            clearTimeout(hideTimer)
             hideTimer = null
-          }, 60)
-        }, 150)
+          }
+          clearCornerQueue()
+
+          const gridRect = grid.getBoundingClientRect()
+          const cardRect = card.getBoundingClientRect()
+          const inset = isSmScreen ? 6 : 4
+          const size = isSmScreen ? 16 : 12
+
+          const x0 = cardRect.left - gridRect.left + inset
+          const y0 = cardRect.top - gridRect.top + inset
+          const x1 = cardRect.right - gridRect.left - inset - size
+          const y1 = cardRect.bottom - gridRect.top - inset - size
+
+          for (let i = 0; i < 4; i++) {
+            const corner = corners[i]
+            if (!corner) continue
+            const x = i % 2 === 0 ? x0 : x1
+            const y = i < 2 ? y0 : y1
+            const originX = x + OUTWARD[i][0]
+            const originY = y + OUTWARD[i][1]
+
+            if (cornersVisible) {
+              animate(corner, { opacity: 1 }, { duration: 0 })
+              animate(
+                corner,
+                { x: originX, y: originY },
+                { type: 'spring', stiffness: 700, damping: 60 },
+              )
+            } else {
+              animate(corner, { x: originX, y: originY, opacity: 0 }, { duration: 0 })
+              revealFrames.push(
+                requestAnimationFrame(() => {
+                  if (activeCard !== card || currentHoverId !== hoverId) return
+                  animate(corner, { opacity: 1 }, { duration: 0.14, ease: 'ease-out' })
+                }),
+              )
+            }
+
+            lockTimers.push(
+              setTimeout(
+                () => {
+                  if (activeCard !== card || currentHoverId !== hoverId) return
+                  cornersVisible = true
+                  animate(corner, { x, y }, { type: 'spring', stiffness: 700, damping: 60 })
+                },
+                50 + i * 40,
+              ),
+            )
+          }
+
+          const logo = $('[data-sponsor-logo]', card)
+          if (logo) {
+            animate(logo, { scale: 0.96 }, { type: 'spring', stiffness: 500, damping: 60 })
+          }
+
+          return () => {
+            if (logo) {
+              animate(logo, { scale: 1 }, { type: 'spring', stiffness: 500, damping: 60 })
+            }
+            if (activeCard !== card) return
+
+            activeCard = null
+            hoverId++
+            const exitHoverId = hoverId
+            clearCornerQueue()
+
+            hideTimer = setTimeout(() => {
+              if (activeCard || exitHoverId !== hoverId) return
+              for (let i = 0; i < 4; i++) {
+                const c = corners[i]
+                if (c) animate(c, { opacity: 0 }, { duration: 0.08, ease: 'ease-out' })
+              }
+              hideTimer = setTimeout(() => {
+                if (!activeCard && exitHoverId === hoverId) cornersVisible = false
+                hideTimer = null
+              }, 60)
+            }, 150)
+          }
+        })
       }
-    })
+    }
   }
 </script>

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -176,14 +176,17 @@ const SPONSORS: Sponsor[] = [
   </div>
 
   <div class="relative mx-auto flex max-w-6xl flex-col items-center">
-    <SectionHeader
-      titleId="sponsors-title"
-      title="PATROCINADORES"
-      subtitle="Las marcas que hacen posible La Velada del Año VI"
-      subtitleClass="mb-10 max-w-xl tracking-[0.25em] sm:mb-12 sm:text-sm"
-    />
+    <div class="sponsors-header motion-hidden">
+      <SectionHeader
+        titleId="sponsors-title"
+        title="PATROCINADORES"
+        subtitle="Las marcas que hacen posible La Velada del Año VI"
+        subtitleClass="mb-10 max-w-xl tracking-[0.25em] sm:mb-12 sm:text-sm"
+        hideDivider
+      />
+    </div>
 
-    <div class="mb-12 flex w-full max-w-[760px] flex-col gap-3 sm:mb-16">
+    <div class="sponsors-promos mb-16 flex w-full max-w-[760px] flex-col gap-5 sm:mb-20">
       {
         PROMO_BANNERS.map(
           (
@@ -208,7 +211,7 @@ const SPONSORS: Sponsor[] = [
               rel="sponsored noopener noreferrer"
               aria-label={label}
               title={name}
-              class="promo-banner group relative block w-full animate-fade-in-up overflow-hidden rounded-md bg-black shadow-[0_14px_40px_rgba(0,0,0,0.3)] ring-1 ring-white/10 transition duration-500 outline-none hover:-translate-y-1 hover:ring-theme-gold/45 focus-visible:-translate-y-1 focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight"
+              class="promo-banner motion-hidden group relative block w-full overflow-hidden rounded-md ring-1 ring-theme-gold/25 outline-none hover:ring-theme-gold/45 focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight"
               style={`animation-delay:${850 + index * 90}ms`}
             >
               <picture>
@@ -223,7 +226,7 @@ const SPONSORS: Sponsor[] = [
                   height={height}
                   loading="lazy"
                   decoding="async"
-                  class="block h-auto w-full transition duration-500 group-hover:scale-[1.01] group-hover:brightness-105 group-focus-visible:scale-[1.01] group-focus-visible:brightness-105"
+                  class="banner-img block h-auto w-full origin-center"
                 />
               </picture>
             </a>
@@ -236,7 +239,7 @@ const SPONSORS: Sponsor[] = [
       <ul class="sponsors-grid" role="list">
         {
           SPONSORS.map(({ name, slug, url, label, Logo, logoClass }, index) => (
-            <li class="animate-fade-in-up" style={`animation-delay:${1100 + index * 65}ms`}>
+            <li class="motion-hidden" style={`animation-delay:${1100 + index * 65}ms`}>
               <a
                 href={withUtm(url, { medium: 'sponsor_card', content: slug })}
                 target="_blank"
@@ -296,6 +299,15 @@ const SPONSORS: Sponsor[] = [
 </section>
 
 <style>
+  .promo-banner img {
+    scale: 1.02;
+  }
+
+  .motion-hidden {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+
   .sponsor-card {
     position: relative;
     isolation: isolate;
@@ -381,18 +393,22 @@ const SPONSORS: Sponsor[] = [
 
   @media (prefers-reduced-motion: reduce) {
     .promo-banner,
-    .promo-banner img {
+    .promo-banner img,
+    .sponsor-card {
       transition: none;
     }
 
     .promo-banner:hover,
     .promo-banner:focus-visible,
     .promo-banner:hover img,
-    .promo-banner:focus-visible img {
+    .promo-banner:focus-visible img,
+    .sponsor-card:hover,
+    .sponsor-card:focus-visible {
       transform: none;
     }
 
-    [class*='animate-fade-in-up'] {
+    [class*='animate-fade-in-up'],
+    .motion-hidden {
       animation: none !important;
       opacity: 1 !important;
       transform: none !important;
@@ -413,13 +429,53 @@ const SPONSORS: Sponsor[] = [
 
 <script>
   import { $, $$ } from '@/lib/dom-selector'
-  import { animate, hover } from 'motion'
+  import { animate, hover, inView } from 'motion'
 
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)')
   const canAnimateHover = window.matchMedia(
     '(hover: hover) and (pointer: fine) and (prefers-reduced-motion: no-preference)',
   ).matches
+  const header = $('.sponsors-header')
+  const promoBanners = $$('.sponsors-promos .promo-banner')
+  const sponsorItems = $$('.sponsors-grid li')
   const grid = $('[data-corner-grid]')
   const corners = $$<SVGElement>('.corner-grid svg')
+  const smQuery = window.matchMedia('(min-width: 640px)')
+  let isSmScreen = smQuery.matches
+  smQuery.addEventListener('change', (event) => {
+    isSmScreen = event.matches
+  })
+
+  if (!reducedMotion.matches) {
+    const reveal = (elements: Element[], delayStep = 0.05) => {
+      elements.forEach((el, i) => {
+        animate(
+          el,
+          { opacity: [0, 1], y: [20, 0] },
+          { duration: 0.6, delay: i * delayStep, ease: 'ease-out' },
+        )
+      })
+    }
+
+    if (header) {
+      inView(header, (el) => {
+        animate(el, { opacity: [0, 1], y: [16, 0] }, { duration: 0.7, ease: 'ease-out' })
+      })
+    }
+
+    inView('.sponsors-promos', () => reveal(promoBanners, 0.08))
+    inView('.sponsors-grid', () => reveal(sponsorItems, 0.045))
+
+    hover('.promo-banner', (banner) => {
+      const img = $<HTMLImageElement>('.banner-img', banner)
+      if (!img) return
+      animate(img, { scale: 1 }, { duration: 0.3 })
+
+      return () => {
+        animate(img, { scale: 1.02 }, { duration: 0.3 })
+      }
+    })
+  }
 
   if (canAnimateHover && grid) {
     const OUTWARD = [
@@ -449,7 +505,7 @@ const SPONSORS: Sponsor[] = [
 
       const gridRect = grid.getBoundingClientRect()
       const cardRect = card.getBoundingClientRect()
-      const sm = window.matchMedia('(min-width: 640px)').matches
+      const sm = isSmScreen
       const inset = sm ? 6 : 4
       const size = sm ? 16 : 12
 


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Split from #1467.

Follow-up to #1543. This PR keeps only the sponsor card hover interaction: the corner-lock animation and logo scale response on card hover/focus.

## Changes

- `src/sections/Sponsors.astro`: replaces static per-card corner spans with a shared animated corner grid overlay.
- `src/sections/Sponsors.astro`: adds Motion-powered hover/focus interaction for sponsor cards.
- `src/sections/Sponsors.astro`: adds guards for reduced motion, touch devices, rapid card-to-card hover, and stale animation state.

## Dependencies

- Added: None
- Removed: None

`motion` is already present in `main`.

## Screenshots

These assets are linked from the original review artifacts; no media files are added to this PR.

| View | Before | After |
|------|--------|-------|
| Desktop motion | ![Sponsors before motion](https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/d33bc3cb/docs/pr-assets/sponsors-lock/sponsors-before.gif) | ![Sponsors after motion](https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/d33bc3cb/docs/pr-assets/sponsors-lock/sponsors-after.gif) |
| Desktop still | ![Sponsors before](https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/d33bc3cb/docs/pr-assets/sponsors-lock/sponsors-before.png) | ![Sponsors after](https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/d33bc3cb/docs/pr-assets/sponsors-lock/sponsors-after.png) |

## Checklist

- [ ] Tested on mobile (<768px)
- [ ] Tested on desktop (>=1024px)
- [ ] No console errors
- [x] No regressions on affected routes expected; change is limited to sponsor card hover behavior

## Breaking Changes

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Nuevas Características**
  * Se renovó la sección de patrocinadores con tarjetas unificadas tipo cuadrícula y un efecto decorativo con esquinas al interactuar.
  * Las promos ahora incluyen una animación visual al pasar el cursor sobre la imagen.

* **Mejoras de Interacción**
  * Mejoras en hover y focus: realce y coordinación del efecto decorativo en tarjetas y logotipos.

* **Accesibilidad**
  * Se mantiene la reducción de movimiento desactivando transformaciones/animaciones cuando corresponde.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->