### PR TITLE
fix(combat): respeta prefers-reduced-motion en el vídeo de fondo

### DIFF
--- a/src/components/combat/CombatBackground.astro
+++ b/src/components/combat/CombatBackground.astro
@@ -24,6 +24,30 @@ const { video } = Astro.props
   )
 }
 
+<script>
+  function initCombatBgVideo() {
+    const video = document.querySelector<HTMLVideoElement>('.combat-bg-video')
+    if (!video) return
+
+    // Accesibilidad: no reproducir si el usuario pide menos movimiento.
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (prefersReducedMotion) {
+      video.removeAttribute('autoplay')
+      video.pause()
+      return
+    }
+
+    // Ahorro de batería/datos: pausar mientras la pestaña no está visible.
+    const handleVisibility = () => {
+      if (document.hidden) video.pause()
+      else void video.play().catch(() => {})
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+  }
+
+  document.addEventListener('astro:page-load', initCombatBgVideo)
+</script>
+
 <style>
   .combat-bg-video-wrap {
     position: fixed;


### PR DESCRIPTION
## Qué
El vídeo de fondo del combate (`CombatBackground`) se autorreproduce en bucle **siempre**, ignorando `prefers-reduced-motion` (accesibilidad) y consumiendo batería/datos en móvil aunque la pestaña no esté visible.

## Cambio
`CombatBackground.astro`: pequeño script que
- **No reproduce** el vídeo si el usuario tiene `prefers-reduced-motion: reduce`.
- **Pausa** el vídeo cuando la pestaña deja de estar visible (`visibilitychange`) y lo reanuda al volver.

## Notas
No se pausa al hacer scroll porque el vídeo es `position: fixed` y queda visible detrás de las secciones transparentes; pausarlo congelaría el fondo a la vista. Las dos condiciones implementadas son ganancias sin efecto visual no deseado.

## Test plan
- [ ] Con `prefers-reduced-motion: reduce` activo, el vídeo de fondo no se reproduce.
- [ ] Sin reduced-motion, el vídeo reproduce normal; al cambiar de pestaña se pausa y al volver se reanuda.