### PR TITLE
feat(boxeadores): muestra la fecha de nacimiento en la ficha del boxeador

### DIFF
--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -44,6 +44,16 @@ const photo = getBoxerPhoto(boxer)
 const countryName = COUNTRY_NAMES[boxer.country] ?? boxer.country
 const genderLabel = GENDER_LABELS[boxer.gender]
 
+// Fecha de nacimiento formateada en español (p. ej. "28 de agosto de 2004").
+// Se construye con hora local para evitar desfases de día por zona horaria.
+const birthDateLabel = boxer.birthDate
+  ? new Intl.DateTimeFormat('es-ES', {
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date(`${boxer.birthDate}T00:00:00`))
+  : null
+
 // Buscamos su combate para enlazar y mostrar el número.
 const battle = battles.find((b) => b.boxerIds.includes(boxer.id))
 const opponentId = battle?.boxerIds.find((id) => id !== boxer.id)
@@ -238,6 +248,11 @@ const breadcrumbJsonLd = {
               {countryName}
             </span>
             <span class="boxer-detail-chip">{genderLabel}</span>
+            {birthDateLabel && (
+              <span class="boxer-detail-chip">
+                <time datetime={boxer.birthDate}>{birthDateLabel}</time>
+              </span>
+            )}
           </div>
 
           <h1


### PR DESCRIPTION
## Type

- [x] feat

## Changes

Muestra la fecha de nacimiento de cada boxeador en su página de detalle (`src/pages/boxeadores/[id].astro`), reutilizando el estilo existente.

- Añade un chip de fecha en la fila de metadatos (junto a combate / país / género), reutilizando la clase `.boxer-detail-chip` para que el estilo sea idéntico al resto.
- La fecha se formatea en español con `Intl.DateTimeFormat('es-ES', …)` (p. ej. `28 de agosto de 2004`), construida con hora local para evitar desfases de día por zona horaria.
- Usa un elemento `<time datetime={boxer.birthDate}>` semántico.
- Si el boxeador no tiene `birthDate`, el chip no se renderiza.

## Dependencias

> [!IMPORTANT]
> Apilada sobre **#1580** (base de esta PR), porque necesita los `birthDate` ya corregidos/completados. Una vez se mergee #1580, reapunto esta PR a `main`.

## Verificación

- `astro build` ✓ (con #1580 de base).
- Formato comprobado: `2004-08-28 → 28 de agosto de 2004`, `2001-04-01 → 1 de abril de 2001`, etc.

## Dependencies

- Added: None
- Removed: None