### PR TITLE
feat: tabla comparativa 'Cara a cara' en la página de combate

### DIFF
--- a/src/components/CombatStatsTable.astro
+++ b/src/components/CombatStatsTable.astro
@@ -107,7 +107,7 @@ const valueClass = (won: boolean) => (won ? 'font-black text-theme-gold' : 'text
           <td class="px-3 py-3 text-theme-cream/85">
             <span class="flex items-center justify-center gap-2">
               <CountryFlag country={boxer1.country} size={18} decorative />
-              {COUNTRY_NAMES[boxer1.country] ?? boxer1.country}
+              <span class="sr-only sm:not-sr-only">{COUNTRY_NAMES[boxer1.country] ?? boxer1.country}</span>
             </span>
           </td>
           <th
@@ -119,7 +119,7 @@ const valueClass = (won: boolean) => (won ? 'font-black text-theme-gold' : 'text
           <td class="px-3 py-3 text-theme-cream/85">
             <span class="flex items-center justify-center gap-2">
               <CountryFlag country={boxer2.country} size={18} decorative />
-              {COUNTRY_NAMES[boxer2.country] ?? boxer2.country}
+              <span class="sr-only sm:not-sr-only">{COUNTRY_NAMES[boxer2.country] ?? boxer2.country}</span>
             </span>
           </td>
         </tr>

--- a/src/components/CombatStatsTable.astro
+++ b/src/components/CombatStatsTable.astro
@@ -1,0 +1,149 @@
+---
+import CountryFlag from '@/components/CountryFlag.astro'
+import { type Boxer, COUNTRY_NAMES, getBoxerAge } from '@/consts/boxers'
+import {
+  formatFollowers,
+  getFollowersByPlatform,
+  getSocialLabel,
+  getTotalFollowers,
+} from '@/lib/socials'
+
+interface Props {
+  boxer1: Boxer
+  boxer2: Boxer
+}
+
+const { boxer1, boxer2 } = Astro.props
+
+// Orden fijo para las redes; solo se muestran las que tenga al menos uno.
+const PLATFORM_ORDER = ['youtube', 'instagram', 'tiktok', 'twitch', 'kick', 'x', 'spotify']
+
+const followers1 = getFollowersByPlatform(boxer1)
+const followers2 = getFollowersByPlatform(boxer2)
+const platforms = PLATFORM_ORDER.filter(
+  (platform) => (followers1[platform] ?? 0) > 0 || (followers2[platform] ?? 0) > 0,
+)
+
+const age1 = getBoxerAge(boxer1)
+const age2 = getBoxerAge(boxer2)
+
+// Filas numéricas comparables: se resalta el valor más alto. El alcance
+// combinado abre la sección de redes y el desglose por plataforma la
+// detalla; las victorias en Veladas cierran como dato más distintivo.
+const comparableRows = [
+  {
+    label: 'Alcance combinado',
+    left: getTotalFollowers(boxer1),
+    right: getTotalFollowers(boxer2),
+    format: formatFollowers,
+  },
+  ...platforms.map((platform) => ({
+    label: getSocialLabel(platform),
+    left: followers1[platform] ?? 0,
+    right: followers2[platform] ?? 0,
+    format: formatFollowers,
+  })),
+  {
+    label: 'Victorias en Veladas',
+    left: boxer1.previousVeladaWins.length,
+    right: boxer2.previousVeladaWins.length,
+    format: (value: number) => String(value),
+  },
+]
+
+const valueClass = (won: boolean) =>
+  won ? 'font-black text-theme-gold' : 'text-theme-cream/85'
+---
+
+<section aria-labelledby="tape-title" class="mt-14 w-full">
+  <h2
+    id="tape-title"
+    class="text-center font-cinzel text-3xl font-black tracking-[0.08em] text-theme-gold sm:text-4xl"
+  >
+    Cara a cara
+  </h2>
+
+  <div class="mt-6 overflow-hidden rounded-3xl border border-theme-gold/25 bg-white/[0.03]">
+    <table class="w-full border-collapse text-sm sm:text-base">
+      <caption class="sr-only">
+        Comparativa cara a cara entre {boxer1.name} y {boxer2.name}: edad, país,
+        alcance en redes sociales y victorias en La Velada del Año.
+      </caption>
+      <thead>
+        <tr class="border-b border-theme-gold/20 bg-white/[0.02]">
+          <th
+            scope="col"
+            class="px-3 py-4 text-center text-sm font-black tracking-wide text-theme-cream sm:text-base"
+          >
+            {boxer1.name}
+          </th>
+          <th scope="col" class="px-2 py-4">
+            <span class="sr-only">Estadística</span>
+          </th>
+          <th
+            scope="col"
+            class="px-3 py-4 text-center text-sm font-black tracking-wide text-theme-cream sm:text-base"
+          >
+            {boxer2.name}
+          </th>
+        </tr>
+      </thead>
+      <tbody class="divide-y divide-theme-gold/10">
+        <tr>
+          <td class="px-3 py-3 text-center tabular-nums text-theme-cream/85">
+            {age1 == null ? '—' : `${age1} años`}
+          </td>
+          <th
+            scope="row"
+            class="px-2 py-3 text-center text-[0.7rem] font-bold uppercase tracking-[0.12em] text-white/55"
+          >
+            Edad
+          </th>
+          <td class="px-3 py-3 text-center tabular-nums text-theme-cream/85">
+            {age2 == null ? '—' : `${age2} años`}
+          </td>
+        </tr>
+
+        <tr>
+          <td class="px-3 py-3 text-theme-cream/85">
+            <span class="inline-flex items-center justify-center gap-2">
+              <CountryFlag country={boxer1.country} size={18} decorative />
+              {COUNTRY_NAMES[boxer1.country] ?? boxer1.country}
+            </span>
+          </td>
+          <th
+            scope="row"
+            class="px-2 py-3 text-center text-[0.7rem] font-bold uppercase tracking-[0.12em] text-white/55"
+          >
+            País
+          </th>
+          <td class="px-3 py-3 text-theme-cream/85">
+            <span class="inline-flex items-center justify-center gap-2">
+              <CountryFlag country={boxer2.country} size={18} decorative />
+              {COUNTRY_NAMES[boxer2.country] ?? boxer2.country}
+            </span>
+          </td>
+        </tr>
+
+        {
+          comparableRows.map((row) => (
+            <tr>
+              <td class:list={['px-3 py-3 text-center tabular-nums', valueClass(row.left > row.right)]}>
+                {row.left > 0 || row.label === 'Victorias en Veladas' ? row.format(row.left) : '—'}
+              </td>
+              <th
+                scope="row"
+                class="px-2 py-3 text-center text-[0.7rem] font-bold uppercase tracking-[0.12em] text-white/55"
+              >
+                {row.label}
+              </th>
+              <td class:list={['px-3 py-3 text-center tabular-nums', valueClass(row.right > row.left)]}>
+                {row.right > 0 || row.label === 'Victorias en Veladas' ? row.format(row.right) : '—'}
+              </td>
+            </tr>
+          ))
+        }
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/src/components/CombatStatsTable.astro
+++ b/src/components/CombatStatsTable.astro
@@ -32,7 +32,7 @@ const age2 = getBoxerAge(boxer2)
 // detalla; las victorias en Veladas cierran como dato más distintivo.
 const comparableRows = [
   {
-    label: 'Alcance combinado',
+    label: 'Total',
     left: getTotalFollowers(boxer1),
     right: getTotalFollowers(boxer2),
     format: formatFollowers,
@@ -51,8 +51,7 @@ const comparableRows = [
   },
 ]
 
-const valueClass = (won: boolean) =>
-  won ? 'font-black text-theme-gold' : 'text-theme-cream/85'
+const valueClass = (won: boolean) => (won ? 'font-black text-theme-gold' : 'text-theme-cream/85')
 ---
 
 <section aria-labelledby="tape-title" class="mt-14 w-full">
@@ -63,14 +62,14 @@ const valueClass = (won: boolean) =>
     Cara a cara
   </h2>
 
-  <div class="mt-6 overflow-hidden rounded-3xl border border-theme-gold/25 bg-white/[0.03]">
+  <div class="mt-6 overflow-hidden rounded-3xl border border-theme-gold/25 bg-white/3">
     <table class="w-full border-collapse text-sm sm:text-base">
       <caption class="sr-only">
-        Comparativa cara a cara entre {boxer1.name} y {boxer2.name}: edad, país,
-        alcance en redes sociales y victorias en La Velada del Año.
+        Comparativa cara a cara entre {boxer1.name} y {boxer2.name}: edad, país, alcance en redes
+        sociales y victorias en La Velada del Año.
       </caption>
       <thead>
-        <tr class="border-b border-theme-gold/20 bg-white/[0.02]">
+        <tr class="border-b border-theme-gold/20 bg-white/3">
           <th
             scope="col"
             class="px-3 py-4 text-center text-sm font-black tracking-wide text-theme-cream sm:text-base"
@@ -90,35 +89,35 @@ const valueClass = (won: boolean) =>
       </thead>
       <tbody class="divide-y divide-theme-gold/10">
         <tr>
-          <td class="px-3 py-3 text-center tabular-nums text-theme-cream/85">
+          <td class="px-3 py-3 text-center text-theme-cream/85 tabular-nums">
             {age1 == null ? '—' : `${age1} años`}
           </td>
           <th
             scope="row"
-            class="px-2 py-3 text-center text-[0.7rem] font-bold uppercase tracking-[0.12em] text-white/55"
+            class="px-2 py-3 text-center text-[0.7rem] font-bold tracking-[0.12em] text-white/55 uppercase"
           >
             Edad
           </th>
-          <td class="px-3 py-3 text-center tabular-nums text-theme-cream/85">
+          <td class="px-3 py-3 text-center text-theme-cream/85 tabular-nums">
             {age2 == null ? '—' : `${age2} años`}
           </td>
         </tr>
 
         <tr>
           <td class="px-3 py-3 text-theme-cream/85">
-            <span class="inline-flex items-center justify-center gap-2">
+            <span class="flex items-center justify-center gap-2">
               <CountryFlag country={boxer1.country} size={18} decorative />
               {COUNTRY_NAMES[boxer1.country] ?? boxer1.country}
             </span>
           </td>
           <th
             scope="row"
-            class="px-2 py-3 text-center text-[0.7rem] font-bold uppercase tracking-[0.12em] text-white/55"
+            class="px-2 py-3 text-center text-[0.7rem] font-bold tracking-[0.12em] text-white/55 uppercase"
           >
             País
           </th>
           <td class="px-3 py-3 text-theme-cream/85">
-            <span class="inline-flex items-center justify-center gap-2">
+            <span class="flex items-center justify-center gap-2">
               <CountryFlag country={boxer2.country} size={18} decorative />
               {COUNTRY_NAMES[boxer2.country] ?? boxer2.country}
             </span>
@@ -128,17 +127,29 @@ const valueClass = (won: boolean) =>
         {
           comparableRows.map((row) => (
             <tr>
-              <td class:list={['px-3 py-3 text-center tabular-nums', valueClass(row.left > row.right)]}>
+              <td
+                class:list={[
+                  'px-3 py-3 text-center tabular-nums',
+                  valueClass(row.left > row.right),
+                ]}
+              >
                 {row.left > 0 || row.label === 'Victorias en Veladas' ? row.format(row.left) : '—'}
               </td>
               <th
                 scope="row"
-                class="px-2 py-3 text-center text-[0.7rem] font-bold uppercase tracking-[0.12em] text-white/55"
+                class="px-2 py-3 text-center text-[0.7rem] font-bold tracking-[0.12em] text-white/55 uppercase"
               >
                 {row.label}
               </th>
-              <td class:list={['px-3 py-3 text-center tabular-nums', valueClass(row.right > row.left)]}>
-                {row.right > 0 || row.label === 'Victorias en Veladas' ? row.format(row.right) : '—'}
+              <td
+                class:list={[
+                  'px-3 py-3 text-center tabular-nums',
+                  valueClass(row.right > row.left),
+                ]}
+              >
+                {row.right > 0 || row.label === 'Victorias en Veladas'
+                  ? row.format(row.right)
+                  : '—'}
               </td>
             </tr>
           ))

--- a/src/consts/boxers.ts
+++ b/src/consts/boxers.ts
@@ -427,6 +427,22 @@ export function getBoxerPhoto(boxer: Boxer): string {
   return `/photos/${boxer.id}/01.webp`
 }
 
+/**
+ * Edad del boxeador. Usa el campo `age` mantenido a mano; si falta, la
+ * deriva de `birthDate`. Devuelve `null` si no hay ningún dato. Preferir
+ * el campo evita el desfase de recalcular en cada build.
+ */
+export function getBoxerAge(boxer: Boxer): number | null {
+  if (boxer.age != null) return boxer.age
+  if (!boxer.birthDate) return null
+  const birth = new Date(`${boxer.birthDate}T00:00:00`)
+  const now = new Date()
+  let age = now.getFullYear() - birth.getFullYear()
+  const monthDiff = now.getMonth() - birth.getMonth()
+  if (monthDiff < 0 || (monthDiff === 0 && now.getDate() < birth.getDate())) age--
+  return age
+}
+
 /** Mapa rápido para acceder a un boxer por su id. */
 export const BOXERS_BY_ID: Record<string, Boxer> = Object.fromEntries(
   BOXERS.map((boxer) => [boxer.id, boxer]),

--- a/src/lib/socials.ts
+++ b/src/lib/socials.ts
@@ -59,6 +59,31 @@ export function getSocialMetricLabel(social: BoxerSocial): string {
 }
 
 /**
+ * Suma total de seguidores del boxeador en todas sus redes. Solo cuenta
+ * `followers` (ignora los oyentes mensuales de Spotify), igual que el
+ * resto de la web. Es el "alcance combinado" del comparador.
+ */
+export function getTotalFollowers(boxer: Boxer): number {
+  return boxer.socials.reduce((sum, s) => sum + (s.followers ?? 0), 0)
+}
+
+/**
+ * Devuelve un mapa `plataforma → seguidores`, agregando las cuentas
+ * múltiples de una misma red (p. ej. dos canales de YouTube). Las redes
+ * sin seguidores se omiten. Solo cuenta `followers`, no oyentes mensuales.
+ */
+export function getFollowersByPlatform(boxer: Boxer): Record<string, number> {
+  const totals: Record<string, number> = {}
+  for (const social of boxer.socials) {
+    const followers = social.followers ?? 0
+    if (followers <= 0) continue
+    const key = social.platform.toLowerCase()
+    totals[key] = (totals[key] ?? 0) + followers
+  }
+  return totals
+}
+
+/**
  * Construye la URL pública del perfil del boxeador en la red social
  * indicada. Para YouTube y siempre que esté disponible, se prefiere el
  * id del canal del boxeador para no depender del handle.

--- a/src/pages/combate/[id].astro
+++ b/src/pages/combate/[id].astro
@@ -1,6 +1,7 @@
 ---
 import type { GetStaticPaths } from 'astro'
 
+import CombatStatsTable from '@/components/CombatStatsTable.astro'
 import CountryFlag from '@/components/CountryFlag.astro'
 import { battles, battlesById } from '@/consts/battles'
 import { EVENT_DATE_TIME } from '@/consts/event'
@@ -171,6 +172,8 @@ export const prerender = true
           </p>
         </article>
       </div>
+
+      <CombatStatsTable boxer1={boxer1} boxer2={boxer2} />
     </div>
   </section>
   <Sponsors />


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page.

## Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes # <!-- sin issue asociada -->

## Changes

Añade una tabla comparativa **"Cara a cara"** (estilo *tale of the tape*) en la página de cada combate individual, para enfrentar las estadísticas de los dos boxeadores de un vistazo.

- `src/components/CombatStatsTable.astro`: **nuevo componente**. Renderiza una tabla accesible que compara a los dos púgiles fila a fila:
  - **Edad** y **País** (con su bandera mediante `CountryFlag`).
  - **Total** de seguidores (alcance combinado) y desglose **por plataforma** (YouTube, Instagram, TikTok, Twitch, Kick, X, Spotify), en un orden fijo y mostrando solo las redes en las que al menos uno de los dos tiene seguidores.
  - **Victorias en Veladas** anteriores.
  - En cada fila numérica se **resalta en dorado** el valor más alto de los dos. Los datos ausentes se muestran como `—`.
  - Marcado semántico: `<caption>` para lectores de pantalla, `scope="col"`/`scope="row"` en las cabeceras y bandera decorativa para no duplicar texto.
- `src/consts/boxers.ts`: nueva función `getBoxerAge(boxer)`. Usa el campo `age` si existe y, si no, lo deriva de `birthDate`; devuelve `null` cuando no hay dato.
- `src/lib/socials.ts`: dos helpers nuevos:
  - `getTotalFollowers(boxer)`: suma total de seguidores en todas las redes (ignora oyentes mensuales de Spotify, igual que el resto de la web).
  - `getFollowersByPlatform(boxer)`: mapa `plataforma → seguidores`, agregando cuentas múltiples de una misma red (p. ej. dos canales de YouTube).
- `src/pages/combate/[id].astro`: integra `<CombatStatsTable />` en la página de combate, debajo de las tarjetas de los boxeadores.

## Dependencies

- Added: ninguna
- Removed: ninguna

## Screenshots

<img width="2668" height="1534" alt="desktop" src="https://github.com/user-attachments/assets/3b18beb6-40a3-42b2-b9f3-284b5d46a30b" />
<img width="770" height="1558" alt="mobile" src="https://github.com/user-attachments/assets/056193f8-69ff-4918-8976-721af08860bc" />


## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None. Solo se añade contenido nuevo; no se modifican props existentes ni APIs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de versión

* **Nuevas funcionalidades**
  * Añadida una tabla comparativa de cara a cara entre dos boxeadores que muestra edad, país, seguidores en redes sociales por plataforma y victorias en veladas. La tabla resalta visualmente quién posee mayores cifras en cada métrica.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->