### PR TITLE
fix(boxers): resolve animation conflict on boxers page navigation

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1414,7 +1414,7 @@ const cardImageEagerAmount = 4
     }
   }
 
-  html[data-skip-boxers-enter] .animate-fade-in-up {
+  :global(html[data-skip-boxers-enter]) .animate-fade-in-up {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -161,7 +161,9 @@ const cardImageEagerAmount = 4
           aria-hidden="true"
         >
           <span class="size-1 rotate-45 bg-theme-gold/85"></span>
-          <span class="font-cinzel text-[0.55rem] font-black tracking-[0.26em] text-theme-gold/95 sm:text-[0.65rem]">
+          <span
+            class="font-cinzel text-[0.55rem] font-black tracking-[0.26em] text-theme-gold/95 sm:text-[0.65rem]"
+          >
             FILTROS
           </span>
           <span class="size-1 rotate-45 bg-theme-gold/85"></span>
@@ -1414,7 +1416,7 @@ const cardImageEagerAmount = 4
     }
   }
 
-  :global(html[data-skip-boxers-enter]) .animate-fade-in-up {
+  html[data-skip-boxers-enter] :global(.animate-fade-in-up) {
     animation: none;
     opacity: 1;
     transform: none;

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1414,6 +1414,12 @@ const cardImageEagerAmount = 4
     }
   }
 
+  html[data-skip-boxers-enter] .animate-fade-in-up {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .boxer-card-wrap,
     .boxers-grid[data-state='default'] > .boxer-card-wrap:nth-child(even)::after {
@@ -1525,6 +1531,7 @@ const cardImageEagerAmount = 4
 
     const ANIM_CLASS = 'animate-fade-in-up'
     const ANIM_DELAY = 35
+    let skipCardsAnimation = document.documentElement.hasAttribute('data-skip-boxers-enter')
 
     function retriggerAnimations() {
       let visibleIndex = 0
@@ -1574,7 +1581,7 @@ const cardImageEagerAmount = 4
 
       for (const card of ordered) gridEl.appendChild(card)
 
-      retriggerAnimations()
+      if (!skipCardsAnimation) retriggerAnimations()
     }
 
     // Cuenta cards que coinciden con un par (country, gender). Pasar '' en
@@ -1661,7 +1668,7 @@ const cardImageEagerAmount = 4
         btn.dataset.disabled = String(shouldDisable)
       }
 
-      retriggerAnimations()
+      if (!skipCardsAnimation) retriggerAnimations()
     }
 
     for (const btn of filterButtons) {
@@ -1707,6 +1714,11 @@ const cardImageEagerAmount = 4
 
     applyFilters()
     applySort()
+
+    if (skipCardsAnimation) {
+      document.documentElement.removeAttribute('data-skip-boxers-enter')
+      skipCardsAnimation = false
+    }
   }
 
   document.addEventListener('astro:page-load', setupBoxersFilters)

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,12 +47,6 @@
     background: var(--color-theme-midnight);
   }
 
-  html[data-skip-boxers-enter] .boxers-page .animate-fade-in-up {
-    animation: none !important;
-    opacity: 1 !important;
-    transform: none !important;
-  }
-
   /* Webkit Browsers (Chrome, Safari, Edge) */
   ::-webkit-scrollbar {
     width: 10px;


### PR DESCRIPTION
Se corrige la cancelación de animaciones durante la navegación entre `/boxeadores/:id` y `/boxeadores`.

El ajuste evita que se cancelen de forma global todas las animaciones de la página, preservando aquellas asociadas a la interacción del usuario, como las que se ejecutan al filtrar u ordenar las tarjetas de boxeadores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de la versión

* **Mejoras de rendimiento**
  * Optimización del comportamiento de animaciones en la página de boxeadores para lograr una carga y actualización más fluidas.
  * Se añade soporte para omitir las animaciones de entrada de los cards en ciertos escenarios, evitando retrigger innecesarios al aplicar filtros y orden.
  * Ajuste del comportamiento de animaciones para recuperar la aplicación de estilos generales cuando corresponde.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->