### PR TITLE
fix: improve accessibility by adding headings for combat cards and ke…

### DIFF
--- a/src/components/CombatCard.astro
+++ b/src/components/CombatCard.astro
@@ -50,6 +50,10 @@ const boxers: Array<CardBoxer & { side: 'a' | 'b' }> = [
 ---
 
 <article class:list={['combat', { 'is-featured': featured }]}>
+    <h2 class="sr-only">
+        Combate {number}: {a.name} ({a.countryName}) VS {b.name} ({b.countryName})
+    </h2>
+    
     {badge && <span class="combat-badge font-cinzel">{badge}</span>}
 
     <span aria-hidden="true" class="combat-corner tl"></span>

--- a/src/pages/combates.astro
+++ b/src/pages/combates.astro
@@ -51,8 +51,6 @@ const breadcrumbJsonLd = {
     { '@type': 'ListItem', position: 2, name: 'Combates', item: canonical },
   ],
 }
-
-const EAGER_IMAGE_COUNT = 4
 ---
 
 <Layout title={title} description={description} canonical={canonical}>
@@ -91,21 +89,27 @@ const EAGER_IMAGE_COUNT = 4
             </div>
             <div class="combates-mains">
               {mainEvents.map((c, i) => (
-                <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
-                  <CombatCard
-                    number={c.position}
-                    url={c.url}
-                    featured
-                    badge={i === 0 ? 'Main Event' : 'Co-estelar'}
-                    a={c.a}
-                    b={c.b}
-                    imageLoadingStrategy={{
-                        loading: i < EAGER_IMAGE_COUNT ? 'eager' : 'lazy',
-                        decoding: i < EAGER_IMAGE_COUNT ? 'auto' : 'async',
-                        fetchpriority: i < EAGER_IMAGE_COUNT ? 'high' : 'auto',
-                    }}
-                  />
-                </div>
+                <>
+                  <h2 class="sr-only">
+                    Combate {c.position}: {c.a.name} ({c.a.countryName}) VS {c.b.name} (
+                    {c.b.countryName})
+                  </h2>
+                  <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
+                    <CombatCard
+                      number={c.position}
+                      url={c.url}
+                      featured
+                      badge={i === 0 ? 'Main Event' : 'Co-estelar'}
+                      a={c.a}
+                      b={c.b}
+                      imageLoadingStrategy={{
+                        loading: 'eager',
+                        decoding: 'auto',
+                        fetchpriority: 'high',
+                      }}
+                    />
+                  </div>
+                </>
               ))}
             </div>
           </>
@@ -120,9 +124,15 @@ const EAGER_IMAGE_COUNT = 4
             </div>
             <div class="combates-under">
               {combats.map((c, i) => (
-                <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
-                  <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
-                </div>
+                <>
+                  <h2 class="sr-only">
+                    Combate {c.position}: {c.a.name} ({c.a.countryName}) VS {c.b.name} (
+                    {c.b.countryName})
+                  </h2>
+                  <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
+                    <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
+                  </div>
+                </>
               ))}
             </div>
           </>

--- a/src/pages/combates.astro
+++ b/src/pages/combates.astro
@@ -89,27 +89,21 @@ const breadcrumbJsonLd = {
             </div>
             <div class="combates-mains">
               {mainEvents.map((c, i) => (
-                <>
-                  <h2 class="sr-only">
-                    Combate {c.position}: {c.a.name} ({c.a.countryName}) VS {c.b.name} (
-                    {c.b.countryName})
-                  </h2>
-                  <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
-                    <CombatCard
-                      number={c.position}
-                      url={c.url}
-                      featured
-                      badge={i === 0 ? 'Main Event' : 'Co-estelar'}
-                      a={c.a}
-                      b={c.b}
-                      imageLoadingStrategy={{
-                        loading: 'eager',
-                        decoding: 'auto',
-                        fetchpriority: 'high',
-                      }}
-                    />
-                  </div>
-                </>
+                <div class="animate-fade-in-up" style={`animation-delay:${i * 70}ms`}>
+                  <CombatCard
+                    number={c.position}
+                    url={c.url}
+                    featured
+                    badge={i === 0 ? 'Main Event' : 'Co-estelar'}
+                    a={c.a}
+                    b={c.b}
+                    imageLoadingStrategy={{
+                      loading: 'eager',
+                      decoding: 'auto',
+                      fetchpriority: 'high',
+                    }}
+                  />
+                </div>
               ))}
             </div>
           </>
@@ -124,15 +118,9 @@ const breadcrumbJsonLd = {
             </div>
             <div class="combates-under">
               {combats.map((c, i) => (
-                <>
-                  <h2 class="sr-only">
-                    Combate {c.position}: {c.a.name} ({c.a.countryName}) VS {c.b.name} (
-                    {c.b.countryName})
-                  </h2>
-                  <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
-                    <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
-                  </div>
-                </>
+                <div class="animate-fade-in-up" style={`animation-delay:${i * 45}ms`}>
+                  <CombatCard number={c.position} url={c.url} a={c.a} b={c.b} />
+                </div>
               ))}
             </div>
           </>


### PR DESCRIPTION
Se agregan títulos `h2` en `/combates` para mantener una estructura jerárquica correcta de encabezados y mejorar la accesibilidad.

Actualmente, estos encabezados utilizan la clase `sr-only` para conservar el diseño.

Se elimina la estrategia condicional de carga de imágenes, ya que los combates marcados como *main event* son únicamente dos y se encuentran al inicio de la página.

Debido a su posición dentro del viewport, sus imágenes siempre deben tener la mayor prioridad de carga.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Notas de Lanzamiento

* **Rendimiento**
  * Se optimizó la carga de imágenes en los eventos principales, mejorando la priorización para una visualización más fluida.

* **Mejoras de Accesibilidad**
  * Se añadió un encabezado solo para lectores de pantalla en cada combate, mostrando el número del combate y la comparación de ambos boxeadores (formato “VS”).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->