### PR TITLE
feat(faq): add event local time tooltip

### DIFF
--- a/src/components/EventLocalTime.astro
+++ b/src/components/EventLocalTime.astro
@@ -1,0 +1,304 @@
+---
+import { EVENT_DATE_TIME, EVENT_DISPLAY_TIME } from '@/consts/event'
+---
+
+<span class="event-local-time">
+  <time
+    datetime={EVENT_DATE_TIME}
+    tabindex="0"
+    class="event-local-time__trigger cursor-help font-medium underline decoration-theme-gold/35 decoration-dotted underline-offset-[0.2em] transition-[text-decoration-color] duration-200 hover:decoration-theme-gold/80"
+  >
+    {EVENT_DISPLAY_TIME}
+  </time>
+  <span popover="manual" role="tooltip" class="event-local-time__tooltip">
+    <span class="event-local-time__tooltip-primary"></span>
+    <span class="event-local-time__tooltip-secondary" hidden></span>
+  </span>
+</span>
+
+<style is:global>
+  .event-local-time__tooltip {
+    position: fixed;
+    inset: auto;
+    top: var(--event-local-time-top, 50%);
+    right: auto;
+    left: var(--event-local-time-left, 50%);
+    bottom: auto;
+    margin: 0;
+    width: max-content;
+    translate: 0 0;
+    display: none;
+    flex-direction: column;
+    gap: 0.2rem;
+    min-width: 10.5rem;
+    max-width: min(20rem, var(--event-local-time-max-width, calc(100vw - 2rem)));
+    padding: 0.55rem 0.85rem 0.65rem;
+    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+    border-radius: 0.25rem;
+    background: color-mix(in srgb, var(--color-theme-midnight) 96%, transparent);
+    backdrop-filter: blur(12px);
+    box-shadow:
+      0 4px 12px color-mix(in srgb, black 28%, transparent),
+      0 12px 28px color-mix(in srgb, black 38%, transparent);
+    font-family: inherit;
+    text-align: left;
+    text-wrap: balance;
+    color: var(--color-theme-cream);
+    transform-origin: 0 100%;
+    opacity: 0;
+    transform: scale(0.96);
+    pointer-events: none;
+  }
+
+  .event-local-time__tooltip-primary {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.35;
+    letter-spacing: 0.01em;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .event-local-time__tooltip-secondary {
+    font-size: 0.75rem;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0.03em;
+    color: color-mix(in srgb, var(--color-theme-cream) 72%, var(--color-theme-gold));
+  }
+
+  .event-local-time__tooltip:popover-open {
+    display: flex;
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
+  }
+
+  @starting-style {
+    .event-local-time__tooltip:popover-open {
+      opacity: 0;
+      transform: scale(0.96);
+    }
+  }
+
+  @media (min-width: 640px) {
+    .event-local-time__tooltip {
+      gap: 0.25rem;
+      padding: 0.65rem 1rem 0.75rem;
+    }
+
+    .event-local-time__tooltip-primary {
+      font-size: 1.0625rem;
+    }
+
+    .event-local-time__tooltip-secondary {
+      font-size: 0.8125rem;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .event-local-time__tooltip {
+      max-width: var(--event-local-time-max-width, calc(100vw - 2rem));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .event-local-time__tooltip,
+    .event-local-time__tooltip:popover-open {
+      transform: none;
+    }
+  }
+
+</style>
+
+<script>
+  import { $, $$ } from '@/lib/dom-selector'
+  import { resolveEventLocalTime } from '@/lib/event-local-time'
+  import type { EventLocalTimeView } from '@/lib/event-local-time'
+  import { animate } from 'motion'
+
+  const EASE = [0.23, 1, 0.32, 1] as const
+  const EXIT_MS = 200
+  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)')
+  const hoverMedia = matchMedia('(hover: hover) and (pointer: fine)')
+
+  function canAnimate() {
+    return !reducedMotion.matches
+  }
+
+  let abort: AbortController | undefined
+
+  function bind(root: HTMLElement, view: EventLocalTimeView, index: number, signal: AbortSignal) {
+    const trigger = $('time', root)
+    const tooltip = $('.event-local-time__tooltip', root)
+    const primary = tooltip && $('.event-local-time__tooltip-primary', tooltip)
+    if (!trigger || !tooltip || !primary) return
+
+    tooltip.id ||= `event-local-time-tip-${index}`
+    primary.textContent = view.tooltipPrimary
+    const secondary = $('.event-local-time__tooltip-secondary', tooltip)
+    if (secondary) {
+      secondary.textContent = view.tooltipSecondary ?? ''
+      secondary.hidden = !view.tooltipSecondary
+    }
+    trigger.setAttribute('aria-describedby', tooltip.id)
+
+    let hidePlayback: ReturnType<typeof animate> | null = null
+    let hideToken = 0
+    let ignoreNextClick = false
+    const isOpen = () => tooltip.matches(':popover-open')
+    const positionTooltip = () => {
+      const triggerRect = trigger.getBoundingClientRect()
+      const container = root.closest<HTMLElement>('[itemprop="acceptedAnswer"]') ?? root
+      const faqSection = root.closest<HTMLElement>('#faq') ?? container
+      const containerRect = container.getBoundingClientRect()
+      const faqRect = faqSection.getBoundingClientRect()
+      const viewportInset = 16
+      const minWidth = 168
+      const containerLeft = Math.max(containerRect.left, viewportInset)
+      const containerRight = Math.min(containerRect.right, window.innerWidth - viewportInset)
+      const left = Math.max(containerLeft, Math.min(triggerRect.left, containerRight - minWidth))
+      const tooltipHeight = tooltip.getBoundingClientRect().height
+      const containerTop = Math.max(faqRect.top, viewportInset)
+      const top = Math.max(containerTop, triggerRect.top - tooltipHeight - 6)
+
+      tooltip.style.setProperty('--event-local-time-left', `${left}px`)
+      tooltip.style.setProperty('--event-local-time-top', `${top}px`)
+      tooltip.style.setProperty(
+        '--event-local-time-max-width',
+        `${Math.max(minWidth, containerRight - left)}px`,
+      )
+    }
+    const syncTooltipPosition = () => {
+      if (isOpen()) positionTooltip()
+    }
+
+    const show = () => {
+      hideToken++
+      hidePlayback?.cancel()
+      hidePlayback = null
+      if (!isOpen()) tooltip.showPopover()
+      positionTooltip()
+      if (!canAnimate()) return
+      void animate(tooltip, { opacity: [0, 1], scale: [0.96, 1] }, { duration: 0.18, ease: EASE })
+      $$<HTMLElement>('.event-local-time__tooltip > span:not([hidden])', tooltip).forEach(
+        (line, i) => {
+          void animate(
+            line,
+            { opacity: [0, 1], transform: ['translateY(0.25rem)', 'translateY(0)'] },
+            { duration: 0.18, delay: i * 0.04, ease: EASE },
+          )
+        },
+      )
+    }
+
+    const hide = async () => {
+      if (!isOpen()) return
+      if (!canAnimate()) {
+        tooltip.hidePopover()
+        return
+      }
+      const token = ++hideToken
+      hidePlayback?.cancel()
+      const opacity = Number.parseFloat(getComputedStyle(tooltip).opacity) || 1
+      hidePlayback = animate(
+        tooltip,
+        { opacity: [opacity, 0], scale: [1, 0.96] },
+        { duration: 0.16, ease: EASE },
+      )
+      await Promise.race([
+        hidePlayback.finished.catch(() => undefined),
+        new Promise<void>((r) => setTimeout(r, EXIT_MS)),
+      ])
+      if (hideToken !== token) return
+      tooltip.hidePopover()
+      tooltip.style.opacity = ''
+      tooltip.style.transform = ''
+      hidePlayback = null
+    }
+
+    const hideIfIdle = () => {
+      window.setTimeout(() => {
+        if (!trigger.matches(':hover') && !tooltip.matches(':hover')) void hide()
+      }, 80)
+    }
+
+    trigger.addEventListener(
+      'pointerenter',
+      (e) => {
+        if (e.pointerType !== 'touch') show()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'pointerleave',
+      (e) => {
+        if (e.pointerType !== 'touch') hideIfIdle()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'focus',
+      () => {
+        show()
+        if (!hoverMedia.matches) ignoreNextClick = true
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'blur',
+      () => {
+        void hide()
+      },
+      { signal },
+    )
+    trigger.addEventListener(
+      'click',
+      (e) => {
+        if (hoverMedia.matches && !(e instanceof PointerEvent && e.pointerType === 'touch')) return
+        e.preventDefault()
+        if (ignoreNextClick) {
+          ignoreNextClick = false
+          return
+        }
+        isOpen() ? void hide() : show()
+      },
+      { signal },
+    )
+    window.addEventListener('resize', syncTooltipPosition, { signal })
+    window.addEventListener('scroll', syncTooltipPosition, { capture: true, signal })
+    window.addEventListener(
+      'pointerdown',
+      (event) => {
+        const target = event.target
+        if (!(target instanceof Node)) return
+        if (root.contains(target) || tooltip.contains(target)) return
+        void hide()
+      },
+      { signal },
+    )
+    window.addEventListener(
+      'keydown',
+      (event) => {
+        if (event.key === 'Escape') void hide()
+      },
+      { signal },
+    )
+  }
+
+  function setup() {
+    abort?.abort()
+    abort = new AbortController()
+    const roots = $$<HTMLElement>('.event-local-time')
+    if (!roots.length) return
+    let view: EventLocalTimeView
+    try {
+      view = resolveEventLocalTime()
+    } catch {
+      return
+    }
+    roots.forEach((root, i) => bind(root, view, i, abort.signal))
+  }
+
+  document.addEventListener('astro:page-load', setup)
+  setup()
+</script>

--- a/src/consts/event.ts
+++ b/src/consts/event.ts
@@ -1,0 +1,11 @@
+export const EVENT_TIME_ZONE = 'Europe/Madrid'
+export const EVENT_DATE_DAY = '2026-07-25'
+export const EVENT_DATE_TIME = '2026-07-25T20:00:00+02:00'
+export const EVENT_DATE = new Date(EVENT_DATE_TIME)
+export const EVENT_ISO = EVENT_DATE.toISOString()
+export const EVENT_DURATION_HOURS = 5
+export const EVENT_END_ISO = new Date(
+  EVENT_DATE.getTime() + EVENT_DURATION_HOURS * 60 * 60 * 1000,
+).toISOString()
+export const EVENT_DISPLAY_TIME = '20:00H (españa peninsular)'
+export const EVENT_DISPLAY_TIME_SHORT = '20:00H CEST'

--- a/src/consts/home-faq.ts
+++ b/src/consts/home-faq.ts
@@ -3,6 +3,8 @@ import { battles } from '@/consts/battles'
 export interface HomeFaqItem {
   question: string
   answer: string
+  schemaAnswer?: string
+  eventTime?: boolean
 }
 
 const mainEvent = battles[battles.length - 1]
@@ -16,7 +18,10 @@ export const HOME_FAQS = [
   {
     question: '¿Cuándo es La Velada del Año VI?',
     answer:
-      'La Velada del Año VI se celebra el sábado 25 de julio de 2026 a partir de las 20:00h (horario de España peninsular).',
+      'La Velada del Año VI se celebra el sábado 25 de julio de 2026 a partir de las',
+    schemaAnswer:
+      'La Velada del Año VI se celebra el sábado 25 de julio de 2026 a partir de las 20:00H (españa peninsular).',
+    eventTime: true,
   },
   {
     question: '¿Dónde se celebra?',

--- a/src/lib/event-local-time.ts
+++ b/src/lib/event-local-time.ts
@@ -1,0 +1,80 @@
+import { EVENT_DATE, EVENT_TIME_ZONE } from '@/consts/event'
+
+const MINUTE_MS = 60_000
+
+export interface EventLocalTimeView {
+  sameLocalTime: boolean
+  timeZoneId: string
+  tooltipPrimary: string
+  tooltipSecondary: string | null
+}
+
+function getUserTimeZoneId(): string {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || EVENT_TIME_ZONE
+  } catch {
+    return EVENT_TIME_ZONE
+  }
+}
+
+function formatRelativeOffset(diffMinutes: number): string {
+  const abs = Math.abs(diffMinutes)
+  const h = Math.floor(abs / 60)
+  const m = abs % 60
+  return `${diffMinutes > 0 ? '+' : '-'}${[h ? `${h} h` : '', m ? `${m} min` : ''].filter(Boolean).join(' ')} de diferencia`
+}
+
+function getTimeZoneOffsetMinutes(date: Date, timeZoneId: string): number {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: timeZoneId,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+  }).formatToParts(date)
+
+  const values = Object.fromEntries(parts.map(({ type, value }) => [type, value]))
+  const asUtc = Date.UTC(
+    Number(values.year),
+    Number(values.month) - 1,
+    Number(values.day),
+    Number(values.hour),
+    Number(values.minute),
+    Number(values.second),
+  )
+
+  return Math.round((asUtc - date.getTime()) / MINUTE_MS)
+}
+
+function formatEventPart(timeZoneId: string, options: Intl.DateTimeFormatOptions): string {
+  return new Intl.DateTimeFormat('es-ES', {
+    timeZone: timeZoneId,
+    ...options,
+  }).format(EVENT_DATE)
+}
+
+export function resolveEventLocalTime(timeZoneId = getUserTimeZoneId()): EventLocalTimeView {
+  const madridOffset = getTimeZoneOffsetMinutes(EVENT_DATE, EVENT_TIME_ZONE)
+  const localOffset = getTimeZoneOffsetMinutes(EVENT_DATE, timeZoneId)
+  const diffMinutes = localOffset - madridOffset
+  const sameLocalTime = diffMinutes === 0
+  const localDate = formatEventPart(timeZoneId, { day: 'numeric', month: 'short' })
+  const eventDate = formatEventPart(EVENT_TIME_ZONE, { day: 'numeric', month: 'short' })
+  const datePrefix = localDate === eventDate ? '' : `${localDate} · `
+  const localTime = new Intl.DateTimeFormat('en-US', {
+    timeZone: timeZoneId,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(EVENT_DATE)
+
+  return {
+    sameLocalTime,
+    timeZoneId,
+    tooltipPrimary: sameLocalTime ? 'Misma hora local' : `Tu hora local: ${datePrefix}${localTime}`,
+    tooltipSecondary: sameLocalTime ? null : formatRelativeOffset(diffMinutes),
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -107,12 +107,12 @@ const sportsEventJsonLd = {
 const faqJsonLd = {
   '@context': 'https://schema.org',
   '@type': 'FAQPage',
-  mainEntity: HOME_FAQS.map(({ question, answer }) => ({
+  mainEntity: HOME_FAQS.map(({ question, answer, schemaAnswer }) => ({
     '@type': 'Question',
     name: question,
     acceptedAnswer: {
       '@type': 'Answer',
-      text: answer,
+      text: schemaAnswer ?? answer,
     },
   })),
 }

--- a/src/sections/FAQ.astro
+++ b/src/sections/FAQ.astro
@@ -1,4 +1,5 @@
 ---
+import EventLocalTime from '@/components/EventLocalTime.astro'
 import SectionHeader from '@/components/SectionHeader.astro'
 import type { HomeFaqItem } from '@/consts/home-faq'
 
@@ -40,7 +41,7 @@ const { faqs } = Astro.props
 
     <ul class="w-full divide-y divide-white/10 border-y border-white/10">
       {
-        faqs.map(({ question, answer }, index) => (
+        faqs.map(({ question, answer, eventTime }, index) => (
           <li>
             <details
               class="group bg-theme-midnight/35 transition duration-300 open:bg-theme-navy/35 hover:bg-theme-navy/25"
@@ -76,6 +77,12 @@ const { faqs } = Astro.props
                   class="max-w-3xl text-base leading-7 text-pretty text-white/75 sm:text-lg sm:leading-8"
                 >
                   {answer}
+                  {eventTime && (
+                    <>
+                      {' '}
+                      <EventLocalTime />.
+                    </>
+                  )}
                 </p>
               </div>
             </details>


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Depends on #1548

## Changes

<!-- List each file changed with a one-line description. -->

- `src/components/EventLocalTime.astro`: adds the inline event local-time label and hover/focus tooltip.
- `src/lib/event-local-time.ts`: resolves the user's local event time with `Date` and `Intl.DateTimeFormat`.
- `src/consts/event.ts`: provides the event date/time constants used by the tooltip.
- `src/consts/home-faq.ts`: marks the event-date FAQ answer as using the local-time label.
- `src/sections/FAQ.astro`: renders `EventLocalTime` inside the existing FAQ answer without changing the FAQ layout.
- `src/pages/index.astro`: uses `schemaAnswer` when present so FAQ JSON-LD keeps complete plain text.

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added: None
- Removed: None

## Screenshots

<!-- Delete if not applicable. -->

| View | Before | After |
|------|--------|-------|
| Event local time | | ![Event time with local-time tooltip](https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/pr-assets-faq-native-section/pr-assets/faq-native-section/faq-event-local-time-tooltip.png) |

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Funcionalidades**
  * Se añadió en el FAQ una marca de tiempo con la hora del evento en la zona horaria local del usuario, con tooltip accesible que muestra la hora local y, si aplica, el desglose de la diferencia respecto a la zona del evento.
* **Mejoras**
  * Se ajustó el contenido del FAQ para separar el texto visible y la variante destinada al marcado estructurado.
  * El JSON-LD del FAQ ahora usa esa variante cuando está disponible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->