### PR TITLE
fix(pronosticos): anima la barra de voto una sola vez (Optimistic UI)

### DIFF
--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -123,7 +123,12 @@ const controllerConfig = JSON.stringify({
     return Number(option.dataset.votePercentage ?? 0)
   }
 
-  function writeOptionPrediction(option: HTMLButtonElement, votes: number, percentage: number) {
+  function writeOptionPrediction(
+    option: HTMLButtonElement,
+    votes: number,
+    percentage: number,
+    { animateChange = true }: { animateChange?: boolean } = {},
+  ) {
     const safeVotes = Math.max(0, votes)
     const safePercentage = Math.max(0, Math.min(100, percentage))
     const previousPercentage = readVotePercentage(option)
@@ -136,7 +141,7 @@ const controllerConfig = JSON.stringify({
     if (percentNode) percentNode.textContent = formatPercent(safePercentage)
     if (votesNode) votesNode.textContent = formatSupport(safeVotes)
 
-    if (Math.abs(previousPercentage - safePercentage) > 0.05 && !prefersReducedMotion()) {
+    if (animateChange && Math.abs(previousPercentage - safePercentage) > 0.05 && !prefersReducedMotion()) {
       window.clearTimeout(voteBarAnimationTimeouts.get(option))
       option.dataset.voteChanging = safePercentage > previousPercentage ? 'up' : 'down'
 

--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -374,7 +374,12 @@ const controllerConfig = JSON.stringify({
       )
       if (!option) return
 
-      writeOptionPrediction(option, predictionOption.votes, predictionOption.percentage)
+      // Reconciliación silenciosa con el servidor: actualizamos cifras y anchura,
+      // pero sin volver a disparar el flare de la barra. La animación ya se ejecutó
+      // una sola vez con el voto optimista al hacer click (sensación de fluidez).
+      writeOptionPrediction(option, predictionOption.votes, predictionOption.percentage, {
+        animateChange: false,
+      })
     })
     updateFightBadge(fight)
   }


### PR DESCRIPTION
##  Qué resuelve

Al pronosticar un boxeador, la barra de voto se animaba **dos veces**: una al hacer click (voto optimista) y otra al confirmarse la petición del servidor. Esto rompía la sensación de fluidez del Optimistic UI.

Ahora la barra **anima una sola vez al click** y la confirmación del servidor reconcilia los datos en silencio.

##  Causa

En `PredictionVoteController.astro` el voto escribía la barra dos veces vía `writeOptionPrediction()`:

1. `applyOptimisticVote()` (al click) dispara el flare `data-vote-changing`.
2. `applyPredictionData()` (al confirmar) lo **volvía a disparar**, porque el `%` del servidor casi nunca coincide con el optimista: el total optimista solo conoce los votos locales, mientras el servidor recalcula el total real (votos concurrentes + caché de 30 s), superando el umbral `> 0.05`.

##  Solución

- Nuevo parámetro opcional `animateChange` (default `true`) en `writeOptionPrediction`. El voto optimista y el revert de error siguen animando igual.
- La reconciliación con el servidor (`applyPredictionData`) pasa `animateChange: false`: actualiza cifras y anchura, pero **sin** re-disparar el flare/sheen/pop.
- Si el dato real difiere, la anchura se ajusta con la transición CSS suave ya existente (corrección de datos, no una segunda animación).
- Respeta `prefers-reduced-motion`. Cambio acotado a una función local del `<script>`.

##  Validación

- `eslint` sobre el componente: sin errores.
- `astro build`: compila correctamente.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Se corrigió el comportamiento de las animaciones en las actualizaciones de predicciones. Las animaciones visuales ya no se repiten innecesariamente cuando el servidor reconcilia los datos tras una acción del usuario.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->