### PR TITLE
refine location panel styles and a11y improvements

### DIFF
--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -69,7 +69,7 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
           </div>
 
           <h3
-            class="mb-2text-xl leading-snug font-bold tracking-wider text-theme-cream uppercase lg:text-[1.35rem]"
+            class="mb-2 text-xl leading-snug font-bold tracking-wider text-theme-cream uppercase lg:text-[1.35rem]"
           >
             Estadio de La Cartuja
           </h3>

--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -42,26 +42,8 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
       <!-- Panel de información -->
       <div class="flex flex-col">
         <div
-          class="group relative flex-1 rounded-lg border border-theme-gold/20 bg-theme-navy/60 p-6 shadow-[0_8px_32px_rgba(0,0,0,0.35)] transition-colors duration-300 hover:border-theme-gold/40 lg:p-7"
+          class="group relative flex-1 rounded-lg border border-theme-gold/20 bg-theme-navy/50 p-6 shadow-[0_8px_32px_rgba(0,0,0,0.35)] transition-colors duration-300 hover:border-theme-gold/40 lg:p-7"
         >
-          <!-- Esquinas doradas decorativas -->
-          <span
-            aria-hidden="true"
-            class="pointer-events-none absolute top-2 left-2 size-3 border-t border-l border-theme-gold/35 transition-colors duration-300 group-hover:border-theme-gold"
-          ></span>
-          <span
-            aria-hidden="true"
-            class="pointer-events-none absolute top-2 right-2 size-3 border-t border-r border-theme-gold/35 transition-colors duration-300 group-hover:border-theme-gold"
-          ></span>
-          <span
-            aria-hidden="true"
-            class="pointer-events-none absolute bottom-2 left-2 size-3 border-b border-l border-theme-gold/35 transition-colors duration-300 group-hover:border-theme-gold"
-          ></span>
-          <span
-            aria-hidden="true"
-            class="pointer-events-none absolute right-2 bottom-2 size-3 border-r border-b border-theme-gold/35 transition-colors duration-300 group-hover:border-theme-gold"
-          ></span>
-
           <!-- Icono + etiqueta recinto -->
           <div class="mb-5 flex items-center gap-3">
             <span
@@ -81,19 +63,17 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
                   clip-rule="evenodd"></path>
               </svg>
             </span>
-            <p class="font-cinzel text-[0.6rem] font-bold tracking-[0.4em] text-theme-gold/70">
-              RECINTO
+            <p class="text-[0.6rem] leading-normal font-bold tracking-[0.4em] text-theme-gold/75">
+              Recinto
             </p>
           </div>
 
           <h3
-            class="mb-2 font-cinzel text-xl leading-snug font-bold tracking-[0.05em] text-theme-cream uppercase lg:text-[1.35rem]"
+            class="mb-2text-xl leading-snug font-bold tracking-wider text-theme-cream uppercase lg:text-[1.35rem]"
           >
             Estadio de La Cartuja
           </h3>
-          <p
-            class="font-cinzel text-[0.7rem] leading-[1.8] tracking-[0.06em] text-white/50 uppercase"
-          >
+          <p class="text-[0.7rem] leading-[1.8] tracking-[0.06em] text-white/50 uppercase">
             Av. de la Palmera, s/n<br />41012 Sevilla, España
           </p>
 
@@ -119,13 +99,11 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
             </span>
             <div>
               <p
-                class="mb-[0.2rem] font-cinzel text-[0.55rem] font-bold tracking-[0.35em] text-theme-gold/55 uppercase"
+                class="mb-[0.2rem] text-[0.55rem] font-bold tracking-[0.35em] text-theme-gold/75 uppercase"
               >
-                FECHA
+                Fecha
               </p>
-              <p
-                class="font-cinzel text-[0.75rem] font-semibold tracking-[0.08em] text-white/75 uppercase"
-              >
+              <p class="text-[0.75rem] font-semibold tracking-[0.08em] text-white/75 uppercase">
                 25 de julio de 2026
               </p>
             </div>
@@ -149,13 +127,11 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
             </span>
             <div>
               <p
-                class="mb-[0.2rem] font-cinzel text-[0.55rem] font-bold tracking-[0.35em] text-theme-gold/55 uppercase"
+                class="mb-[0.2rem] text-[0.55rem] font-bold tracking-[0.35em] text-theme-gold/75 uppercase"
               >
-                HORA
+                Hora
               </p>
-              <p
-                class="font-cinzel text-[0.75rem] font-semibold tracking-[0.08em] text-white/75 uppercase"
-              >
+              <p class="text-[0.75rem] font-semibold tracking-[0.08em] text-white/75 uppercase">
                 20:00h (hora peninsular)
               </p>
             </div>
@@ -182,9 +158,9 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
             </span>
             <div>
               <p
-                class="mb-[0.2rem] font-cinzel text-[0.55rem] font-bold tracking-[0.35em] text-theme-gold/55 uppercase"
+                class="mb-[0.2rem] font-cinzel text-[0.55rem] font-bold tracking-[0.35em] text-theme-gold/75 uppercase"
               >
