### PR TITLE
fix(podcast): avisa de que el enlace a YouTube abre en una pestaña nueva

### DIFF
--- a/src/sections/Podcast.astro
+++ b/src/sections/Podcast.astro
@@ -90,6 +90,7 @@ function formatRelative(date: Date) {
               href={CHANNEL_URL}
               target="_blank"
               rel="noopener noreferrer"
+              aria-label="Ver canal del podcast en YouTube (abre en nueva pestaña)"
               class="font-cinzel text-[0.6rem] tracking-[0.25em] text-white/50 transition hover:text-theme-gold focus-visible:text-theme-gold sm:text-[0.65rem]"
             >
               VER CANAL EN YOUTUBE


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una auditoría de accesibilidad (WCAG 2.2).

## Changes

- `src/sections/Podcast.astro`: añade un `aria-label` al enlace "VER CANAL EN YOUTUBE" que nombra el destino e indica que abre en una pestaña nueva.

## Por qué

El enlace abre en una pestaña nueva (`target="_blank"`) pero no lo avisaba por ningún lado: ni en el texto visible ni con un `aria-label`. Para quien navega con lector de pantalla, la pestaña cambia sin previo aviso, lo que incumple el criterio **WCAG 3.2.2**.

Solo añade texto accesible. No cambia nada visualmente y el `rel="noopener noreferrer"` ya estaba puesto.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras de Accesibilidad**
  * Se mejoró la descripción del enlace a YouTube para lectores de pantalla, indicando explícitamente que abre en una nueva pestaña.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->