### PR TITLE
Optimize image loading strategy for boxer cards

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -102,6 +102,8 @@ const genderFilters: Array<{ code: BoxerGender; name: string; count: number }> =
 }))
 
 const totalBoxers = BOXERS.length
+
+const cardImageEagerAmount = 4
 ---
 
 <Layout title={title} description={description} canonical={canonical}>
@@ -342,10 +344,13 @@ const totalBoxers = BOXERS.length
                     <img
                       src={b.heroImages.webp}
                       alt={`Recorte fotográfico de ${b.name}`}
-                      loading="lazy"
-                      decoding="async"
+                      width="1066"
+                      height="1600"
+                      loading={index < cardImageEagerAmount ? 'eager' : 'lazy'}
+                      decoding={index < cardImageEagerAmount ? 'auto' : 'async'}
+                      fetchpriority={index < cardImageEagerAmount ? 'high' : 'auto'}
                       transition:name={`boxer-hero-${b.id}`}
-                      class="boxer-card-img absolute inset-0 h-full w-full object-cover object-top"
+                      class="boxer-card-img h-full w-full object-cover object-top"
                     />
                   </picture>
 


### PR DESCRIPTION
Se ajusta la estrategia de carga, decodificación y prioridad de las imágenes en `/boxeadores`, garantizando que las cuatro primeras imágenes se carguen con alta prioridad.

Este cambio elimina el parpadeo perceptible durante la carga inicial, mejora la experiencia de usuario y evita incumplir recomendaciones de Lighthouse, como **"LCP resources should not use loading=lazy"**.

Parpadeo mencionado:

https://github.com/user-attachments/assets/eca2cfb0-66d5-4a4d-9833-16d786601c3e


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Optimizaciones de Rendimiento**
  * Mejorado el rendimiento de carga de imágenes en tarjetas de boxeadores mediante carga selectiva: las primeras tarjetas se cargan con prioridad alta, mientras que las siguientes utilizan carga diferida.
  * Corrección en el renderizado de imágenes con declaración explícita de dimensiones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->