### PR TITLE
fix(BoxerSelector): adjust hero boxer image size and position

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -229,7 +229,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
         </picture>
       </div>
 
-      <div class="relative z-20 -mt-4 flex flex-col items-center sm:-mt-6 md:-mt-8 lg:-mt-10">
+      <div class="relative z-20 flex flex-col items-center sm:-mt-6 md:-mt-8 lg:-mt-10 top-7">
         <h2
           data-active-name
           class="boxer-name relative font-cinzel text-3xl font-black leading-none tracking-[0.08em] text-theme-cream sm:text-5xl md:text-6xl lg:text-7xl"
@@ -261,7 +261,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
 
   <div class="boxer-selector-foot mt-auto flex w-full shrink-0 flex-col items-center gap-1.5 md:gap-3">
     <div
-      class="boxer-cta-bar relative z-20 flex w-full flex-col items-center gap-3 px-4 pt-2 transition-opacity duration-300 ease-out md:gap-4 md:pt-4"
+      class="boxer-cta-bar relative z-20 flex w-full flex-col items-center gap-3 transition-opacity duration-300 ease-out md:gap-4"
     >
       <SectionDivider class="boxer-default-divider" />
 
@@ -700,7 +700,7 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   }
 
   .boxer-portrait-layer {
-    --boxer-portrait-drop: clamp(3.25rem, 8vh, 5.5rem);
+    --boxer-portrait-drop: 140px;
   }
 
   .boxer-portrait-wrap {


### PR DESCRIPTION
Se ajusta el tamaño de la imagen del boxeador seleccionado en el componente `BoxerSelector.astro` para hacerlo visiblemente más grande y mejor posicionado

Antes:
<img width="1876" height="987" alt="image" src="https://github.com/user-attachments/assets/6c878cd4-1efd-448d-a972-683ad6e46ab8" />

Despúes
<img width="1873" height="988" alt="image" src="https://github.com/user-attachments/assets/b75d15ad-5a3b-4d65-a9f9-a8f708e0cb5b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Estilo**
  * Ajuste del posicionamiento vertical en el selector de boxeadores para mejorar la alineación del nombre y país.
  * Optimización del espaciado en la barra de llamada a la acción, eliminando padding innecesario.
  * Refinamiento de las proporciones visuales del retrato del boxeador mediante ajustes en el recorte vertical.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->