### PR TITLE
fix(selector): primera vista responsive en móvil y carrusel tipo selector

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -809,6 +809,12 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       0 18px 38px rgba(0, 0, 0, 0.4);
   }
 
+  /* Durante el reajuste de set (normalize) refrescamos el foco sin transición
+     para que el nuevo slide central herede el marco al instante, sin parpadeo. */
+  .boxer-mobile-slider.is-normalizing .boxer-mobile-frame {
+    transition: none;
+  }
+
   .bmf-corner {
     position: absolute;
     width: 26%;
@@ -1543,6 +1549,16 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       if (!focusRaf) focusRaf = requestAnimationFrame(updateFocus)
     }
 
+    // Tras normalize() el scrollLeft salta un set completo, así que el slide
+    // centrado pasa a ser OTRO elemento (idéntico). Refrescamos las vars de
+    // foco al instante y sin transición, para que el nuevo slide central herede
+    // el realce sin parpadeo (el salto es invisible porque los sets son iguales).
+    const refreshFocusInstant = () => {
+      slider.classList.add('is-normalizing')
+      updateFocus()
+      requestAnimationFrame(() => slider.classList.remove('is-normalizing'))
+    }
+
     slider.addEventListener('scroll', requestFocus, { passive: true })
 
     requestAnimationFrame(() => {
@@ -1555,16 +1571,21 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     // (incluido el snap) ha terminado, evitando cualquier corte visual.
     // Como fallback, debounce manual: ejecutamos `normalize` ~160ms después
     // del último evento de scroll, tiempo de sobra para que termine el snap.
+    const normalizeAndRefresh = () => {
+      normalize()
+      refreshFocusInstant()
+    }
+
     const supportsScrollEnd = 'onscrollend' in window
     if (supportsScrollEnd) {
-      slider.addEventListener('scrollend', normalize, { passive: true })
+      slider.addEventListener('scrollend', normalizeAndRefresh, { passive: true })
     } else {
       let scrollEndTimer: ReturnType<typeof setTimeout> | null = null
       slider.addEventListener(
         'scroll',
         () => {
           if (scrollEndTimer) clearTimeout(scrollEndTimer)
-          scrollEndTimer = setTimeout(normalize, 160)
+          scrollEndTimer = setTimeout(normalizeAndRefresh, 160)
         },
         { passive: true },
       )

--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -293,31 +293,39 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
                     aria-label={`Ver perfil de ${boxer.name}`}
                     aria-hidden={isAccessibleSet ? undefined : 'true'}
                     tabindex={isAccessibleSet ? undefined : -1}
-                    class="boxer-mobile-slide group relative aspect-[3/4] shrink-0 snap-center overflow-hidden rounded-[1.1rem] border border-theme-gold/35 bg-theme-midnight outline-none"
+                    class="boxer-mobile-slide group relative aspect-[3/4] shrink-0 snap-center border border-theme-gold/35 bg-theme-midnight outline-none"
                     style={`animation-delay: ${650 + index * 20}ms`}
                   >
-                    <picture>
-                      <source type="image/avif" srcset={selectImages.avif} />
-                      <source type="image/webp" srcset={selectImages.webp} />
-                      <img
-                        src={selectImages.webp}
-                        alt=""
-                        role="presentation"
-                        loading="lazy"
-                        decoding="async"
-                        width="180"
-                        height="240"
-                        data-mirrored={MIRRORED_BOXER_IDS.has(boxer.id) ? 'true' : 'false'}
-                        class="boxer-mobile-slide-img absolute inset-0 h-full w-full object-cover object-top transition duration-500 group-active:scale-[1.03]"
-                      />
-                    </picture>
-                    <span
-                      aria-hidden="true"
-                      class="boxer-mobile-slide-name-bar pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-center px-2 pb-2.5 pt-10"
-                    >
-                      <span class="boxer-mobile-slide-name font-cinzel text-[0.66rem] font-bold uppercase leading-[1.05] tracking-[0.16em] text-theme-cream text-balance">
-                        {boxer.name}
+                    <span class="boxer-mobile-slide-media absolute inset-0 overflow-hidden">
+                      <picture>
+                        <source type="image/avif" srcset={selectImages.avif} />
+                        <source type="image/webp" srcset={selectImages.webp} />
+                        <img
+                          src={selectImages.webp}
+                          alt=""
+                          role="presentation"
+                          loading="lazy"
+                          decoding="async"
+                          width="180"
+                          height="240"
+                          data-mirrored={MIRRORED_BOXER_IDS.has(boxer.id) ? 'true' : 'false'}
+                          class="boxer-mobile-slide-img absolute inset-0 h-full w-full object-cover object-top transition duration-500 group-active:scale-[1.03]"
+                        />
+                      </picture>
+                      <span
+                        aria-hidden="true"
+                        class="boxer-mobile-slide-name-bar pointer-events-none absolute inset-x-0 bottom-0 flex items-end justify-center px-2 pb-2.5 pt-10"
+                      >
+                        <span class="boxer-mobile-slide-name font-cinzel text-[0.66rem] font-bold uppercase leading-[1.05] tracking-[0.16em] text-theme-cream text-balance">
+                          {boxer.name}
+                        </span>
                       </span>
+                    </span>
+                    <span aria-hidden="true" class="boxer-mobile-frame">
+                      <span class="bmf-corner bmf-tl" />
+                      <span class="bmf-corner bmf-tr" />
+                      <span class="bmf-corner bmf-bl" />
+                      <span class="bmf-corner bmf-br" />
                     </span>
                   </a>
                 )
@@ -449,6 +457,17 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   @media (max-width: 767px) {
     [data-default-panel]{
       justify-content: center;
+    }
+
+    /* En móvil la primera vista mete logo + fecha + CTA + carrusel en una
+       sola pantalla (svh). Reducimos un punto el logo y damos respiro al
+       carrusel para que entre todo sin amontonarse ni cortarse abajo. */
+    .boxer-default-logo {
+      width: 50vw;
+    }
+
+    .boxer-selector-foot {
+      padding-bottom: max(0.5rem, env(safe-area-inset-bottom));
     }
 
     [data-boxer-selector][data-state='boxer'] [data-default-panel] {
@@ -741,7 +760,9 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
     scroll-snap-type: x mandatory;
     scrollbar-width: none;
     -webkit-overflow-scrolling: touch;
-    padding-block: 0.25rem 0.6rem;
+    /* Más aire vertical para que la tarjeta central, al agrandarse, no se
+       recorte arriba/abajo (overflow-x:auto fuerza overflow-y a recortar). */
+    padding-block: 1rem 1.1rem;
   }
 
   .boxer-mobile-slider::-webkit-scrollbar {
@@ -760,7 +781,85 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent),
       0 12px 28px rgba(0, 0, 0, 0.35);
     opacity: 0;
+    /* La animación de entrada usa `translate`/`opacity` (no `transform`) para
+       dejar libre `transform` al efecto de foco del carrusel. */
     animation: boxer-mobile-slide-in 520ms cubic-bezier(0.16, 1, 0.3, 1) forwards;
+    /* Foco "character select": el JS escribe --focus-* según la distancia al
+       centro. Defaults a 1 para que sin JS (o SSR) se vean normales. */
+    transform: scale(var(--focus-scale, 1));
+    transform-origin: center center;
+    filter: brightness(var(--focus-bright, 1)) saturate(var(--focus-sat, 1));
+    will-change: transform, filter;
+  }
+
+  /* Marco de esquinas estilo "character select" (igual que el cursor de la
+     versión escritorio). Aparece FUERA de la card y su opacidad la controla el
+     JS de forma continua (--focus-frame) según la cercanía al centro, con una
+     transición que amortigua el snap: se funde de a poco, sin cortes. */
+  .boxer-mobile-frame {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    pointer-events: none;
+    opacity: var(--focus-frame, 0);
+    transition: opacity 320ms cubic-bezier(0.33, 1, 0.68, 1);
+    box-shadow:
+      inset 0 0 0 1.5px color-mix(in srgb, var(--color-theme-gold) 62%, transparent),
+      0 0 26px color-mix(in srgb, var(--color-theme-gold) 32%, transparent),
+      0 18px 38px rgba(0, 0, 0, 0.4);
+  }
+
+  .bmf-corner {
+    position: absolute;
+    width: 26%;
+    height: 22%;
+    border: 2px solid var(--color-theme-gold);
+    filter: drop-shadow(0 0 4px color-mix(in srgb, var(--color-theme-gold) 70%, transparent));
+    animation: boxer-mobile-frame-breathe 1.9s ease-in-out infinite;
+  }
+
+  .bmf-tl {
+    top: -6px;
+    left: -6px;
+    border-right: 0;
+    border-bottom: 0;
+  }
+  .bmf-tr {
+    top: -6px;
+    right: -6px;
+    border-left: 0;
+    border-bottom: 0;
+  }
+  .bmf-bl {
+    bottom: -6px;
+    left: -6px;
+    border-right: 0;
+    border-top: 0;
+  }
+  .bmf-br {
+    bottom: -6px;
+    right: -6px;
+    border-left: 0;
+    border-top: 0;
+  }
+
+  @keyframes boxer-mobile-frame-breathe {
+    0%,
+    100% {
+      filter: drop-shadow(0 0 4px color-mix(in srgb, var(--color-theme-gold) 55%, transparent));
+    }
+    50% {
+      filter: drop-shadow(0 0 8px color-mix(in srgb, var(--color-theme-gold) 80%, transparent));
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .boxer-mobile-slide {
+      transform: none;
+    }
+    .bmf-corner {
+      animation: none;
+    }
   }
 
   .boxer-mobile-slide::before {
@@ -819,11 +918,11 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   @keyframes boxer-mobile-slide-in {
     from {
       opacity: 0;
-      transform: translateY(10px) scale(0.98);
+      translate: 0 10px;
     }
     to {
       opacity: 1;
-      transform: translateY(0) scale(1);
+      translate: 0 0;
     }
   }
 
@@ -1418,7 +1517,38 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       }
     }
 
-    requestAnimationFrame(moveToMiddleSet)
+    // Efecto "character select": la tarjeta más centrada en el viewport del
+    // carrusel se agranda y brilla, y las laterales se encogen/atenúan según su
+    // distancia al centro. Además, el marco de esquinas se funde de forma
+    // continua (--focus-frame) para que no aparezca de golpe. Se recalcula en
+    // cada frame de scroll (rAF) usando offsets (no getBoundingClientRect) para
+    // no forzar reflows por slide.
+    let focusRaf = 0
+    const updateFocus = () => {
+      focusRaf = 0
+      const half = slider.clientWidth / 2 || 1
+      const viewportCenter = slider.scrollLeft + half
+      for (const slide of slides) {
+        const slideCenter = slide.offsetLeft + slide.offsetWidth / 2
+        const ratio = Math.min(Math.abs(slideCenter - viewportCenter) / half, 1)
+        slide.style.setProperty('--focus-scale', (1.12 - ratio * 0.24).toFixed(3))
+        slide.style.setProperty('--focus-bright', (1.05 - ratio * 0.4).toFixed(3))
+        slide.style.setProperty('--focus-sat', (1.05 - ratio * 0.25).toFixed(3))
+        // Rango ancho (0.55) + smoothstep para que el marco entre/salga suave.
+        const t = Math.max(0, 1 - ratio / 0.55)
+        slide.style.setProperty('--focus-frame', (t * t * (3 - 2 * t)).toFixed(3))
+      }
+    }
+    const requestFocus = () => {
+      if (!focusRaf) focusRaf = requestAnimationFrame(updateFocus)
+    }
+
+    slider.addEventListener('scroll', requestFocus, { passive: true })
+
+    requestAnimationFrame(() => {
+      moveToMiddleSet()
+      updateFocus()
+    })
 
     // `scrollend` está disponible en Safari iOS 18.2+, Chrome 114+ y
     // Firefox 109+. Cuando exista, normalizamos solo cuando todo el scroll
@@ -1440,7 +1570,12 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
       )
     }
 
