### PR TITLE
fix(footer): avisa de que los enlaces externos abren en una pestaña nueva

### DIFF
--- a/src/sections/Footer.astro
+++ b/src/sections/Footer.astro
@@ -80,7 +80,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
           rel="noopener noreferrer"
           style="--brand: #a970ff;"
           class="group relative flex min-h-11 w-full items-center justify-center gap-2 px-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-          aria-label="Seguir a Ibai en Twitch"
+          aria-label="Seguir a Ibai en Twitch (abre en nueva pestaña)"
         >
           <span
             aria-hidden="true"
@@ -102,7 +102,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
           rel="noopener noreferrer"
           style="--brand: #00f2ea;"
           class="group relative flex min-h-11 w-full items-center justify-center gap-2 px-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-          aria-label="Seguir a Ibai Llanos en TikTok"
+          aria-label="Seguir a Ibai Llanos en TikTok (abre en nueva pestaña)"
         >
           <span
             aria-hidden="true"
@@ -124,7 +124,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
           rel="noopener noreferrer"
           style="--brand: #ff0000;"
           class="group relative flex min-h-11 w-full items-center justify-center gap-2 px-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-          aria-label="Seguir a Ibai Llanos en YouTube"
+          aria-label="Seguir a Ibai Llanos en YouTube (abre en nueva pestaña)"
         >
           <span
             aria-hidden="true"
@@ -146,7 +146,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
           rel="noopener noreferrer"
           style="--brand: #ffffff;"
           class="group relative flex min-h-11 w-full items-center justify-center gap-2 px-4 transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-          aria-label="Seguir a Ibai Llanos en X"
+          aria-label="Seguir a Ibai Llanos en X (abre en nueva pestaña)"
         >
           <span
             aria-hidden="true"
@@ -173,7 +173,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
           href={INFOJOBS_FOOTER_URL}
           target="_blank"
           rel="sponsored noopener noreferrer"
-          aria-label="Ir a la página web de InfoJobs"
+          aria-label="Ir a la página web de InfoJobs (abre en nueva pestaña)"
           style="--brand: #167db7;"
           class="group inline-flex items-center text-white transition duration-300 hover:-translate-y-0.5 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-[var(--brand)]"
         >
@@ -203,7 +203,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
                     target="_blank"
                     rel="noopener noreferrer"
                     class="group/edition relative inline-flex min-h-8 items-center justify-center px-1 outline-none transition-colors duration-150 ease-out [@media(hover:hover)_and_(pointer:fine)]:hover:text-theme-cream [@media(hover:hover)_and_(pointer:fine)]:hover:delay-[125ms] focus-visible:text-theme-cream focus-visible:delay-[125ms] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
-                    aria-label={`Ir a la web de La Velada del Año ${year}`}
+                    aria-label={`Ir a la web de La Velada del Año ${year} (abre en nueva pestaña)`}
                   >
                     <span
                       aria-hidden="true"
@@ -236,6 +236,7 @@ const INFOJOBS_FOOTER_URL = withUtm('https://www.infojobs.net/', {
           href="https://midu.dev"
           target="_blank"
           rel="noopener noreferrer"
+          aria-label="Ir a midu.dev (abre en nueva pestaña)"
           class="text-theme-cream/90 underline underline-offset-4 transition hover:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-white/80"
           >MIDU.DEV</a
         > Y SU COMUNIDAD


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una auditoría de accesibilidad (WCAG 2.2).

## Changes

- `src/sections/Footer.astro`: añade "(abre en nueva pestaña)" al `aria-label` de los enlaces que usan `target="_blank"` (Twitch, TikTok, YouTube, X, InfoJobs y ediciones anteriores) y añade un `aria-label` al enlace de midu.dev, que no tenía ninguno.

## Por qué

Todos esos enlaces abren en una pestaña nueva (`target="_blank"`), pero nada se lo avisaba a quien usa lector de pantalla: el nombre accesible no mencionaba el cambio de contexto. Esto incumple el criterio **WCAG 3.2.2** y resulta desconcertante, porque la pestaña cambia "sin avisar".

El arreglo solo toca el texto accesible (`aria-label`). No cambia nada visualmente y los `rel="noopener noreferrer"` ya estaban puestos, así que no toco la parte de seguridad.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales: solo cambia lo que anuncian los lectores de pantalla.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la versión

* **Mejoras de Accesibilidad**
  * Se actualizaron las etiquetas de accesibilidad en enlaces del pie de página para indicar explícitamente que abren en una nueva pestaña, mejorando la experiencia con lectores de pantalla.
  * Cambios aplicados a enlaces de redes sociales, patrocinadores y secciones de ediciones anteriores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->