### PR TITLE
fix(auth-button): iguala la altura del botón SALIR a la de los botones de login

### DIFF
--- a/src/components/AuthButton.astro
+++ b/src/components/AuthButton.astro
@@ -26,7 +26,7 @@ const { user } = Astro.props
       </span>
       <button
         id="sign-out-btn"
-        class="inline-flex min-h-9 items-center rounded-full border border-white/15 bg-black/20 px-4 py-2 font-cinzel text-[0.6rem] font-bold tracking-[0.2em] text-white/70 backdrop-blur-md transition duration-300 hover:border-theme-gold/60 hover:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
+        class="inline-flex min-h-11 items-center rounded-full border border-white/15 bg-black/20 px-4 py-2 font-cinzel text-[0.6rem] font-bold tracking-[0.2em] text-white/70 backdrop-blur-md transition duration-300 hover:border-theme-gold/60 hover:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
       >
         SALIR
       </button>


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una revisión de UI.

## Changes

- `src/components/AuthButton.astro`: cambia el botón "SALIR" de `min-h-9` (36px) a `min-h-11` (44px).

## Por qué

En el mismo componente conviven dos alturas de botón:

- Botones de login (Twitch / Google): `min-h-11` → 44px.
- Botón "SALIR": `min-h-9` → 36px.

Eso da una incoherencia visual (dos alturas distintas en el mismo bloque) y además deja el área de pulsación del botón de salir por debajo de los 44px recomendados para tocar cómodo en móvil.

El arreglo es subirlo a `min-h-11` para que todos los botones de auth compartan la misma altura.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Cambio visual mínimo: el botón SALIR queda un pelín más alto, alineado con los de login.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Estilo**
  * Se ajustó la altura del botón de cierre de sesión para mejorar la consistencia visual de la interfaz.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->