### PR TITLE
Fix scroll jump issue by keeping content in view when applying filters

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1479,6 +1479,24 @@ const totalBoxers = BOXERS.length
       gridEl.dataset.state = state
     }
 
+    const HEADER_HEIGHT = 70
+    const SCROLL_OFFSET = 110
+
+    function keepContentInView(anchor: HTMLElement | null) {
+      if (!anchor) return
+
+      const { top: anchorTop } = anchor.getBoundingClientRect()
+
+      if (anchorTop > HEADER_HEIGHT) return
+
+      const scrollTop = anchor.getBoundingClientRect().top + window.scrollY - SCROLL_OFFSET
+
+      window.scrollTo({
+        top: scrollTop,
+        behavior: 'instant',
+      })
+    }
+
     // Reordena el DOM (no sólo CSS `order`) para que el orden de
     // tabulación coincida con el visual. Con 20 cards el coste es
     // despreciable y mantenemos la accesibilidad correcta.
@@ -1536,6 +1554,8 @@ const totalBoxers = BOXERS.length
       const gridState = !hasActiveFilter && isDefaultSortMode ? 'default' : 'modified'
 
       setGridState(gridState)
+      // Mantiene el contenido dentro del viewport al aplicar filtros. Esto evita que los cambios en la altura del contenedor de las cards, ya sea por crecimiento o reducción de su contenido, provoquen desplazamientos inesperados que puedan enviar al usuario a la siguiente sección o dejar contenido parcialmente cortado.
+      keepContentInView(sortBar)
 
       let visible = 0
       for (const card of cards) {


### PR DESCRIPTION
Se crea la función `keepContentInView` que mantiene el contenido dentro del viewport al aplicar filtros. Esto evita que los cambios en la altura del contenedor de las cards, ya sea por crecimiento o reducción de su contenido, provoquen desplazamientos inesperados que puedan enviar al usuario a la siguiente sección o dejar contenido parcialmente cortado.

Antes: 
<img width="800" height="450" alt="antes" src="https://github.com/user-attachments/assets/ae795963-3082-4fa0-851d-c91d97da7be1" />

Despúes:
<img width="800" height="450" alt="despúes" src="https://github.com/user-attachments/assets/54500431-c735-40af-80b8-08956e4f6e58" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Bug Fixes**
  * Se corrigió un problema de desplazamiento inesperado que ocurría al aplicar filtros. El contenido ahora permanece en su posición correcta cuando cambia la altura del grid, mejorando la experiencia de navegación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->