### PR TITLE
fix(404): quita la URL canónica de la página de error

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -38,7 +38,6 @@ const rescueBoxers = [
 <Layout
   title="404 - La Velada del Año VI"
   description="Página no encontrada en La Velada del Año VI. Vuelve al inicio para seguir disfrutando del evento de boxeo de Ibai Llanos."
-  canonical="https://www.infolavelada.com/404"
   robots="noindex, follow"
 >
   <section


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una revisión de SEO técnico.

## Changes

- `src/pages/404.astro`: elimina el prop `canonical="https://www.infolavelada.com/404"` del `<Layout>`.

## Por qué

La página 404 ya está marcada como `robots="noindex, follow"`, es decir, le pide a Google que no la indexe. Pero a la vez declaraba una URL canónica apuntándose a sí misma (`/404`), y una canónica le dice al buscador justo lo contrario: "esta URL es una página legítima e indexable". Son dos señales que se contradicen.

Lo correcto en una página de error es no declarar canónica. Con `noindex` es suficiente.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales: la 404 se ve igual.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Se realizó un ajuste en la configuración de metadatos de la página de error 404, manteniendo todos los demás ajustes sin cambios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->