### PR TITLE
fix: center stadium underline animation

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -161,11 +161,11 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
           >
             <a
               href="#sede"
-              class="group/edition relative cursor-pointer focus-visible:outline-none"
+              class="group/edition relative inline-block cursor-pointer focus-visible:outline-none"
             >
               <span
                 aria-hidden="true"
-                class="pointer-events-none absolute inset-x-0 -bottom-1 h-px origin-center scale-x-0 bg-theme-gold transition-transform duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:scale-x-100 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-125 group-focus-visible/edition:scale-x-100 group-focus-visible/edition:delay-125"
+                class="pointer-events-none absolute left-1/2 -bottom-1 h-px w-0 -translate-x-1/2 bg-theme-gold transition-[width] duration-150 ease-out delay-0 [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:w-full [@media(hover:hover)_and_(pointer:fine)]:group-hover/edition:delay-125 group-focus-visible/edition:w-full group-focus-visible/edition:delay-125"
               />
               Estadio de la Cartuja, Sevilla
             </a>


### PR DESCRIPTION
## Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

- src/components/BoxerSelector.astro: change animated underline from left-to-right to centered.

## Dependencies

- Added: None
- Removed: None

## Screenshots

| View | Before | After |
|------|--------|-------|
| Mobile | N/A | N/A |
| Desktop | N/A | https://github.com/tonyblu331/la-velada-web-oficial/releases/download/pr-1546-video/stadium-underline-hover.mp4 |

## Checklist

- [ ] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None
