### PR TITLE
fix(boxer-selector): corrige un color-mix() inválido en el CTA por defecto

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -265,7 +265,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         <span class="h-px w-10 bg-linear-to-l from-transparent to-theme-gold/55 sm:w-20"></span>
       </div>
 
-      <p class="boxer-default-cta font-cinzel text-sm font-bold tracking-[0.3em] text-[color-mix(var(--color-theme-cream),white_30%)] uppercase">
+      <p class="boxer-default-cta font-cinzel text-sm font-bold tracking-[0.3em] text-[color-mix(in_srgb,var(--color-theme-cream),white_30%)] uppercase">
         ¡Selecciona tu boxeador o boxeadora!
       </p>
     </div>


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una revisión de UI/CSS.

## Changes

- `src/components/BoxerSelector.astro`: añade el espacio de color `in srgb` que faltaba en el `color-mix()` del color de texto del CTA por defecto.

## Por qué

El CTA "¡Selecciona tu boxeador o boxeadora!" fijaba su color así:

```
text-[color-mix(var(--color-theme-cream),white_30%)]
```

`color-mix()` **exige** indicar el espacio de color como primer argumento (`in srgb`). Sin él, la función es inválida: el navegador **descarta toda la declaración `color`** y el texto acaba con el color heredado en lugar del tono crema buscado.

El resto de `color-mix()` del propio archivo ya llevan `in srgb`; este se quedó sin él. El arreglo es añadir ese espacio de color:

```
text-[color-mix(in_srgb,var(--color-theme-cream),white_30%)]
```

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Cambio visual mínimo e intencionado: el texto del CTA recupera su color crema correcto.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de versión

* **Estilos**
  * Ajuste técnico en la especificación de colores para mejorar la precisión de la representación cromática en un componente de selección.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->