### PR TITLE
fix(pronosticos): anima la barra de voto una sola vez (Optimistic UI)

### DIFF
--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -123,7 +123,12 @@ const controllerConfig = JSON.stringify({
     return Number(option.dataset.votePercentage ?? 0)
   }
 
-  function writeOptionPrediction(option: HTMLButtonElement, votes: number, percentage: number) {
+  function writeOptionPrediction(
+    option: HTMLButtonElement,
+    votes: number,
+    percentage: number,
+    { animateChange = true }: { animateChange?: boolean } = {},
+  ) {
     const safeVotes = Math.max(0, votes)
     const safePercentage = Math.max(0, Math.min(100, percentage))
     const previousPercentage = readVotePercentage(option)
@@ -136,7 +141,7 @@ const controllerConfig = JSON.stringify({
     if (percentNode) percentNode.textContent = formatPercent(safePercentage)
     if (votesNode) votesNode.textContent = formatSupport(safeVotes)
 
-    if (Math.abs(previousPercentage - safePercentage) > 0.05 && !prefersReducedMotion()) {
+    if (animateChange && Math.abs(previousPercentage - safePercentage) > 0.05 && !prefersReducedMotion()) {
       window.clearTimeout(voteBarAnimationTimeouts.get(option))
       option.dataset.voteChanging = safePercentage > previousPercentage ? 'up' : 'down'
 

--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -374,7 +374,12 @@ const controllerConfig = JSON.stringify({
       )
       if (!option) return
 
-      writeOptionPrediction(option, predictionOption.votes, predictionOption.percentage)
+      // Reconciliación silenciosa con el servidor: actualizamos cifras y anchura,
+      // pero sin volver a disparar el flare de la barra. La animación ya se ejecutó
+      // una sola vez con el voto optimista al hacer click (sensación de fluidez).
+      writeOptionPrediction(option, predictionOption.votes, predictionOption.percentage, {
+        animateChange: false,
+      })
     })
     updateFightBadge(fight)
   }


### PR DESCRIPTION
## Que resuelve

Al pronosticar un boxeador, la barra de voto se animaba **dos veces**: una al hacer click (voto optimista) y otra al confirmarse la peticion del servidor. Esto rompia la sensacion de fluidez del Optimistic UI.

Ahora la barra **anima una sola vez al click** y la confirmacion del servidor reconcilia los datos en silencio.

## Causa

En `PredictionVoteController.astro` el voto escribia la barra dos veces via `writeOptionPrediction()`:

1. `applyOptimisticVote()` (al click) dispara el flare `data-vote-changing`.
2. `applyPredictionData()` (al confirmar) lo **volvia a disparar**, porque el `%` del servidor casi nunca coincide con el optimista: el total optimista solo conoce los votos locales, mientras el servidor recalcula el total real (votos concurrentes + cache de 30 s), superando el umbral `> 0.05`.

## Solucion

- Nuevo parametro opcional `animateChange` (default `true`) en `writeOptionPrediction`. El voto optimista y el revert de error siguen animando igual.
- La reconciliacion con el servidor (`applyPredictionData`) pasa `animateChange: false`: actualiza cifras y anchura, pero **sin** re-disparar el flare/sheen/pop.
- Si el dato real difiere, la anchura se ajusta con la transicion CSS suave ya existente (correccion de datos, no una segunda animacion).
- Respeta `prefers-reduced-motion`. Cambio acotado a una funcion local del `<script>`.

## Validacion

- `eslint` sobre el componente: sin errores.
- `astro build`: compila correctamente.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Bug Fixes**
  * Se mejoró el manejo de animaciones en las barras de predicción para evitar comportamientos visuales duplicados al sincronizar datos del servidor.

* **Refactor**
  * Optimización del control de animaciones para mayor precisión en la actualización de datos de predicción.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->