### PR TITLE
fix(sponsors): añade las comas finales que faltan para pasar el lint

### DIFF
--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -200,7 +200,7 @@ const SPONSORS: Sponsor[] = [
               width,
               height,
             },
-            index
+            index,
           ) => (
             <a
               href={withUtm(url, { medium: 'promo_banner', content: slug })}
@@ -227,7 +227,7 @@ const SPONSORS: Sponsor[] = [
                 />
               </picture>
             </a>
-          )
+          ),
         )
       }
     </div>


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Lo detecté ejecutando `pnpm lint` en una copia limpia de `main`: falla con 2 errores y deja el CI en rojo.

## Changes

- `src/sections/Sponsors.astro`: añade la coma final que faltaba tras el parámetro `index` y tras el `)` de cierre de la función de render del `.map` de los banners promocionales. La regla `comma-dangle` de ESLint exige ambas, así que sin ellas `pnpm lint` falla.

## Por qué

En `main` tal cual está hoy, `pnpm lint` no pasa:

```
src/sections/Sponsors.astro
  203:18  error  Missing trailing comma  comma-dangle
  230:12  error  Missing trailing comma  comma-dangle
```

Es un arreglo puramente mecánico (solo añade dos comas), no toca lógica ni estilos, y deja el lint en verde otra vez.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> No hay cambios visuales: la sección de patrocinadores se renderiza exactamente igual.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Mejoras**
  * Se optimizó la animación de los banners de patrocinadores para mostrar un efecto escalonado más fluido y visualmente atractivo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->