### PR TITLE
fix(combate): usa 100svh en el hero de la ficha de combate (coherencia móvil)

### DIFF
--- a/src/pages/combate/[id].astro
+++ b/src/pages/combate/[id].astro
@@ -104,7 +104,7 @@ export const prerender = true
     slot="head"
   />
   <section
-    class="relative isolate min-h-screen overflow-hidden px-4 py-24 text-theme-cream sm:px-6"
+    class="relative isolate min-h-[100svh] overflow-hidden px-4 py-24 text-theme-cream sm:px-6"
     aria-labelledby="battle-title"
   >
     <div


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Sin issue asociada. Sale de una revisión de UI/responsive.

## Changes

- `src/pages/combate/[id].astro`: cambia el `min-h-screen` (`100vh`) del hero por `min-h-[100svh]`.

## Por qué

El hero de la ficha de combate usaba `min-h-screen`, que equivale a `100vh`. En móvil, `100vh` **incluye la barra de direcciones del navegador**, así que la sección queda más alta que la pantalla visible y empuja el contenido por debajo del pliegue.

El resto de páginas principales (`boxeadores`, `combates`, `pronosticos`) ya usan `min-height: 100svh`, que tiene en cuenta el viewport "pequeño" y evita ese desbordamiento. Este cambio deja la ficha de combate coherente con las demás.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

> Sin cambios visuales en escritorio; en móvil evita el alto de más por la barra del navegador.

## Breaking Changes

Ninguno.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de la Versión

* **Estilo**
  * Ajustada la altura mínima del contenedor principal para usar unidades de viewport más precisas, mejorando la presentación en dispositivos móviles y navegadores modernos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->