### PR TITLE
fix: endurecer la carga de imágenes locales y el acceso a la sesión

### DIFF
--- a/src/pages/api/predictions.ts
+++ b/src/pages/api/predictions.ts
@@ -24,7 +24,7 @@ async function getUserId(request: Request) {
     headers: request.headers,
   })
 
-  return session?.user.id ?? null
+  return session?.user?.id ?? null
 }
 
 export const GET: APIRoute = async ({ request, url }) => {

--- a/src/utils/get-optimized-image-url.ts
+++ b/src/utils/get-optimized-image-url.ts
@@ -25,10 +25,16 @@ async function getLocalImageUrl(imageUrl: string): Promise<ImageMetadata | strin
   // Format the image path to be used in the import.meta.glob
   const formattedImagePath = sanitizedImagePath.includes('../../public') ? sanitizedImagePath : `../../public/${sanitizedImagePath}`
 
-  // Get image object from the import.meta.glob
-  const imageObject = await images[formattedImagePath as keyof typeof images]()
+  // Get the image loader from the import.meta.glob
+  const imageLoader = images[formattedImagePath as keyof typeof images]
+
+  // Fail loudly with a useful message instead of an opaque "is not a function" TypeError
+  if (!imageLoader) {
+    throw new Error(`Imagen local no encontrada: ${formattedImagePath}`)
+  }
 
   // Return the image object
+  const imageObject = await imageLoader()
   return imageObject.default
 }
 


### PR DESCRIPTION
## 📝 Descripción

Dos arreglos pequeños de robustez (*correctness*) que evitan fallos opacos
y difíciles de depurar. No hay cambios de comportamiento visible, de diseño
ni de API pública.

---

## 🐛 Problema 1 — `getOptimizedImageUrl` lanza un `TypeError` sin contexto

En `src/utils/get-optimized-image-url.ts`, cuando se solicita una imagen
local cuya ruta **no existe** como clave del `import.meta.glob`, el acceso
`images[ruta]` devuelve `undefined` y, al invocarlo inmediatamente con `()`,
se produce un error opaco:

```
TypeError: images[...] is not a function
```

Ese error no indica qué ruta falló ni desde qué componente, lo que complica
mucho la depuración (por ejemplo, una ruta mal escrita o un archivo que aún
no se ha generado revienta el render de la página sin pista alguna).

### Solución

Se separa la obtención del *loader* de su invocación y se valida que exista
antes de llamarlo, lanzando un error descriptivo que incluye la ruta:

```ts
const imageLoader = images[formattedImagePath as keyof typeof images]

if (!imageLoader) {
  throw new Error(`Imagen local no encontrada: ${formattedImagePath}`)
}

const imageObject = await imageLoader()
return imageObject.default
```

---

## 🐛 Problema 2 — Posible `500` en `/api/predictions` con sesión inconsistente

En `src/pages/api/predictions.ts`, la función `getUserId` accedía a la
propiedad con un *optional chaining* incompleto:

```ts
return session?.user.id ?? null
```

El `?.` solo protege contra `session` nulo. Si `session` existe pero
`session.user` es `undefined` (un estado de sesión inconsistente), se lanza
`Cannot read properties of undefined (reading 'id')`, que acaba devolviendo
un **500** en lugar de tratarlo correctamente como usuario no autenticado.

### Solución

Encadenamiento opcional completo, de modo que cualquier ausencia de usuario
se resuelve a `null` (no autenticado), que es el flujo ya contemplado por
los endpoints:

```ts
return session?.user?.id ?? null
```

---

## ✅ Plan de pruebas

- [x] `pnpm build` completa correctamente de principio a fin (compilación, bundling y prerender).
- [x] Verificado que los avisos de lint existentes en `src/sections/Sponsors.astro` son previos a este PR y ajenos a estos cambios (no se tocan esos archivos).
- [x] El flujo de optimización de imágenes sigue funcionando con rutas válidas; las rutas inválidas ahora fallan con un mensaje claro en vez de un `TypeError` genérico.
- [x] El endpoint `/api/predictions` con `?mine=1` sin sesión válida sigue devolviendo `401` (no autenticado) en lugar de `500`.

## 📦 Archivos modificados

- `src/utils/get-optimized-image-url.ts` — validación del *loader* del glob.
- `src/pages/api/predictions.ts` — *optional chaining* completo en `getUserId`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de versión

* **Bug Fixes**
  * Mejorado el manejo de errores al procesar imágenes locales con mensajes más explícitos.
  * Optimizado el acceso a datos de sesión para mayor confiabilidad en la autenticación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->