### PR TITLE
refactor(faq): use native details accordion

### DIFF
--- a/src/components/EventLocalTime.astro
+++ b/src/components/EventLocalTime.astro
@@ -1,0 +1,275 @@
+---
+import { EVENT_DATE_TIME, EVENT_DISPLAY_TIME } from '@/consts/event'
+---
+
+<span class="event-local-time">
+  <time
+    datetime={EVENT_DATE_TIME}
+    tabindex="0"
+    class="event-local-time__trigger cursor-help font-medium underline decoration-theme-gold/35 decoration-dotted underline-offset-[0.2em] transition-[text-decoration-color] duration-200 hover:decoration-theme-gold/80"
+  >
+    {EVENT_DISPLAY_TIME}
+  </time>
+  <span popover="manual" role="tooltip" class="event-local-time__tooltip">
+    <span class="event-local-time__tooltip-primary"></span>
+    <span class="event-local-time__tooltip-secondary" hidden></span>
+  </span>
+</span>
+
+<style is:global>
+  .event-local-time__trigger {
+    anchor-name: --event-local-time-trigger;
+  }
+
+  .event-local-time__tooltip {
+    position: fixed;
+    position-anchor: --event-local-time-trigger;
+    position-try-fallbacks: none;
+    inset: auto;
+    top: auto;
+    right: anchor(right);
+    left: auto;
+    bottom: anchor(top);
+    margin: 0;
+    width: max-content;
+    translate: 0 -0.35rem;
+    display: none;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 10.5rem;
+    max-width: min(20rem, 78vw);
+    padding: 0.55rem 0.85rem 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+    border-radius: 0.25rem;
+    background: color-mix(in srgb, var(--color-theme-midnight) 96%, transparent);
+    backdrop-filter: blur(12px);
+    box-shadow:
+      0 4px 12px color-mix(in srgb, black 28%, transparent),
+      0 12px 28px color-mix(in srgb, black 38%, transparent);
+    font-family: inherit;
+    text-align: left;
+    text-wrap: balance;
+    color: var(--color-theme-cream);
+    transform-origin: 100% 100%;
+    opacity: 0;
+    transform: scale(0.96);
+    pointer-events: none;
+  }
+
+  .event-local-time__tooltip-primary {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.35;
+    letter-spacing: 0.01em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .event-local-time__tooltip-secondary {
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0.03em;
+    color: color-mix(in srgb, var(--color-theme-cream) 72%, var(--color-theme-gold));
+  }
+
+  .event-local-time__tooltip:popover-open {
+    display: flex;
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
+  }
+
+  @starting-style {
+    .event-local-time__tooltip:popover-open {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+  }
+
+  @media (min-width: 640px) {
+    .event-local-time__tooltip {
+      gap: 0.25rem;
+      padding: 0.65rem 1rem 0.75rem;
+    }
+
+    .event-local-time__tooltip-primary {
+      font-size: 1.0625rem;
+    }
+
+    .event-local-time__tooltip-secondary {
+      font-size: 0.8125rem;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .event-local-time__tooltip {
+      right: auto;
+      left: anchor(left);
+      max-width: calc(100vw - 2rem);
+      transform-origin: 0 100%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .event-local-time__tooltip,
+    .event-local-time__tooltip:popover-open {
+      transform: none;
+    }
+  }
+
+  @supports not (anchor-name: --x) {
+    .event-local-time__tooltip {
+      position: fixed;
+      left: 50%;
+      right: auto;
+      bottom: auto;
+      top: 50%;
+      translate: -50% -50%;
+      transform: none;
+      transform-origin: 50% 50%;
+      text-align: center;
+    }
+  }
+</style>
+
+<script>
+  import { $, $$ } from '@/lib/dom-selector'
+  import { resolveEventLocalTime } from '@/lib/event-local-time'
+  import type { EventLocalTimeView } from '@/lib/event-local-time'
+  import { animate } from 'motion'
+
+  const EASE = [0.23, 1, 0.32, 1] as const
+  const EXIT_MS = 200
+  const anchorSupported = CSS.supports('anchor-name', '--x')
+  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)')
+  const hoverMedia = matchMedia('(hover: hover) and (pointer: fine)')
+
+  function canAnimate() {
+    return anchorSupported && !reducedMotion.matches
+  }
+
+  let abort: AbortController | undefined
+
+  function bind(root: HTMLElement, view: EventLocalTimeView, index: number, signal: AbortSignal) {
+    const trigger = $('time', root)
+    const tooltip = $('.event-local-time__tooltip', root)
+    const primary = tooltip && $('.event-local-time__tooltip-primary', tooltip)
+    if (!trigger || !tooltip || !primary) return
+
+    tooltip.id ||= `event-local-time-tip-${index}`
+    primary.textContent = view.tooltipPrimary
+    const secondary = $('.event-local-time__tooltip-secondary', tooltip)
+    if (secondary) {
+      secondary.textContent = view.tooltipSecondary ?? ''
+      secondary.hidden = !view.tooltipSecondary
+    }
+    trigger.setAttribute('aria-describedby', tooltip.id)
+
+    let hidePlayback: ReturnType<typeof animate> | null = null
+    let hideToken = 0
+    const isOpen = () => tooltip.matches(':popover-open')
+
+    const show = () => {
+      hideToken++
+      hidePlayback?.cancel()
+      hidePlayback = null
+      if (!isOpen()) tooltip.showPopover()
+      if (!canAnimate()) return
+      void animate(tooltip, { opacity: [0, 1], scale: [0.96, 1] }, { duration: 0.18, ease: EASE })
+      $$<HTMLElement>('.event-local-time__tooltip > span:not([hidden])', tooltip).forEach(
+        (line, i) => {
+          void animate(
+            line,
+            { opacity: [0, 1], transform: ['translateY(0.25rem)', 'translateY(0)'] },
+            { duration: 0.18, delay: i * 0.04, ease: EASE },
+          )
+        },
+      )
+    }
+
+    const hide = async () => {
+      if (!isOpen()) return
+      if (!canAnimate()) {
+        tooltip.hidePopover()
+        return
+      }
+      const token = ++hideToken
+      hidePlayback?.cancel()
+      const opacity = Number.parseFloat(getComputedStyle(tooltip).opacity) || 1
+      hidePlayback = animate(
+        tooltip,
+        { opacity: [opacity, 0], scale: [1, 0.96] },
+        { duration: 0.16, ease: EASE },
+      )
+      await Promise.race([
+        hidePlayback.finished.catch(() => undefined),
+        new Promise<void>((r) => setTimeout(r, EXIT_MS)),
+      ])
+      if (hideToken !== token) return
+      tooltip.hidePopover()
+      tooltip.style.opacity = ''
+      tooltip.style.transform = ''
+      hidePlayback = null
+    }
+
+    const hideIfIdle = () =>
+      requestAnimationFrame(() => {
+        if (!trigger.matches(':hover') && !tooltip.matches(':hover')) void hide()
+      })
+
+    trigger.addEventListener(
+      'pointerenter',
+      (e) => {
+        if (e.pointerType !== 'touch') show()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'pointerleave',
+      (e) => {
+        if (e.pointerType !== 'touch') hideIfIdle()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'focus',
+      () => {
+        if (hoverMedia.matches) show()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'blur',
+      () => {
+        if (hoverMedia.matches) void hide()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'click',
+      (e) => {
+        if (hoverMedia.matches && !(e instanceof PointerEvent && e.pointerType === 'touch')) return
+        e.preventDefault()
+        isOpen() ? void hide() : show()
+      },
+      { signal },
+    )
+  }
+
+  function setup() {
+    abort?.abort()
+    abort = new AbortController()
+    const roots = $$<HTMLElement>('.event-local-time')
+    if (!roots.length) return
+    let view: EventLocalTimeView
+    try {
+      view = resolveEventLocalTime()
+    } catch {
+      return
+    }
+    roots.forEach((root, i) => bind(root, view, i, abort.signal))
+  }
+
+  document.addEventListener('astro:page-load', setup)
+  setup()
+</script>

--- a/src/components/SectionHeader.astro
+++ b/src/components/SectionHeader.astro
@@ -4,7 +4,7 @@ import SectionDivider from '@/components/SectionDivider.astro'
 interface Props {
   titleId: string
   title: string
-  subtitle: string
+  subtitle?: string
   eyebrow?: string
   dividerClass?: string
   titleClass?: string
@@ -55,11 +55,15 @@ const {
   {title}
 </h2>
 
-<p
-  class:list={[
-    'text-center font-cinzel text-xs font-medium text-balance text-white/55',
-    subtitleClass,
-  ]}
->
-  {subtitle}
-</p>
+{
+  subtitle && (
+    <p
+      class:list={[
+        'text-center font-cinzel text-xs font-medium text-balance text-white/55',
+        subtitleClass,
+      ]}
+    >
+      {subtitle}
+    </p>
+  )
+}

--- a/src/consts/event.ts
+++ b/src/consts/event.ts
@@ -1,0 +1,11 @@
+export const EVENT_TIME_ZONE = 'Europe/Madrid'
+export const EVENT_DATE_DAY = '2026-07-25'
+export const EVENT_DATE_TIME = '2026-07-25T20:00:00+02:00'
+export const EVENT_DATE = new Date(EVENT_DATE_TIME)
+export const EVENT_ISO = EVENT_DATE.toISOString()
+export const EVENT_DURATION_HOURS = 5
+export const EVENT_END_ISO = new Date(
+  EVENT_DATE.getTime() + EVENT_DURATION_HOURS * 60 * 60 * 1000,
+).toISOString()
+export const EVENT_DISPLAY_TIME = '20:00H (españa peninsular)'
+export const EVENT_DISPLAY_TIME_SHORT = '20:00H CEST'

--- a/src/consts/home-faq.ts
+++ b/src/consts/home-faq.ts
@@ -1,39 +1,73 @@
 import { battles } from '@/consts/battles'
 
+interface HomeFaqStreamChannel {
+  platform: string
+  href: string
+  label: string
+}
+
+interface HomeFaqBattleItem {
+  number: number
+  title: string
+}
+
 export interface HomeFaqItem {
   question: string
   answer: string
+  channels?: readonly HomeFaqStreamChannel[]
+  battles?: readonly HomeFaqBattleItem[]
+  mainEventBattle?: HomeFaqBattleItem
+  eventTime?: boolean
 }
 
-const mainEvent = battles[battles.length - 1]
-if (!mainEvent) {
+const lastBattle = battles[battles.length - 1]
+if (!lastBattle) {
   throw new Error('No hay combates definidos para el FAQ de la home')
 }
 
-const confirmedBattles = battles.map(({ title }) => title).join('; ')
+const mainEventBattle: HomeFaqBattleItem = {
+  number: lastBattle.number,
+  title: lastBattle.title,
+}
 
 export const HOME_FAQS = [
   {
     question: '¿Cuándo es La Velada del Año VI?',
     answer:
-      'La Velada del Año VI se celebra el sábado 25 de julio de 2026 a partir de las 20:00h (horario de España peninsular).',
-  },
-  {
-    question: '¿Dónde se celebra?',
-    answer: 'Se celebra en el Estadio de La Cartuja, en Sevilla (España).',
+      'La Velada del Año VI se celebra el sábado 25 de julio de 2026 a partir de las',
+    eventTime: true,
   },
   {
     question: '¿Dónde se puede ver online?',
     answer:
-      'Se podrá ver online, en directo y gratis, en los canales oficiales de Ibai Llanos en Twitch, YouTube y TikTok.',
+      'En directo y de forma gratuita en los canales oficiales de Ibai Llanos, en:',
+    channels: [
+      {
+        platform: 'Twitch',
+        href: 'https://twitch.tv/ibai',
+        label: 'twitch.tv/ibai',
+      },
+      {
+        platform: 'YouTube',
+        href: 'https://youtube.com/@IbaiLlanos',
+        label: 'youtube.com/@IbaiLlanos',
+      },
+      {
+        platform: 'TikTok',
+        href: 'https://tiktok.com/@ibaillanos',
+        label: 'tiktok.com/@ibaillanos',
+      },
+    ],
   },
   {
     question: '¿Cuáles son los combates confirmados?',
-    answer: `Los combates confirmados de La Velada del Año VI son: ${confirmedBattles}.`,
+    answer: 'Estos son los combates confirmados de La Velada del Año VI:',
+    battles: battles.map((battle) => ({ number: battle.number, title: battle.title })),
   },
   {
     question: '¿Cuál es el main event?',
-    answer: `El main event confirmado es ${mainEvent.title}.`,
+    answer: 'El combate estelar de la noche es',
+    mainEventBattle,
   },
   {
     question: '¿Hay entradas disponibles?',

--- a/src/lib/event-local-time.ts
+++ b/src/lib/event-local-time.ts
@@ -1,0 +1,80 @@
+import { EVENT_DATE, EVENT_TIME_ZONE } from '@/consts/event'
+
+const MINUTE_MS = 60_000
+
+export interface EventLocalTimeView {
+  sameLocalTime: boolean
+  timeZoneId: string
+  tooltipPrimary: string
+  tooltipSecondary: string | null
+}
+
+function getUserTimeZoneId(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || EVENT_TIME_ZONE
+  } catch {
+    return EVENT_TIME_ZONE
+  }
+}
+
+function formatRelativeOffset(diffMinutes: number): string {
+  const abs = Math.abs(diffMinutes)
+  const h = Math.floor(abs / 60)
+  const m = abs % 60
+  return `${diffMinutes > 0 ? '+' : '-'}${[h ? `${h} h` : '', m ? `${m} min` : ''].filter(Boolean).join(' ')} de diferencia`
+}
+
+function getTimeZoneOffsetMinutes(date: Date, timeZoneId: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timeZoneId,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date)
+
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]))
+  const asUtc = Date.UTC(
+    Number(values.year),
+    Number(values.month) - 1,
+    Number(values.day),
+    Number(values.hour),
+    Number(values.minute),
+    Number(values.second),
+  )
+
+  return Math.round((asUtc - date.getTime()) / MINUTE_MS)
+}
+
+function formatEventPart(timeZoneId: string, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('es-ES', {
+    timeZone: timeZoneId,
+    ...options,
+  }).format(EVENT_DATE)
+}
+
+export function resolveEventLocalTime(timeZoneId = getUserTimeZoneId()): EventLocalTimeView {
+  const madridOffset = getTimeZoneOffsetMinutes(EVENT_DATE, EVENT_TIME_ZONE)
+  const localOffset = getTimeZoneOffsetMinutes(EVENT_DATE, timeZoneId)
+  const diffMinutes = localOffset - madridOffset
+  const sameLocalTime = diffMinutes === 0
+  const localDate = formatEventPart(timeZoneId, { day: 'numeric', month: 'short' })
+  const eventDate = formatEventPart(EVENT_TIME_ZONE, { day: 'numeric', month: 'short' })
+  const datePrefix = localDate === eventDate ? '' : `${localDate} · `
+  const localTime = new Intl.DateTimeFormat('en-US', {
+    timeZone: timeZoneId,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(EVENT_DATE)
+
+  return {
+    sameLocalTime,
+    timeZoneId,
+    tooltipPrimary: sameLocalTime ? 'Misma hora local' : `Tu hora local: ${datePrefix}${localTime}`,
+    tooltipSecondary: sameLocalTime ? null : formatRelativeOffset(diffMinutes),
+  }
+}

--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -1,5 +1,7 @@
 ---
+import EventLocalTime from '@/components/EventLocalTime.astro'
 import SectionHeader from '@/components/SectionHeader.astro'
+
 import type { HomeFaqItem } from '@/consts/home-faq'
 
 interface Props {
@@ -11,7 +13,7 @@ const { faqs } = Astro.props
 
 <section
   id="faq"
-  class="relative w-full overflow-hidden px-4 py-20 sm:px-6 lg:py-28"
+  class="faq-section relative w-full px-4 pt-12 pb-14 sm:px-6 sm:pt-18 sm:pb-20 lg:pt-24 lg:pb-28"
   aria-labelledby="faq-title"
   itemscope
   itemtype="https://schema.org/FAQPage"
@@ -28,60 +30,563 @@ const { faqs } = Astro.props
   >
   </div>
 
-  <div class="relative mx-auto flex max-w-4xl flex-col items-center">
-    <SectionHeader
-      titleId="faq-title"
-      eyebrow="INFORMACIÓN OFICIAL"
-      title="PREGUNTAS FRECUENTES"
-      subtitle="Respuestas rápidas sobre fecha, sede, directo, combates, entradas y anuncios de La Velada del Año VI."
-      titleClass="mb-4"
-      subtitleClass="mb-10 max-w-2xl tracking-[0.2em] sm:mb-14 sm:text-sm"
-    />
+  <div class="faq-layout relative mx-auto w-full max-w-7xl">
+    <header class="faq-title-row" aria-labelledby="faq-title">
+      <div class="faq-title-row__copy">
+        <SectionHeader
+          titleId="faq-title"
+          eyebrow="INFORMACIÓN OFICIAL"
+          title="PREGUNTAS FRECUENTES"
+          dividerClass="hidden"
+          eyebrowClass="mx-auto whitespace-nowrap text-center tracking-[0.32em] sm:tracking-[0.38em]"
+          titleClass="mx-auto mb-0 max-w-[13ch] text-center text-balance sm:text-4xl lg:max-w-[14ch] lg:text-[clamp(2.1rem,3.4vw,2.85rem)] lg:leading-[1.06] lg:tracking-[0.12em] xl:text-[clamp(2.35rem,3.6vw,3.1rem)]"
+        />
+      </div>
+    </header>
 
-    <ul class="w-full divide-y divide-white/10 border-y border-white/10">
-      {
-        faqs.map(({ question, answer }, index) => (
-          <li>
-            <details
-              class="group bg-theme-midnight/35 transition duration-300 open:bg-theme-navy/35 hover:bg-theme-navy/25"
-              itemprop="mainEntity"
-              itemscope
-              itemtype="https://schema.org/Question"
-              open={index === 0}
-            >
-              <summary class="flex min-h-20 cursor-pointer list-none items-center justify-between gap-5 px-2.5 py-5 outline-none marker:hidden focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight sm:min-h-24 sm:px-4 sm:py-6 [&::-webkit-details-marker]:hidden">
-                <h3
-                  itemprop="name"
-                  class="font-cinzel text-xl leading-tight font-bold tracking-[0.02em] text-balance text-theme-cream transition duration-300 group-open:text-theme-gold sm:text-2xl"
-                >
-                  {question}
-                </h3>
-                <span
-                  class="relative flex size-10.25 shrink-0 items-center justify-center rounded-full border border-theme-gold/30 bg-black/25 text-theme-gold transition duration-300 group-open:rotate-45 group-open:border-theme-gold/70 group-open:bg-theme-gold/15 sm:size-11.25"
-                  aria-hidden="true"
-                >
-                  <span class="absolute h-px w-4.25 bg-current"></span>
-                  <span class="absolute h-4.25 w-px bg-current"></span>
-                </span>
-              </summary>
-
-              <div
-                class="px-2.5 pb-6 pr-14 sm:px-4 sm:pr-20"
-                itemprop="acceptedAnswer"
-                itemscope
-                itemtype="https://schema.org/Answer"
+    <div class="faq-main">
+      <ul class="faq-list w-full">
+        {
+          faqs.map((faq, index) => {
+            const { question, answer, channels, battles, mainEventBattle, eventTime } = faq
+            return (
+              <li
+                class:list={['faq-item-wrap', index === faqs.length - 1 && 'faq-item-wrap--last']}
               >
-                <p
-                  itemprop="text"
-                  class="max-w-3xl text-base leading-7 text-pretty text-white/75 sm:text-lg sm:leading-8"
+                <span class="faq-divider" aria-hidden="true">
+                  <span class="faq-divider__gold" />
+                </span>
+                <details
+                  class:list={['faq-item group']}
+                  name="faq"
+                  itemprop="mainEntity"
+                  itemscope
+                  itemtype="https://schema.org/Question"
                 >
-                  {answer}
-                </p>
-              </div>
-            </details>
-          </li>
-        ))
-      }
-    </ul>
+                  <summary class="faq-summary min-h-16 cursor-pointer list-none px-2.5 py-4 outline-none marker:hidden sm:min-h-20 sm:px-4 sm:py-5 [&::-webkit-details-marker]:hidden">
+                    <h3
+                      itemprop="name"
+                      class="faq-summary__title font-cinzel text-lg leading-tight font-bold tracking-[0.02em] text-balance text-theme-cream transition-[color] duration-200 ease-out sm:text-2xl"
+                    >
+                      {question}
+                    </h3>
+                    <span class="faq-icon relative size-10 shrink-0 sm:size-11" aria-hidden="true">
+                      <span class="faq-icon__inner relative flex size-full items-center justify-center rounded-full border border-theme-gold/30 bg-black/25 text-theme-gold">
+                        <span class="faq-icon__bar faq-icon__bar--h absolute h-px w-4 bg-current" />
+                        <span class="faq-icon__bar faq-icon__bar--v absolute h-4 w-px bg-current" />
+                      </span>
+                    </span>
+                  </summary>
+
+                  <div
+                    class="faq-answer-shell"
+                    itemprop="acceptedAnswer"
+                    itemscope
+                    itemtype="https://schema.org/Answer"
+                  >
+                    <div
+                      itemprop="text"
+                      class:list={[
+                        'faq-answer-body px-2.5 pt-1 pb-7 text-base leading-7 text-pretty text-white/75 sm:px-4 sm:pb-9 sm:text-lg sm:leading-8',
+                        channels && 'faq-answer-body--stream',
+                        battles && 'faq-answer-body--battles',
+                        mainEventBattle && 'faq-answer-body--main-event',
+                      ]}
+                    >
+                      <p
+                        class:list={[(channels || battles || mainEventBattle) && 'faq-answer-lead']}
+                      >
+                        {answer}
+                        {eventTime && (
+                          <>
+                            {' '}
+                            <EventLocalTime />.
+                          </>
+                        )}
+                      </p>
+                      {channels && (
+                        <ul class="faq-channels list-none pl-0">
+                          {channels.map(({ platform, href, label }) => (
+                            <li>
+                              <a
+                                href={href}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                aria-label={`Ver en ${platform}: ${label}`}
+                                class="faq-channel-link inline-flex min-h-10 items-center py-1 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold/70"
+                              >
+                                <span class="faq-channel-handle text-[0.95em] font-medium tracking-normal text-theme-gold/90 sm:text-[1.05em]">
+                                  {label}
+                                </span>
+                              </a>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                      {battles && (
+                        <ol class="faq-battles list-none pl-0">
+                          {battles.map(({ number, title }) => (
+                            <li class="faq-battle-row">
+                              <span class="faq-battle-num" aria-hidden="true">
+                                {number}
+                              </span>
+                              <span class="faq-battle-title">{title}</span>
+                            </li>
+                          ))}
+                        </ol>
+                      )}
+                      {mainEventBattle && (
+                        <p class="faq-main-event-name" aria-label={mainEventBattle.title}>
+                          {mainEventBattle.title}
+                        </p>
+                      )}
+                    </div>
+                  </div>
+                </details>
+              </li>
+            )
+          })
+        }
+      </ul>
+    </div>
   </div>
 </section>
+
+<style>
+  .faq-section {
+    --faq-ease-out: cubic-bezier(0.23, 1, 0.32, 1);
+    --faq-content-width: 48rem;
+    --faq-text-measure: 56ch;
+    --faq-icon-col: 2rem;
+    --faq-icon-gap: 0.5rem;
+    interpolate-size: allow-keywords;
+  }
+
+  .faq-section,
+  .faq-main,
+  .faq-list {
+    overflow-anchor: none;
+  }
+
+  .faq-layout {
+    display: grid;
+    gap: 1.75rem;
+    max-width: var(--faq-content-width);
+  }
+
+  .faq-title-row__copy {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin-inline: auto;
+    text-align: center;
+  }
+
+  .faq-title-row :global(#faq-title),
+  .faq-title-row :global(p) {
+    text-align: center;
+  }
+
+  @media (min-width: 1024px) {
+    .faq-main {
+      width: min(100%, var(--faq-content-width));
+      max-width: var(--faq-content-width);
+      min-width: 0;
+      justify-self: center;
+      overflow-x: clip;
+    }
+
+    .faq-list {
+      width: 100%;
+    }
+
+    .faq-section {
+      --faq-text-measure: 60ch;
+    }
+
+    .faq-summary {
+      padding-inline: 1rem;
+      padding-block: clamp(1.25rem, 2vw, 1.75rem);
+      min-height: 5.5rem;
+    }
+
+    .faq-answer-body {
+      padding-inline: 1rem;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .faq-section {
+      --faq-content-width: 48rem;
+      --faq-text-measure: 60ch;
+    }
+  }
+
+  .faq-list {
+    border-bottom: none;
+  }
+
+  .faq-divider {
+    position: relative;
+    display: block;
+    height: 1px;
+    width: 100%;
+    flex-shrink: 0;
+    overflow: hidden;
+    background-color: rgb(255 255 255 / 0.1);
+  }
+
+  .faq-divider__gold {
+    position: absolute;
+    inset: 0;
+    background-color: var(--color-theme-gold);
+    transform: scaleX(0);
+    transform-origin: center center;
+    transition: transform 180ms var(--faq-ease-out);
+  }
+
+  .faq-item-wrap:has(.faq-item[open]) .faq-divider__gold {
+    transform: scaleX(1);
+  }
+
+  .faq-item-wrap:has(.faq-item[open]) .faq-summary__title {
+    color: var(--color-theme-gold);
+  }
+
+  .faq-item-wrap:has(.faq-item[open]) .faq-icon__inner {
+    border-color: color-mix(in srgb, var(--color-theme-gold) 70%, transparent);
+    background-color: color-mix(in srgb, var(--color-theme-gold) 15%, transparent);
+  }
+
+  .faq-item-wrap {
+    scroll-margin-block: 0.75rem;
+  }
+
+  .faq-item-wrap--last {
+    padding-bottom: clamp(1.25rem, 4vh, 3rem);
+    overflow-anchor: none;
+    contain: layout;
+  }
+
+  .faq-item-wrap--last .faq-item {
+    overflow-anchor: none;
+  }
+
+  .faq-item-wrap--last .faq-summary {
+    scroll-margin-top: 0;
+    scroll-margin-bottom: 0;
+  }
+
+  .faq-summary {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) var(--faq-icon-col);
+    column-gap: var(--faq-icon-gap);
+    align-items: center;
+    scroll-margin-top: 5.5rem;
+    scroll-margin-bottom: 0.25rem;
+    border-radius: 0.25rem;
+    transition: background-color 200ms ease-out;
+  }
+
+  .faq-summary__title {
+    grid-column: 1;
+    min-width: 0;
+    max-width: var(--faq-text-measure);
+    text-align: left;
+  }
+
+  .faq-icon {
+    grid-column: 2;
+    grid-row: 1;
+    justify-self: end;
+    contain: layout size style;
+    overflow: hidden;
+  }
+
+  .faq-icon__inner {
+    transform: rotate(0deg);
+    transform-origin: center;
+    transition:
+      transform 240ms var(--faq-ease-out),
+      border-color 200ms ease-out,
+      background-color 200ms ease-out;
+  }
+
+  .faq-item[open] .faq-icon__inner {
+    transform: rotate(45deg);
+  }
+
+  @media (min-width: 640px) {
+    .faq-section {
+      --faq-icon-col: 2.75rem;
+      --faq-icon-gap: 0.75rem;
+      --faq-text-measure: 56ch;
+    }
+
+    .faq-summary {
+      scroll-margin-top: 6rem;
+    }
+  }
+
+  .faq-icon__bar {
+    transform-origin: center;
+  }
+
+  .faq-item {
+    background-color: transparent;
+    border-radius: 0.35rem;
+    outline: 1px solid transparent;
+    outline-offset: 0.35rem;
+    transition:
+      background-color 200ms ease-out,
+      outline-color 200ms ease-out;
+  }
+
+  .faq-item::details-content {
+    block-size: 0;
+    overflow: clip;
+    transition:
+      block-size 280ms var(--faq-ease-out),
+      content-visibility 280ms var(--faq-ease-out);
+    transition-behavior: allow-discrete;
+  }
+
+  .faq-item[open]::details-content {
+    block-size: auto;
+  }
+
+  .faq-item:has(.faq-summary:focus-visible) {
+    outline-color: color-mix(in srgb, var(--color-theme-gold) 70%, transparent);
+    outline-width: 2px;
+  }
+
+  @media (hover: hover) {
+    .faq-item:not([open]) .faq-summary:hover {
+      background-color: color-mix(in srgb, var(--color-theme-navy) 25%, transparent);
+    }
+  }
+
+  .faq-answer-shell {
+    display: grid;
+    grid-template-rows: 0fr;
+    grid-template-columns: minmax(0, 1fr) var(--faq-icon-col);
+    column-gap: var(--faq-icon-gap);
+    align-content: start;
+    overflow: hidden;
+    overflow-anchor: none;
+    transform-origin: top center;
+    transition: grid-template-rows 260ms var(--faq-ease-out);
+  }
+
+  .faq-item[open] .faq-answer-shell {
+    grid-template-rows: 1fr;
+  }
+
+  .faq-answer-body {
+    grid-column: 1;
+    min-width: 0;
+    min-height: 0;
+    max-width: var(--faq-text-measure);
+    overflow: hidden;
+    opacity: 0;
+    text-align: left;
+    transform: translateY(-0.25rem);
+    transition:
+      opacity 180ms var(--faq-ease-out),
+      transform 220ms var(--faq-ease-out);
+  }
+
+  .faq-item[open] .faq-answer-body {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .faq-answer-body--stream .faq-answer-lead {
+    margin: 0;
+  }
+
+  .faq-answer-body--stream .faq-channels {
+    margin-top: 1.125rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  @media (min-width: 640px) {
+    .faq-answer-body--stream .faq-channels {
+      margin-top: 1.25rem;
+      gap: 1.125rem;
+    }
+  }
+
+  .faq-answer-body--stream .faq-channels li {
+    padding-block: 0.25rem;
+  }
+
+  .faq-channel-handle {
+    position: relative;
+    transition: color 200ms ease;
+  }
+
+  .faq-channel-link {
+    position: relative;
+  }
+
+  .faq-channel-link::before {
+    content: '';
+    position: absolute;
+    inset: -0.35rem -0.5rem;
+    min-width: 2.5rem;
+    min-height: 2.5rem;
+  }
+
+  .faq-channel-link:hover .faq-channel-handle,
+  .faq-channel-link:focus-visible .faq-channel-handle {
+    color: var(--color-theme-cream);
+  }
+
+  .faq-channel-handle::after {
+    content: '';
+    position: absolute;
+    bottom: -0.3rem;
+    left: 50%;
+    height: 1px;
+    width: 0;
+    transform: translateX(-50%);
+    background-color: var(--color-theme-gold);
+    transition: width 280ms var(--faq-ease-out);
+  }
+
+  .faq-channel-link:hover .faq-channel-handle::after,
+  .faq-channel-link:focus-visible .faq-channel-handle::after {
+    width: 100%;
+  }
+
+  .faq-answer-body--venue {
+    max-width: min(100%, 52rem);
+  }
+
+  .faq-venue-link {
+    font-weight: 500;
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
+    text-decoration-style: dotted;
+    text-underline-offset: 0.2em;
+    transition:
+      color 200ms ease,
+      text-decoration-color 200ms ease;
+  }
+
+  .faq-venue-link:hover,
+  .faq-venue-link:focus-visible {
+    color: var(--color-theme-cream);
+    text-decoration-color: color-mix(in srgb, var(--color-theme-gold) 80%, transparent);
+    outline: none;
+  }
+
+  .faq-answer-body--battles {
+    max-width: none;
+    width: 100%;
+  }
+
+  .faq-answer-body--battles .faq-answer-lead {
+    max-width: var(--faq-text-measure);
+    text-align: left;
+    margin-inline: 0;
+  }
+
+  .faq-answer-body--battles .faq-battles {
+    --faq-battle-gap: 0.875rem;
+    --faq-battle-col-gap: clamp(1.75rem, 4vw, 2.5rem);
+    margin-top: var(--faq-battle-gap);
+    margin-inline: 0;
+    width: fit-content;
+    max-width: 100%;
+    display: grid;
+    grid-template-columns: max-content;
+    justify-items: start;
+    gap: var(--faq-battle-gap);
+  }
+
+  @media (min-width: 640px) {
+    .faq-answer-body--battles .faq-battles {
+      grid-template-columns: max-content max-content;
+      column-gap: var(--faq-battle-col-gap);
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .faq-answer-body--battles .faq-battles,
+    .faq-answer-body--main-event .faq-main-event-name {
+      margin-inline: 0;
+    }
+  }
+
+  .faq-battle-row {
+    display: grid;
+    width: max-content;
+    max-width: min(100%, 22rem);
+    grid-template-columns: 1.75rem minmax(0, 1fr);
+    align-items: baseline;
+    column-gap: 0.75rem;
+    min-width: 0;
+    text-align: left;
+  }
+
+  .faq-battle-num {
+    font-size: 0.68rem;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    letter-spacing: 0.12em;
+    color: color-mix(in srgb, var(--color-theme-gold) 75%, transparent);
+  }
+
+  .faq-battle-title {
+    font-weight: 500;
+    line-height: 1.4;
+    text-wrap: balance;
+    color: color-mix(in srgb, var(--color-theme-cream) 95%, transparent);
+  }
+
+  .faq-answer-body--main-event .faq-main-event-name {
+    margin: 0.75rem 0 0;
+    max-width: min(100%, 40rem);
+    font-size: 1.125rem;
+    line-height: 1.4;
+    font-weight: 600;
+    text-wrap: balance;
+    color: color-mix(in srgb, var(--color-theme-cream) 92%, transparent);
+  }
+
+  @media (min-width: 640px) {
+    .faq-answer-body--main-event .faq-main-event-name {
+      margin-top: 0.875rem;
+      font-size: 1.25rem;
+    }
+  }
+
+  :global(footer) {
+    overflow-anchor: none;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .faq-answer-shell {
+      transition: none;
+    }
+
+    .faq-item[open] .faq-answer-shell {
+      grid-template-rows: 1fr;
+    }
+
+    .faq-answer-body {
+      transition: none;
+      transform: none;
+    }
+
+    .faq-item[open] .faq-answer-body {
+      opacity: 1;
+    }
+  }
+</style>


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [ ] feat
- [ ] fix
- [x] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

<!-- List each file changed with a one-line description. -->

- `src/sections/FAQ.astro`: refactors the FAQ section to native grouped `<details name="faq">`, CSS-based disclosure animation, centered heading, and left-aligned answer content.
- `src/consts/home-faq.ts`: changes FAQ data from plain text answers to structured answers for channels, fights, main event, and event time; removes the location/map FAQ entry.
- `src/components/EventLocalTime.astro`: adds the inline event local-time UI used by the FAQ.
- `src/lib/event-local-time.ts`: adds local-time resolution with `Date` and `Intl.DateTimeFormat`.
- `src/consts/event.ts`: adds event date/time constants needed by the FAQ local-time UI.
- `src/components/SectionHeader.astro`: supports the heading composition used by the FAQ section.

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added: None
- Removed: None

## Screenshots

<!-- Delete if not applicable. -->

| View | Before | After |
|------|--------|-------|
| Event local time | | ![Event time with local-time tooltip](https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/pr-assets-faq-native-section/pr-assets/faq-native-section/faq-event-local-time-tooltip.png) |
| Mobile | Pending | Pending |
| Desktop | Pending | Pending |

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->

None.