### PR TITLE
feat(combate): fila de seguidores en la comparativa de la página de combate

### DIFF
--- a/src/components/combat/CombatStatsSection.astro
+++ b/src/components/combat/CombatStatsSection.astro
@@ -288,7 +288,7 @@ const hasFollowers = followersTotal > 0
     height: 6px;
     border-radius: 9999px;
     --bar-gold: var(--color-theme-gold);
-    --bar-blue: color-mix(in srgb, var(--color-theme-navy) 45%, #5e8bd8);
+    --bar-blue: #284f9e;
     --bar-left: var(--bar-gold);
     --bar-right: var(--bar-blue);
     background: linear-gradient(

--- a/src/components/combat/CombatStatsSection.astro
+++ b/src/components/combat/CombatStatsSection.astro
@@ -29,8 +29,12 @@ const sumFollowers = (boxer: Boxer) =>
 const followers1 = sumFollowers(boxer1)
 const followers2 = sumFollowers(boxer2)
 const followersTotal = followers1 + followers2
-// Reparto de la barra comparativa; 50/50 si no hay datos de ninguno.
+// Punto de corte de la barra: ancho del segmento izquierdo (boxer A). Es la
+// geometría real del reparto y no depende de quién lidere.
 const followersShareA = followersTotal > 0 ? (followers1 / followersTotal) * 100 : 50
+// Lado que se pinta en oro sólido = el de mayor alcance, igual que el realce del
+// número. La geometría (corte) no cambia; solo qué segmento va iluminado.
+const followersLeaderSide = followers1 >= followers2 ? 'a' : 'b'
 const hasFollowers = followersTotal > 0
 ---
 
@@ -133,6 +137,7 @@ const hasFollowers = followersTotal > 0
 
             <div
               class="followers-bar"
+              data-leader={followersLeaderSide}
               style={`--share-a: ${followersShareA}%`}
               aria-hidden="true"
             />
@@ -273,18 +278,29 @@ const hasFollowers = followersTotal > 0
     text-shadow: 0 0 20px color-mix(in srgb, var(--color-theme-gold) 32%, transparent);
   }
 
-  /* Barra proporcional (tale of the tape): oro para el líder por la izquierda,
-     oro atenuado para el rival por la derecha, con un corte limpio en el reparto. */
+  /* Barra proporcional (tale of the tape): el segmento del de mayor alcance va
+     en oro sólido y el del rival en oro atenuado, cada uno en su lado real. El
+     corte (--share-a) es la geometría del reparto y no depende de quién lidere;
+     solo se intercambia qué lado se ilumina (data-leader). */
   .followers-bar {
     grid-column: 1 / -1;
     height: 5px;
     border-radius: 9999px;
+    --bar-strong: var(--color-theme-gold);
+    --bar-weak: color-mix(in srgb, var(--color-theme-gold) 20%, transparent);
+    --bar-left: var(--bar-strong);
+    --bar-right: var(--bar-weak);
     background: linear-gradient(
       90deg,
-      var(--color-theme-gold) 0 var(--share-a),
-      color-mix(in srgb, var(--color-theme-gold) 20%, transparent) var(--share-a) 100%
+      var(--bar-left) 0 var(--share-a),
+      var(--bar-right) var(--share-a) 100%
     );
     box-shadow: inset 0 0 0 1px rgba(199, 168, 107, 0.18);
+  }
+
+  .followers-bar[data-leader='b'] {
+    --bar-left: var(--bar-weak);
+    --bar-right: var(--bar-strong);
   }
 
   .stats-cell {
@@ -330,11 +346,25 @@ const hasFollowers = followersTotal > 0
 
   @media (max-width: 639px) {
     .stats-row {
-      padding: 0.75rem 1rem;
+      padding: 0.75rem 0.85rem;
+      gap: 0.5rem;
+    }
+
+    /* En móvil el label central fijo a 7.25rem ahogaba las celdas laterales y el
+       país + bandera se salían de la tarjeta. Le damos menos ancho, dejamos que
+       las celdas encojan y reducimos el valor y la bandera para que el nombre
+       del país quepa en una sola línea (sin partir la palabra). */
+    .stats-label {
+      min-width: 5.25rem;
+    }
+
+    .stats-cell {
+      min-width: 0;
     }
 
     .stats-value {
-      font-size: 0.72rem;
+      font-size: 0.66rem;
+      letter-spacing: 0.02em;
     }
 
     .followers-value {
@@ -344,6 +374,11 @@ const hasFollowers = followersTotal > 0
     .boxer-avatar {
       width: 4rem;
       height: 4rem;
+    }
+
+    :global(.stats-flag) {
+      width: 15px !important;
+      height: 15px !important;
     }
   }
 

--- a/src/components/combat/CombatStatsSection.astro
+++ b/src/components/combat/CombatStatsSection.astro
@@ -2,6 +2,7 @@
 import CountryFlag from '@/components/CountryFlag.astro'
 import SectionDivider from '@/components/SectionDivider.astro'
 import type { Boxer, BoxerImageVariants } from '@/consts/boxers'
+import { formatFollowers, getSocialMetricValue } from '@/lib/socials'
 
 interface CombatStat {
   label: string
@@ -20,6 +21,17 @@ interface Props {
 }
 
 const { boxer1, boxer2, boxer1Select, boxer2Select, stats } = Astro.props
+
+// Seguidores totales sumando todas las redes (followers o oyentes/mes).
+const sumFollowers = (boxer: Boxer) =>
+  boxer.socials.reduce((total, social) => total + getSocialMetricValue(social), 0)
+
+const followers1 = sumFollowers(boxer1)
+const followers2 = sumFollowers(boxer2)
+const followersTotal = followers1 + followers2
+// Reparto de la barra comparativa; 50/50 si no hay datos de ninguno.
+const followersShareA = followersTotal > 0 ? (followers1 / followersTotal) * 100 : 50
+const hasFollowers = followersTotal > 0
 ---
 
 <section class="combat-section px-4 pt-16 pb-20 sm:px-6" aria-labelledby="features-title">
@@ -98,6 +110,35 @@ const { boxer1, boxer2, boxer1Select, boxer2Select, stats } = Astro.props
       role="table"
       aria-label={`Características: ${boxer1.name} vs ${boxer2.name}`}
     >
+      {
+        hasFollowers && (
+          <div class="stats-row stats-row-followers" role="row">
+            <div class="stats-cell cell-a" role="cell">
+              <span class="followers-value" data-leader={followers1 > followers2 ? 'true' : 'false'}>
+                {formatFollowers(followers1)}
+              </span>
+            </div>
+
+            <div class="stats-label" role="rowheader">
+              <span class="font-cinzel text-[0.6rem] font-bold tracking-[0.28em] text-theme-gold/85 uppercase">
+                Seguidores
+              </span>
+            </div>
+
+            <div class="stats-cell cell-b" role="cell">
+              <span class="followers-value" data-leader={followers2 > followers1 ? 'true' : 'false'}>
+                {formatFollowers(followers2)}
+              </span>
+            </div>
+
+            <div
+              class="followers-bar"
+              style={`--share-a: ${followersShareA}%`}
+              aria-hidden="true"
+            />
+          </div>
+        )
+      }
       {
         stats.map((stat, i) => (
           <div class:list={['stats-row', { 'stats-row-first': i === 0 }]} role="row">
@@ -201,6 +242,51 @@ const { boxer1, boxer2, boxer1Select, boxer2Select, stats } = Astro.props
     background: rgba(199, 168, 107, 0.04);
   }
 
+  /* Fila destacada de seguidores: el dato estrella de la comparativa. */
+  .stats-row-followers {
+    row-gap: 0.85rem;
+    padding-top: 1.1rem;
+    padding-bottom: 1.1rem;
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-theme-gold) 11%, transparent),
+      color-mix(in srgb, var(--color-theme-gold) 4%, transparent)
+    );
+  }
+
+  .followers-value {
+    font-family: var(--font-cinzel);
+    font-size: 1.65rem;
+    font-weight: 900;
+    line-height: 1;
+    letter-spacing: 0.01em;
+    font-variant-numeric: tabular-nums;
+    color: rgba(244, 228, 201, 0.92);
+    transition:
+      color 220ms ease,
+      text-shadow 220ms ease;
+  }
+
+  /* El de mayor alcance se ilumina en oro. */
+  .followers-value[data-leader='true'] {
+    color: var(--color-theme-gold);
+    text-shadow: 0 0 20px color-mix(in srgb, var(--color-theme-gold) 32%, transparent);
+  }
+
+  /* Barra proporcional (tale of the tape): oro para el líder por la izquierda,
+     oro atenuado para el rival por la derecha, con un corte limpio en el reparto. */
+  .followers-bar {
+    grid-column: 1 / -1;
+    height: 5px;
+    border-radius: 9999px;
+    background: linear-gradient(
+      90deg,
+      var(--color-theme-gold) 0 var(--share-a),
+      color-mix(in srgb, var(--color-theme-gold) 20%, transparent) var(--share-a) 100%
+    );
+    box-shadow: inset 0 0 0 1px rgba(199, 168, 107, 0.18);
+  }
+
   .stats-cell {
     display: flex;
     align-items: center;
@@ -251,9 +337,19 @@ const { boxer1, boxer2, boxer1Select, boxer2Select, stats } = Astro.props
       font-size: 0.72rem;
     }
 
+    .followers-value {
+      font-size: 1.3rem;
+    }
+
     .boxer-avatar {
       width: 4rem;
       height: 4rem;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .followers-value {
+      transition: none;
     }
   }
 </style>

--- a/src/components/combat/CombatStatsSection.astro
+++ b/src/components/combat/CombatStatsSection.astro
@@ -278,29 +278,30 @@ const hasFollowers = followersTotal > 0
     text-shadow: 0 0 20px color-mix(in srgb, var(--color-theme-gold) 32%, transparent);
   }
 
-  /* Barra proporcional (tale of the tape): el segmento del de mayor alcance va
-     en oro sólido y el del rival en oro atenuado, cada uno en su lado real. El
-     corte (--share-a) es la geometría del reparto y no depende de quién lidere;
-     solo se intercambia qué lado se ilumina (data-leader). */
+  /* Barra comparativa (tale of the tape): dos colores en vez de uno para que se
+     lea como enfrentamiento y no como barra de progreso. Oro para el de mayor
+     alcance, azul (familia navy de marca, aclarado para contrastar sobre el
+     fondo oscuro) para el rival. El corte (--share-a) es la geometría real del
+     reparto; solo se intercambia qué lado va en oro según el líder. */
   .followers-bar {
     grid-column: 1 / -1;
-    height: 5px;
+    height: 6px;
     border-radius: 9999px;
-    --bar-strong: var(--color-theme-gold);
-    --bar-weak: color-mix(in srgb, var(--color-theme-gold) 20%, transparent);
-    --bar-left: var(--bar-strong);
-    --bar-right: var(--bar-weak);
+    --bar-gold: var(--color-theme-gold);
+    --bar-blue: color-mix(in srgb, var(--color-theme-navy) 45%, #5e8bd8);
+    --bar-left: var(--bar-gold);
+    --bar-right: var(--bar-blue);
     background: linear-gradient(
       90deg,
       var(--bar-left) 0 var(--share-a),
       var(--bar-right) var(--share-a) 100%
     );
-    box-shadow: inset 0 0 0 1px rgba(199, 168, 107, 0.18);
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.08);
   }
 
   .followers-bar[data-leader='b'] {
-    --bar-left: var(--bar-weak);
-    --bar-right: var(--bar-strong);
+    --bar-left: var(--bar-blue);
+    --bar-right: var(--bar-gold);
   }
 
   .stats-cell {


### PR DESCRIPTION
## Qué

Añade el **alcance total** de cada boxeador (suma de seguidores de todas sus redes) como una fila destacada en la tabla de características de la página de combate (`/combate/[id]`), introducida en #1593.

Viene de la idea propuesta en #1599 (cerrada en favor del rediseño #1593). Lo he adaptado a la maquetación actual de `CombatStatsSection` en lugar del diseño antiguo.

## Cómo

- Reutiliza los helpers que ya existen en `@/lib/socials`: `formatFollowers` y `getSocialMetricValue` (que ya contempla `followers` y `monthlyListeners`).
- El total se calcula **dentro de `CombatStatsSection`** —que ya recibe `boxer1` y `boxer2`— así que **no toca `[id].astro`** ni la firma de props.
- Si ningún boxeador tiene datos de seguidores, la fila simplemente no se renderiza.

```astro
const sumFollowers = (boxer: Boxer) =>
  boxer.socials.reduce((total, social) => total + getSocialMetricValue(social), 0)
```

## Diseño

En la misma línea visual de la tabla (Cinzel, oro de marca, su mismo grid `1fr auto 1fr`), pero tratada como el dato estrella:

- Número grande por boxeador, con **el de mayor alcance iluminado en oro**.
- Una **barra proporcional ‘tale of the tape’** bajo los valores: oro para el líder por la izquierda, oro atenuado para el rival por la derecha, con el corte en el reparto real.
- Respeta `prefers-reduced-motion` y es accesible (la barra es decorativa con `aria-hidden`; los números son texto real bajo el `rowheader` "Seguidores").

Ejemplo (illojuan vs thegrefg): **1,4M** — **9,1M**, barra 19% / 81%.

## Capturas

<img width="1250" height="685" alt="image" src="https://github.com/user-attachments/assets/44c69834-78c2-4b8c-b11e-922b9e8027c0" />

<img width="379" height="672" alt="image" src="https://github.com/user-attachments/assets/8a7a2927-52d0-47f8-8afb-f180072bfb22" />

## Test plan

- [x] `pnpm build` pasa.
- [x] Render verificado en `/combate/[id]` (números, realce del líder y reparto de la barra correctos).
- [X] Revisar en móvil (el número baja a 1,3rem) y en un combate con seguidores parejos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit — Release Notes

* **Nuevas características**
  * Se agregó una fila “Seguidores” en la tabla de estadísticas de boxeadores, con el total por participante.
  * Se incorporó una barra comparativa para visualizar la proporción de seguidores entre boxeadores.

* **Mejoras de estilo y accesibilidad**
  * Se resalta al boxeador líder en la fila de seguidores y se optimizó su presentación para móviles.
  * Se desactivó la transición de la visualización de seguidores cuando está activado “reducir movimiento”.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->