### PR TITLE
fix(a11y): no exponer combates inactivos como enlaces enfocables al 404

### DIFF
--- a/src/components/CombatCard.astro
+++ b/src/components/CombatCard.astro
@@ -27,6 +27,15 @@ const { number, url, featured = false, badge, a, b } = Astro.props
 const combatHref = '/404'
 void url // (se conserva en props para reactivar el enlace real más adelante)
 
+// Mientras el combate apunta al 404 temporal no debe ser un enlace real:
+// un `<a aria-disabled>` sigue siendo enfocable por teclado y navegable con
+// Enter, llevando al usuario a un 404 a propósito. Cuando está «próximamente»
+// renderizamos un elemento no interactivo (no enfocable, sin href) y exponemos
+// el estado mediante role="img" + aria-label para lectores de pantalla.
+const isComingSoon = combatHref === '/404'
+const CombatTag = isComingSoon ? 'span' : 'a'
+const combatAriaLabel = `Combate: ${a.name} contra ${b.name}${isComingSoon ? ' (próximamente)' : ''}`
+
 const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     { ...a, side: 'a' },
     { ...b, side: 'b' },
@@ -74,15 +83,25 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
     }
 
     {/* Enlace del combate → 404 temporal (ver nota arriba: cambiar combatHref por url). */}
-    <a class={combatHref === '/404' ? 'vslink pointer-events-none' : 'vslink'} href={combatHref} aria-disabled={combatHref === '/404'} aria-label={`Combate: ${a.name} contra ${b.name} (próximamente)`}>
+    <CombatTag
+        class={isComingSoon ? 'vslink pointer-events-none' : 'vslink'}
+        href={isComingSoon ? undefined : combatHref}
+        role={isComingSoon ? 'img' : undefined}
+        aria-label={combatAriaLabel}
+    >
         <span class="vsmedal font-cinzel"><b>VS</b></span>
-    </a>
+    </CombatTag>
     </div>
 
-    <a class={combatHref === '/404' ? 'combat-foot pointer-events-none' : 'combat-foot'} href={combatHref} aria-disabled={combatHref === '/404'} aria-label={`Combate: ${a.name} contra ${b.name} (próximamente)`}>
+    <CombatTag
+        class={isComingSoon ? 'combat-foot pointer-events-none' : 'combat-foot'}
+        href={isComingSoon ? undefined : combatHref}
+        role={isComingSoon ? 'img' : undefined}
+        aria-label={combatAriaLabel}
+    >
     <span class="combat-no font-cinzel">Combate {String(number).padStart(2, '0')}</span>
     <span class="combat-cta font-cinzel">Ver cara a cara <span aria-hidden="true">&rarr;</span></span>
-    </a>
+    </CombatTag>
 </article>
 
 <style>


### PR DESCRIPTION
## 📝 Descripción

Mientras la landing individual de cada combate (`/combate/[id]`) todavía no
está disponible, las tarjetas de combate enlazan a `/404` a propósito. El
problema es **cómo** se marca ese estado inactivo: con un enlace real
«deshabilitado».

```astro
<a class="vslink pointer-events-none" href="/404" aria-disabled="true" aria-label="…">
```

Esto tiene dos problemas de accesibilidad reales:

1. **`aria-disabled` no es un atributo válido en `<a>`.** El enlace sigue
   siendo enfocable por teclado y se anuncia como un enlace normal.
2. **`pointer-events-none` solo bloquea el ratón.** Un usuario que navega con
   teclado puede llegar al enlace con `Tab` y pulsar `Enter`, aterrizando en
   la página **404 a propósito**.

El resultado: para quien usa teclado o lector de pantalla, la tarjeta expone
un enlace «desactivado» que, sin embargo, navega a un error.

## 🔧 Solución

Cuando el combate está «próximamente» se renderiza un elemento **no
interactivo** en lugar de un enlace:

- Se usa un `<span>` (sin `href`), por lo que **no es enfocable** ni navegable
  con teclado.
- El estado se expone correctamente a lectores de pantalla mediante
  `role="img"` + `aria-label` (`"Combate: A contra B (próximamente)"`).
- Cuando la vista real del combate esté lista y se reactive el enlace
  (`combatHref = url`), vuelve a renderizarse como un `<a>` navegable de forma
  automática, sin más cambios.

```astro
const isComingSoon = combatHref === '/404'
const CombatTag = isComingSoon ? 'span' : 'a'
```

## 🎨 Impacto visual

**Ninguno.** Los estilos usan selectores por clase (`.vslink`, `.combat-foot`),
así que el `<span>` conserva exactamente el mismo aspecto que el `<a>`. Se
mantiene `pointer-events-none` para preservar el comportamiento visual actual.

## ✅ Plan de pruebas

- [x] `pnpm build` completa correctamente.
- [x] Inspeccionado el HTML generado: las tarjetas inactivas renderizan
      `<span role="img" aria-label="…(próximamente)">` en lugar de
      `<a href="/404">`.
- [x] El elemento ya no es alcanzable con `Tab` ni navega a `/404` con `Enter`.
- [x] El aspecto visual de la tarjeta es idéntico al actual.

## 📦 Archivos modificados

- `src/components/CombatCard.astro`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Notas de Lanzamiento

* **Accesibilidad**
  * Se mejoraron las etiquetas ARIA en los combates, proporcionando mejor contexto a usuarios de lectores de pantalla sobre los participantes y estado del evento.
  * Se optimizó la estructura semántica del marcado para mejor comprensión de la información de combate.

* **Mejoras**
  * Se refinó la presentación de combates próximamente con mejor diferenciación visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->