### PR TITLE
fix(layout): enlaza el apple-touch-icon en el head

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -89,6 +89,7 @@ const organizationJsonLd = {
 
     <link rel="icon" href="/favicon.ico" sizes="48x48" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="manifest" href="/site.webmanifest" />
 
     <link


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una revisión de SEO/PWA.

## Changes

- `src/layouts/Layout.astro`: añade `<link rel="apple-touch-icon" href="/apple-touch-icon.png" />` en el `<head>`.

## Por qué

El archivo `public/apple-touch-icon.png` ya existe en el repo, pero no se enlaza desde ningún sitio. Resultado: cuando alguien añade la web a la pantalla de inicio en iOS/iPadOS, en lugar del icono sale una captura de la página.

Basta con declarar el `<link>` estándar apuntando al asset que ya está ahí.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales en la web; solo afecta al icono al guardar en pantalla de inicio en iOS.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agregado soporte para icono de acceso rápido en dispositivos Apple.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->