### PR TITLE
fix(data): corrige la edad de Edu Aguirre (38)

### DIFF
--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -107,7 +107,7 @@ export const BOXERS: Boxer[] = [
       previousVeladaWins: [],
       gender: 'm',
       birthDate: '1988-01-14',
-      age: 30,
+      age: 38,
       heightCm: 175,
       weightKg: 70,
       fightWeightKg: 70,


### PR DESCRIPTION
## Qué
La edad de **Edu Aguirre** estaba como `30` cuando su fecha de nacimiento (`1988-01-14`) corresponde a **38 años**.

## Por qué importa
La nueva tabla de características del combate (`CombatStatsSection`) muestra `boxer.age` directamente, por lo que se publicaba un dato incorrecto al usuario.

## Cambio
`src/consts/boxers.ts`: `age: 30` → `age: 38` (acorde a `birthDate`).

## Test plan
- [ ] Abrir `/combate/edu-aguirre-vs-gaston-edul` y verificar que la fila **Edad** muestra `38 años`.