### PR TITLE
refactor: remove dynamic wrapper and simplify grid state management i…

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1378,17 +1378,17 @@ const totalBoxers = BOXERS.length
     display: none;
   }
 
-  .boxers-grid{
+  .boxers-grid {
     --cards-gap: calc(var(--spacing) * 3);
   }
 
   @media (width >= 64rem) {
-    .boxers-grid{
+    .boxers-grid {
       --cards-gap: calc(var(--spacing) * 5);
     }
   }
 
-  [data-state="default"] > .boxer-card-wrap:nth-child(even)::after {
+  .boxers-grid[data-state="default"] > .boxer-card-wrap:nth-child(even)::after {
     --inline-size: 2.3em;
     --block-size: 2.05em;
     content: 'VS';
@@ -1402,12 +1402,24 @@ const totalBoxers = BOXERS.length
     block-size: var(--block-size);
     font-family: var(--font-cinzel);
     font-weight: 700;
-    font-size: clamp(1rem, 0.939rem + 0.259vw, 1.25rem);
+    font-size: clamp(1.125rem, 0.875rem + 0.313vw, 1.25rem);
     color: var(--color-theme-gold);
     background-color: var(--color-theme-midnight);
     border-radius: 4px;
     line-height: normal;
     border: 1px solid color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
+  }
+
+  @media (width <= 48rem) {  
+    .boxers-grid[data-state="default"] > .boxer-card-wrap:nth-child(even)::after {
+      font-size: clamp(1rem, 0.641rem + 1.531vw, 1.375rem);
+    }
+  }
+
+  @media (width >=  48rem) and (width <= 79.999rem) {
+    .boxers-grid[data-state='default'] > .boxer-card-wrap:nth-child(even)::after {
+      content: none;
+    }
   }
 
   @media (prefers-reduced-motion: reduce) {

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -854,7 +854,6 @@ const totalBoxers = BOXERS.length
 
   @media (max-width: 639px) {
     .boxer-filters-panel {
-      border-radius: 8px;
       box-shadow:
         inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent),
         0 16px 36px rgba(0, 0, 0, 0.38),
@@ -1332,7 +1331,6 @@ const totalBoxers = BOXERS.length
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-midnight) 100%, transparent);
   }
 
-  /* ---------- Reset ---------- */
   .boxer-filter-reset {
     appearance: none;
     display: inline-flex;
@@ -1376,83 +1374,40 @@ const totalBoxers = BOXERS.length
     color: var(--color-theme-cream);
   }
 
-  /* Card ocultada por los filtros: la sacamos del flow para que el grid
-     compacte sin huecos. Mantenemos un fade para que no sea brusco.
-     El `min-width: 0` es clave para que en 2 columnas en mobile las
-     cards puedan encogerse y nunca desborden el viewport. */
-  .boxer-card-wrap {
-    min-width: 0;
-    transition: opacity 220ms ease;
-  }
-
   .boxer-card-wrap[data-hidden='true'] {
     display: none;
   }
 
-  /* ---------- Modo «Agrupado» (Cartelera sin filtros) ---------- */
-  /* Cuando estamos en Cartelera y no hay filtros, agrupamos las parejas en
-     rectángulos dorados. */
-  .boxers-grid[data-view='grouped'] {
-    grid-template-columns: minmax(0, 1fr) !important;
-    gap: 2rem;
+  .boxers-grid{
+    --cards-gap: calc(var(--spacing) * 3);
   }
 
-  @media (min-width: 1024px) {
-    .boxers-grid[data-view='grouped'] {
-      grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
-      gap: 2rem;
+  @media (width >= 64rem) {
+    .boxers-grid{
+      --cards-gap: calc(var(--spacing) * 5);
     }
   }
 
-  /* El rectángulo dorado agrupa a los dos boxeadores del combate. */
-  :global(.combate-group) {
-    display: flex;
-    flex-direction: row;
-    gap: 1rem;
-    padding: 1.5rem;
-    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 40%, transparent);
-    border-radius: 12px;
-    background: radial-gradient(
-      ellipse at top,
-      color-mix(in srgb, var(--color-theme-gold) 15%, transparent) 0%,
-      transparent 70%
-    );
-    box-shadow: 0 0 20px color-mix(in srgb, var(--color-theme-gold) 10%, transparent);
-    position: relative;
-  }
-
-  /* Etiqueta central de "VS" entre los boxeadores */
-  :global(.combate-group::after) {
+  [data-state="default"] > .boxer-card-wrap:nth-child(even)::after {
+    --inline-size: 2.3em;
+    --block-size: 2.05em;
     content: 'VS';
     position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
+    inset-block: 0;
+    inset-inline-start: calc((var(--inline-size) + var(--cards-gap)) / 2 * -1);
+    display: grid;
+    place-items: center;
+    margin-block: auto;
+    inline-size: var(--inline-size);
+    block-size: var(--block-size);
     font-family: var(--font-cinzel);
     font-weight: 700;
-    font-size: 1.2rem;
+    font-size: clamp(1rem, 0.939rem + 0.259vw, 1.25rem);
     color: var(--color-theme-gold);
-    text-shadow: 0 2px 10px rgba(0,0,0,0.5);
-    background: var(--color-theme-midnight);
-    padding: 0.25rem 0.5rem;
+    background-color: var(--color-theme-midnight);
     border-radius: 4px;
+    line-height: normal;
     border: 1px solid color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
-    z-index: 10;
-  }
-
-  :global(.combate-group > .boxer-card-wrap) {
-    flex: 1;
-    min-width: 0;
-  }
-
-  @media (max-width: 639px) {
-    :global(.combate-group) {
-      padding: 1rem;
-      gap: 0.75rem;
-    }
-    :global(.combate-group::after) {
-      font-size: 1rem;
-    }
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -1531,24 +1486,19 @@ const totalBoxers = BOXERS.length
     }
     let sortMode: SortMode = urlState.sort
 
-    // Grupos decorativos inyectados en el grid para envolver los combates.
-    let combateGroups: HTMLElement[] = []
-
-    function removeCombateGroups() {
-      for (const group of combateGroups) group.remove()
-      combateGroups = []
+    function setGridState(state: 'default' | 'modified'){
+      gridEl.dataset.state = state
     }
 
     // Reordena el DOM (no sólo CSS `order`) para que el orden de
     // tabulación coincida con el visual. Con 20 cards el coste es
     // despreciable y mantenemos la accesibilidad correcta.
     function applySort() {
-      removeCombateGroups()
-
       const hasActiveFilter = state.country !== '' || state.gender !== ''
-      const isGrouped = sortMode === 'cartel' && !hasActiveFilter
+      const isDefaultSortMode = sortMode === 'cartel'
+      const gridState = !hasActiveFilter && isDefaultSortMode ? 'default': 'modified'
 
-      gridEl.dataset.view = isGrouped ? 'grouped' : ''
+      setGridState(gridState)
 
       const ordered = [...cards]
       if (sortMode === 'followers-desc') {
@@ -1572,31 +1522,7 @@ const totalBoxers = BOXERS.length
         )
       }
 
-      if (isGrouped) {
-        // En modo agrupado: mostrar todas las cards y agruparlas por combate en rectángulos dorados.
-        for (const card of cards) card.dataset.hidden = 'false'
-
-        let currentBattle = ''
-        let currentGroup: HTMLElement | null = null
-        
-        for (const card of ordered) {
-          const battle = card.dataset.battle ?? ''
-          if (battle !== currentBattle) {
-            currentBattle = battle
-            
-            const groupLi = document.createElement('li')
-            groupLi.className = 'combate-group'
-            
-            gridEl.appendChild(groupLi)
-            combateGroups.push(groupLi)
-            
-            currentGroup = groupLi
-          }
-          if (currentGroup) currentGroup.appendChild(card)
-        }
-      } else {
-        for (const card of ordered) gridEl.appendChild(card)
-      }
+    for (const card of ordered) gridEl.appendChild(card)
     }
 
     // Cuenta cards que coinciden con un par (country, gender). Pasar '' en
@@ -1623,13 +1549,10 @@ const totalBoxers = BOXERS.length
 
     function applyFilters() {
       const hasActiveFilter = state.country !== '' || state.gender !== ''
+      const isDefaultSortMode = sortMode === 'cartel'
+      const gridState = !hasActiveFilter && isDefaultSortMode ? 'default': 'modified'
 
-      // Actualizar agrupamiento si estamos en Cartelera y cambia el estado de los filtros.
-      const currentlyGrouped = gridEl.dataset.view === 'grouped'
-      const shouldBeGrouped = sortMode === 'cartel' && !hasActiveFilter
-      if (currentlyGrouped !== shouldBeGrouped) {
-        applySort()
-      }
+      setGridState(gridState)
 
       let visible = 0
       for (const card of cards) {
@@ -1717,10 +1640,6 @@ const totalBoxers = BOXERS.length
           b.setAttribute('aria-pressed', String(b.dataset.sort === sortMode))
         }
         applySort()
-
-        // Siempre re-aplicamos filtros al cambiar de orden,
-        // esto también asegurará que los grupos dorados se formen o deshagan.
-        applyFilters()
         syncStateToURL()
       })
     }


### PR DESCRIPTION
Se elimina el *wrapper* dinámico utilizado en `/boxeadores` para reducir la complejidad en el JavaScript, evitando errores como elementos `li` dentro de elementos `li` y simplificar la estructura.

Además, este cambio permite mantener una presentación visual más consistente al aplicar filtros o modificar el orden de las tarjetas de boxeadores.

Se mantiene el badge *VS* solo cuando no hay ningun filtro u ordenamiento aplicado.

preparando para arreglar las animaciones.

Antes:
<img width="1311" height="621" alt="image" src="https://github.com/user-attachments/assets/a730144f-d8b5-46d5-ad6c-46975041b0b7" />

Despúes:
<img width="1307" height="595" alt="image" src="https://github.com/user-attachments/assets/bbac6f0f-4d5d-478d-9e27-7f9efa62df5c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimizada la lógica del modo de agrupación en la cartelera de boxeadores, reduciendo elementos visuales del grid.
  * Mejorada la sincronización entre ordenación y filtros, reflejando el estado visual del grid según la combinación de opciones.
  * Reorganización del listado más eficiente al aplicar la ordenación, manteniendo el comportamiento correcto sin recrear estructura extra.
* **Mejoras de UI**
  * Refinado el panel de filtros en móvil (sombra y presentación).
  * Actualizado el indicador “VS” para generarse mediante estilos, con ajustes responsivos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->