-    window.addEventListener('resize', () => requestAnimationFrame(moveToMiddleSet))
+    window.addEventListener('resize', () =>
+      requestAnimationFrame(() => {
+        moveToMiddleSet()
+        updateFocus()
+      }),
+    )
   }
 
   function initBoxerSelector() {

--- a/src/sections/Hero.astro
+++ b/src/sections/Hero.astro
@@ -36,7 +36,7 @@ const timestamp = EVENT_DATE.getTime()
 
     <div class="absolute inset-0 z-1 bg-linear-to-b from-black/40 via-transparent to-theme-midnight/80" aria-hidden="true"></div>
 
-    <header class="relative z-10 flex min-h-screen w-full flex-col items-center justify-start px-4 pt-14 pb-3 text-center sm:pt-16 lg:pb-5">
+    <header class="relative z-10 flex min-h-svh w-full flex-col items-center justify-start px-4 pt-14 pb-4 text-center sm:pt-16 lg:pb-5">
       <h1 class="sr-only">
         La Velada del Año VI — Evento de boxeo amateur entre streamers organizado por Ibai
         Llanos el sábado 25 de julio de 2026 en el Estadio de La Cartuja de Sevilla


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page.

## Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

<!-- Mejora de responsive detectada en la primera vista del selector en móvil. -->
N/A

## Changes

- `src/sections/Hero.astro`: la cabecera del hero usa `min-h-svh` en lugar de `min-h-screen`, para que la primera vista del selector entre en el alto **real** del viewport en móvil (con `100vh` el carrusel quedaba comprimido/cortado bajo la barra del navegador). Pequeño respiro inferior (`pb-3` → `pb-4`).
- `src/components/BoxerSelector.astro`:
  - **Primera vista móvil**: logo algo más pequeño (`50vw`) y `padding-bottom` con `safe-area-inset` en el pie, para que logo + fecha + CTA + carrusel quepan con aire y sin cortarse.
  - **Carrusel tipo "character select"**: la tarjeta más centrada se agranda y se ilumina, y las laterales se encogen/atenúan según su distancia al centro (cálculo continuo por `requestAnimationFrame`, usando offsets para no forzar reflows).
  - **Marco de esquinas** (corner brackets) sobre la tarjeta central — mismo lenguaje visual que el cursor de selección de escritorio — con **fundido continuo y suave** (sin saltos) al deslizar.
  - La animación de entrada de las tarjetas pasa a `translate`/`opacity` para dejar `transform` libre al efecto de foco.
  - Respeta `prefers-reduced-motion`.

## Dependencies

- Added: None
- Removed: None

## Screenshots

<!--
  Before = estado actual en producción (https://www.infolavelada.com/)
  After  = esta PR (deploy preview de Vercel que aparece en este hilo)
  Arrastra cada captura dentro de la celda correspondiente.
-->

| View | Before (producción) | After (esta PR) |
|------|---------------------|-----------------|
| Mobile | <img width="383" height="673" alt="image" src="https://github.com/user-attachments/assets/0dbca88d-2089-43e2-a23c-189151e94108" />| <img width="383" height="673" alt="image" src="https://github.com/user-attachments/assets/b3526b1e-77ea-42d0-8e1e-5c863da07cb2" /> |

<!-- Opcional: vídeo del carrusel deslizando para mostrar el efecto de foco/marco. -->

## Checklist

- [x] Tested on mobile (<768px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Mejora del selector de personajes en móvil con un carrusel más cinematográfico, marcos ornamentales y efectos visuales dinámicos centrados en el foco del contenido.

* **Bug Fixes**
  * Recalculo continuo del foco durante el scroll y normalización posterior al ajuste del carrusel para reducir parpadeos.

* **Style**
  * Mejoras de espaciado y altura segura en móvil (incluye ajustes para notches/safe areas) y cambios en las transiciones, con soporte para reducir la animación cuando corresponda.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->