### PR TITLE
Fix relative positioning for even boxer cards in the grid layout

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1362,6 +1362,10 @@ const totalBoxers = BOXERS.length
     }
   }
 
+  .boxers-grid[data-state='default'] > .boxer-card-wrap:nth-child(even) {
+    position: relative;
+  }
+
   .boxers-grid[data-state='default'] > .boxer-card-wrap:nth-child(even)::after {
     --inline-size: 2.3em;
     --block-size: 2.05em;


### PR DESCRIPTION
Se corrige posicionamiento del badge `VS` agregando `position: relative` al contenedor.
El badge cambiaba de posicion al viajar de `/boxeadores` a `/boxeadores/id` y regresar a `/boxeadores`

Antes:
<img width="800" height="450" alt="antes" src="https://github.com/user-attachments/assets/9ccb518b-e694-4fbd-87b9-adce2d40ca31" />

Despúes:
<img width="800" height="450" alt="despúes" src="https://github.com/user-attachments/assets/56577fef-01ec-40a6-8f48-7fadb04ede88" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Estilo**
  * Mejoras en el posicionamiento visual de las tarjetas de boxeadores en la cuadrícula para una mejor presentación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->