### PR TITLE
style: set max height for boxer detail background

### DIFF
--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -151,7 +151,7 @@ const breadcrumbJsonLd = {
   >
     <picture
       data-boxer-detail-bg
-      class="pointer-events-none absolute inset-0 -z-20"
+      class="pointer-events-none absolute inset-0 max-h-svh -z-20"
       aria-hidden="true"
     >
       <source


### PR DESCRIPTION
Se establece un `max-height` para el fondo de la página de detalles del boxeador, evitando que se expanda junto con el contenido.

Antes desktop:
<img width="1877" height="981" alt="image" src="https://github.com/user-attachments/assets/5ee3c7f5-15f8-4387-bd82-0969b8b437a0" />

Despúes desktop:
<img width="1877" height="984" alt="image" src="https://github.com/user-attachments/assets/c1258516-37fa-403e-92e3-4d652735ced1" />

Antes mobile:
<img width="373" height="626" alt="image" src="https://github.com/user-attachments/assets/0626586f-3970-4d0f-b047-9673cd971903" />

Despúes mobile:
<img width="370" height="628" alt="image" src="https://github.com/user-attachments/assets/1b8ef978-a691-4318-a652-e424f1c4c68c" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Se ajustó la altura máxima del contenedor de fondo en la página de detalles para optimizar su presentación visual.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->