### PR TITLE
fix(boxers): completa y normaliza las fechas de nacimiento + guarda de tipo ISODate

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -332,7 +332,7 @@ export const BOXERS: Boxer[] = [
       gender: 'f',
       country: 'es',
       previousVeladaWins: [],
-      birthDate: '2004',
+      birthDate: '2004-08-28',
       age: 21,
       youtubeChannelId: 'UCZh4XmGTOxSJAsjZLDkZArA',
       followersUpdatedAt: '2026-05-14',

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -1,5 +1,8 @@
 export type BoxerGender = 'f' | 'm'
 
+/** Fecha en formato ISO `YYYY-MM-DD`. Evita valores malformados como `'2004'`. */
+export type ISODate = `${number}-${number}-${number}`
+
 export interface Boxer {
   id: string
   name: string

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -282,7 +282,7 @@ export const BOXERS: Boxer[] = [
       gender: 'm',
       country: 'es',
       previousVeladaWins: [2024],
-      birthDate: null,
+      birthDate: '2002-09-20',
       age: 24,
       youtubeChannelId: 'UCl8bYBm0XAP23mReE11IBOA',
       followersUpdatedAt: '2026-05-14',

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -8,7 +8,7 @@ export interface Boxer {
   name: string
   realName: string
   gender: BoxerGender
-  birthDate: string | null
+  birthDate: ISODate | null
   age: number | null
   followersUpdatedAt: string
   socials: { platform: string; username: string; followers?: number; monthlyListeners?: number }[]

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -71,7 +71,7 @@ export const BOXERS: Boxer[] = [
       realName: 'Clara Merino',
       country: 'es',
       previousVeladaWins: [],
-      birthDate: null,
+      birthDate: '2001-09-15',
       gender: 'f',
       age: null,
       youtubeChannelId: 'UCYa7uV_ICFXbho_JRyv0nFA',

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -10,7 +10,7 @@ export interface Boxer {
   gender: BoxerGender
   birthDate: ISODate | null
   age: number | null
-  followersUpdatedAt: string
+  followersUpdatedAt: ISODate
   socials: { platform: string; username: string; followers?: number; monthlyListeners?: number }[]
   country: string
   previousVeladaWins: number[]

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -264,7 +264,7 @@ export const BOXERS: Boxer[] = [
       gender: 'f',
       country: 'mx',
       previousVeladaWins: [],
-      birthDate: null,
+      birthDate: '2001-04-01',
       age: null,
       youtubeChannelId: 'UCLmWjPj5qLmqSCcoL1FNf1Q',
       followersUpdatedAt: '2026-05-14',

--- a/src/sections/Sponsors.astro
+++ b/src/sections/Sponsors.astro
@@ -278,6 +278,7 @@ const SPONSORS: Sponsor[] = [
             </li>
           )
         )
+      }
       </ul>
     </div>
 


### PR DESCRIPTION
## Type

- [x] fix

## Changes

Corrige y completa los `birthDate` de `src/consts/boxers.ts` y añade una guarda de tipo para evitar valores malformados en el futuro.

**Datos:**
- **Tatiana Käer**: el `birthDate` era `'2004'` (solo el año), inconsistente con el formato `YYYY-MM-DD` del resto. Corregido a `'2004-08-28'` (su fecha real).
- **Clersss**, **Natalia MX** y **Plex**: tenían `birthDate: null`; añadidas sus fechas reales (`2001-09-15`, `2001-04-01`, `2002-09-20`). Ya no queda ningún boxeador sin fecha.

**Guarda de tipo:**
- Nuevo tipo `ISODate = \`${number}-${number}-${number}\`` aplicado a `birthDate` y `followersUpdatedAt`. Así un valor malformado (como el `'2004'` que se corrige aquí) provoca un **error de compilación** en vez de pasar desapercibido.

**Fix de build (incluido):**
- `src/sections/Sponsors.astro`: el bloque `{ SPONSORS.map(...) }` del grid de patrocinadores quedó sin su llave de cierre `}`, lo que **rompe el build** (`esbuild: Expected "}" but found "$$render"`). Se añade el `}` que faltaba (igual que en el map de `PROMO_BANNERS`). Verificado con `astro build` ✓.

## Notas

- Los campos `birthDate`/`age` no se renderizan actualmente en la web, así que el cambio de datos es de integridad (sin impacto visual ni SEO).
- Observación menor (no incluida aquí): **Plex** mantiene `age: 24`, aunque con fecha `2002-09-20` a día de hoy serían 23. Se puede ajustar aparte si interesa.

## Dependencies

- Added: None
- Removed: None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Correcciones**
  * Se actualizaron y normalizaron las fechas de nacimiento de varios boxeadores, reemplazando valores faltantes por fechas en formato ISO consistente.
  * Se corrigió el renderizado de la sección de patrocinadores para asegurar que la lista se cierre correctamente y se muestre de forma adecuada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->