### PR TITLE
perf(layout): quita fetchpriority=low del preload de la fuente Cinzel

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -97,7 +97,6 @@ const organizationJsonLd = {
       as="font"
       type="font/woff2"
       crossorigin="anonymous"
-      fetchpriority="low"
     />
     <link
       rel="preload"


### PR DESCRIPTION
## Type

- [x] perf

## Related Issue

Sin issue asociada. Sale de una revisión de rendimiento (Core Web Vitals).

## Changes

- `src/layouts/Layout.astro`: elimina `fetchpriority="low"` del `<link rel="preload">` de `cinzel-regular.woff2`.

## Por qué

Cinzel es la fuente base de toda la interfaz, y se está precargando con `<link rel="preload">`... pero con `fetchpriority="low"`. Eso es contradictorio: el `preload` sirve para **adelantar** la descarga, mientras que `low` la manda al **final** de la cola, por detrás de recursos no críticos.

El efecto probable es un FOUT (un parpadeo con la fuente del sistema antes de que cargue Cinzel). Quitando el atributo, el preload recupera la prioridad por defecto de una fuente (alta), que es justo lo que queremos.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales (más allá de cargar la fuente correcta un pelín antes).

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Optimizaciones de Rendimiento**
  * Ajustado el comportamiento de carga de recursos de fuente para mejorar el rendimiento de la página.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->