### PR TITLE
add visibility control to boxer cell enter animation

### DIFF
--- a/src/components/BoxerSelector.astro
+++ b/src/components/BoxerSelector.astro
@@ -1370,9 +1370,11 @@ const MOBILE_SLIDER_SETS = ['previous', 'current', 'next'] as const
   @keyframes boxer-cell-enter {
     from {
       opacity: 0;
+      visibility: hidden;
     }
     to {
       opacity: 1;
+      visibility: visible;
     }
   }
 


### PR DESCRIPTION
Se agrega una transición de `visibility: hidden` a `visibility: visible` en elementos interactivos para evitar interacciones accidentales mientras sus animaciones de entrada aún no han finalizado.

En este caso, los elementos afectados son enlaces que podrían provocar una navegación no intencionada y hacer que el usuario abandone el contexto actual. Además, estos enlaces cuentan con efectos *hover* controlados mediante JavaScript que pueden activarse antes de que la animación concluya, generando comportamientos visuales inconsistentes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Mejoras de estilo

* Se optimizó el comportamiento y el control explícito de las animaciones de transición, garantizando una visibilidad consistente y fluida durante todos los cambios de estado visual en la interfaz. Esta mejora refuerza significativamente la coherencia y profesionalismo de la experiencia interactiva completa para los usuarios finales de la aplicación.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->