-                AFORO
+                Aforo
               </p>
               <p
                 class="font-cinzel text-[0.75rem] font-semibold tracking-[0.08em] text-white/75 uppercase"
@@ -194,34 +170,30 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
             </div>
           </div>
 
-          <!-- Separador -->
           <div class="my-5 h-px bg-linear-to-r from-transparent via-theme-gold/30 to-transparent">
           </div>
 
-          <!-- CTA ubicación -->
-          <div class="flex flex-col items-center gap-4">
-            <a
-              href={VENUE_WEB_MAP_URL}
-              data-geo-href={VENUE_GEO_URL}
-              class="inline-flex items-center gap-2 rounded border border-theme-gold/35 px-4 py-[0.6rem] font-cinzel text-[0.65rem] font-bold tracking-[0.25em] text-theme-gold uppercase no-underline transition-all duration-300 outline-none hover:-translate-y-px hover:border-theme-gold hover:bg-theme-gold/10 hover:text-theme-cream focus-visible:-translate-y-px focus-visible:border-theme-gold focus-visible:bg-theme-gold/10 focus-visible:text-theme-cream focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight motion-reduce:transition-none motion-reduce:hover:translate-y-0"
-              aria-label="Abrir la ubicación del Estadio de La Cartuja en la aplicación de mapas"
+          <a
+            href={VENUE_WEB_MAP_URL}
+            data-geo-href={VENUE_GEO_URL}
+            class="flex items-center justify-center gap-2 rounded border border-theme-gold/35 py-[0.6rem] text-[0.65rem] font-bold tracking-[0.25em] text-theme-gold transition-[translate,border-color,background-color,color] duration-300 outline-none hover:-translate-y-px hover:border-theme-gold hover:bg-theme-gold/10 hover:text-theme-cream focus-visible:-translate-y-px focus-visible:border-theme-gold focus-visible:bg-theme-gold/10 focus-visible:text-theme-cream focus-visible:ring-2 focus-visible:ring-theme-gold/60 focus-visible:ring-offset-2 focus-visible:ring-offset-theme-midnight motion-reduce:transition-none motion-reduce:hover:translate-y-0"
+            aria-label="Abrir la ubicación del Estadio de La Cartuja en la aplicación de mapas"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              fill="currentColor"
+              width="14"
+              height="14"
+              aria-hidden="true"
             >
-              <svg
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-                width="14"
-                height="14"
-                aria-hidden="true"
-              >
-                <path
-                  fill-rule="evenodd"
-                  d="M15.75 2.25H21a.75.75 0 01.75.75v5.25a.75.75 0 01-1.5 0V4.81L8.03 17.03a.75.75 0 01-1.06-1.06L19.19 3.75h-3.44a.75.75 0 010-1.5zm-10.5 4.5a1.5 1.5 0 00-1.5 1.5v10.5a1.5 1.5 0 001.5 1.5h10.5a1.5 1.5 0 001.5-1.5V10.5a.75.75 0 011.5 0v8.25a3 3 0 01-3 3H5.25a3 3 0 01-3-3V8.25a3 3 0 013-3H13.5a.75.75 0 010 1.5H5.25z"
-                  clip-rule="evenodd"></path>
-              </svg>
-              Abrir ubicación
-            </a>
-          </div>
+              <path
+                fill-rule="evenodd"
+                d="M15.75 2.25H21a.75.75 0 01.75.75v5.25a.75.75 0 01-1.5 0V4.81L8.03 17.03a.75.75 0 01-1.06-1.06L19.19 3.75h-3.44a.75.75 0 010-1.5zm-10.5 4.5a1.5 1.5 0 00-1.5 1.5v10.5a1.5 1.5 0 001.5 1.5h10.5a1.5 1.5 0 001.5-1.5V10.5a.75.75 0 011.5 0v8.25a3 3 0 01-3 3H5.25a3 3 0 01-3-3V8.25a3 3 0 013-3H13.5a.75.75 0 010 1.5H5.25z"
+                clip-rule="evenodd"></path>
+            </svg>
+            Abrir ubicación
+          </a>
         </div>
       </div>
 


### PR DESCRIPTION
Se amplía el enlace que permite abrir la ubicación del evento.

Además, se define explícitamente la lista de propiedades animadas para evitar el uso de `transition-all`, se mejora el contraste de los textos descriptivos (*labels*) y se eliminan elementos decorativos innecesarios para reducir el ruido visual.

Antes:
<img width="377" height="493" alt="image" src="https://github.com/user-attachments/assets/e19d0094-2e1b-4c38-a6b8-3ffe3c241393" />

Despúes:
<img width="378" height="508" alt="image" src="https://github.com/user-attachments/assets/338eabe5-d98a-4804-80a1-a8fa91674fb8" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Style**
  * Actualizados los estilos del panel de información del mapa, incluyendo cambios en el color de fondo.
  * Ajustada la presentación de las etiquetas y textos de “Recinto”, “Fecha”, “Hora” y “Aforo” (mayúsculas/estilos tipográficos y espaciado).
  * Actualizado el área de “CTA ubicación”: ahora el enlace se muestra de forma más directa y con mejoras visuales, incluyendo estados de interacción y mejor legibilidad en foco.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->