### PR TITLE
chore(predictions): elimina un console.log de depuración del cliente

### DIFF
--- a/src/lib/get-predictions-for-page.ts
+++ b/src/lib/get-predictions-for-page.ts
@@ -34,7 +34,6 @@ export const getPredictionsForPage = async () => {
 
       // Si la caché no ha expirado, usar los datos cacheados
       if (now - timestamp < CACHE_DURATION) {
-        console.log('Usando datos de caché para predicciones')
         processPredictions(predictions)
         return
       }


### PR DESCRIPTION
## Type

- [x] chore

## Related Issue

Sin issue asociada.

## Changes

- `src/lib/get-predictions-for-page.ts`: elimina el `console.log('Usando datos de caché para predicciones')` que se ejecutaba en cada acierto de caché.

## Por qué

Ese `console.log` corre en el navegador, así que se imprimía en la consola de cualquier visitante cada vez que se usaban los datos cacheados. Es ruido de depuración que se quedó por error y va contra la norma de "nada de console.log en producción".

Quitarlo no cambia el comportamiento: la caché sigue funcionando igual.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales.

## Breaking Changes

Ninguno.