### PR TITLE
refine 'VS' box styling with fixed font size and enhanced background …

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1395,9 +1395,14 @@ const cardImageEagerAmount = 4
     block-size: var(--block-size);
     font-family: var(--font-cinzel);
     font-weight: 900;
-    font-size: clamp(1.125rem, 0.875rem + 0.313vw, 1.25rem);
+    font-size: 1.125rem;
     color: var(--color-theme-gold);
     background-color: var(--color-theme-midnight);
+    background-image: radial-gradient(
+      ellipse at top,
+      color-mix(in srgb, var(--color-theme-gold), transparent 88%) 0%,
+      transparent 80%
+    );
     border-radius: 4px;
     line-height: normal;
     border: 1px solid color-mix(in srgb, var(--color-theme-gold) 30%, transparent);


### PR DESCRIPTION
Se mejoran detallitos para que el badge `VS` se integre mejor con el diseño

Antes:
<img width="504" height="331" alt="image" src="https://github.com/user-attachments/assets/34a5ee99-6406-4725-864c-b39e54d0a060" />

Despúes:
<img width="508" height="333" alt="image" src="https://github.com/user-attachments/assets/166c18f4-8860-4b32-b002-5df801cd706c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Se mejoró el diseño visual del rótulo "VS" en las tarjetas de boxeadores con un nuevo efecto de degradado dorado para una presentación más refinada.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->