### PR TITLE
fix: enable boxer card initial animations by refactoring the logic

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1421,7 +1421,7 @@ const cardImageEagerAmount = 4
     }
   }
 
-  html[data-skip-boxers-enter] :global(.animate-fade-in-up) {
+  html[data-skip-boxers-enter] .boxer-card-wrap {
     animation: none;
     opacity: 1;
     transform: none;
@@ -1538,7 +1538,6 @@ const cardImageEagerAmount = 4
 
     const ANIM_CLASS = 'animate-fade-in-up'
     const ANIM_DELAY = 35
-    let skipCardsAnimation = document.documentElement.hasAttribute('data-skip-boxers-enter')
 
     function retriggerAnimations() {
       let visibleIndex = 0
@@ -1558,6 +1557,12 @@ const cardImageEagerAmount = 4
 
         visibleIndex++
       }
+    }
+
+    // Remueve el atributo 'data-skip-boxers-enter' añádido en el script de 'Layout.astro'
+    // que impide las animaciones de entrada en las tarjetas de los boxeadores
+    function allowBoxerCardAnimations() {
+      document.documentElement.removeAttribute('data-skip-boxers-enter')
     }
 
     // Reordena el DOM (no sólo CSS `order`) para que el orden de
@@ -1587,8 +1592,6 @@ const cardImageEagerAmount = 4
       }
 
       for (const card of ordered) gridEl.appendChild(card)
-
-      if (!skipCardsAnimation) retriggerAnimations()
     }
 
     // Cuenta cards que coinciden con un par (country, gender). Pasar '' en
@@ -1674,8 +1677,6 @@ const cardImageEagerAmount = 4
         btn.disabled = shouldDisable
         btn.dataset.disabled = String(shouldDisable)
       }
-
-      if (!skipCardsAnimation) retriggerAnimations()
     }
 
     for (const btn of filterButtons) {
@@ -1688,6 +1689,8 @@ const cardImageEagerAmount = 4
         if (state[group] === value) return
         state[group] = value
         applyFilters()
+        allowBoxerCardAnimations()
+        retriggerAnimations()
         syncStateToURL()
       })
     }
@@ -1697,6 +1700,8 @@ const cardImageEagerAmount = 4
         state.country = ''
         state.gender = ''
         applyFilters()
+        allowBoxerCardAnimations()
+        retriggerAnimations()
         syncStateToURL()
       })
     }
@@ -1710,6 +1715,8 @@ const cardImageEagerAmount = 4
           b.setAttribute('aria-pressed', String(b.dataset.sort === sortMode))
         }
         applySort()
+        allowBoxerCardAnimations()
+        retriggerAnimations()
         syncStateToURL()
       })
     }
@@ -1721,11 +1728,7 @@ const cardImageEagerAmount = 4
 
     applyFilters()
     applySort()
-
-    if (skipCardsAnimation) {
-      document.documentElement.removeAttribute('data-skip-boxers-enter')
-      skipCardsAnimation = false
-    }
+    retriggerAnimations()
   }
 
   document.addEventListener('astro:page-load', setupBoxersFilters)


### PR DESCRIPTION
Se corrige la lógica encargada de activar las animaciones iniciales de las tarjetas de boxeadores en `/boxeadores`.

Anteriormente, al navegar desde `/boxeadores/:id` hacia `/boxeadores`, las tarjetas no llegaban a mostrarse debido a que las animaciones de entrada no se inicializaban correctamente. Con este ajuste, las animaciones se ejecutan según lo esperado y las tarjetas permanecen visibles durante la navegación.

Antes:
<img width="1319" height="916" alt="image" src="https://github.com/user-attachments/assets/c6407da3-55c3-4c1e-b75a-d184f06c24a1" />

Despúes:
<img width="1394" height="966" alt="image" src="https://github.com/user-attachments/assets/a0ea6763-b42c-4b2a-955c-649f499b95ab" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimización de la lógica de control de animaciones en la sección de boxeadores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->