### PR TITLE
fix: centra y anima el título y subtítulo de la página de boxeadores

### DIFF
--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -764,7 +764,8 @@ const cardImageEagerAmount = 4
       gap: 2rem;
     }
 
-    /* Título en la misma columna que el grid (f4e0c631: justify-self center, no stretch). */
+    /* Cabecera a todo el ancho: título y subtítulo centrados respecto a la
+       página completa (no solo sobre la columna del grid). */
     .boxers-page-header {
       display: grid;
       grid-template-columns: var(--boxers-sidebar-width) minmax(0, 1fr);
@@ -774,7 +775,7 @@ const cardImageEagerAmount = 4
     }
 
     .boxers-page-header > * {
-      grid-column: 2;
+      grid-column: 1 / -1;
       justify-self: center;
     }
 

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -147,7 +147,7 @@ const cardImageEagerAmount = 4
 
       <form
         data-boxers-filters
-        class="boxer-filters-panel relative w-full not-motion-reduce:animate-fade-in-up not-motion-reduce:animate-delay-300"
+        class="boxer-filters-panel relative w-full animate-fade-in-up animate-delay-300"
         aria-label="Filtros de boxeadores"
         onsubmit="return false"
       >
@@ -268,7 +268,7 @@ const cardImageEagerAmount = 4
       <div class="boxers-results w-full">
         <div
           data-boxers-sort
-          class="boxer-sort-bar relative not-motion-reduce:animate-fade-in-up not-motion-reduce:animate-delay-300"
+          class="boxer-sort-bar relative animate-fade-in-up animate-delay-300"
           role="region"
           aria-label="Ordenar boxeadores"
         >
@@ -723,7 +723,9 @@ const cardImageEagerAmount = 4
 
   @media (prefers-reduced-motion: reduce) {
     .boxers-page-title,
-    .boxers-page-lead {
+    .boxers-page-lead,
+    .boxer-filters-panel,
+    .boxer-sort-bar {
       animation: none;
     }
 

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -132,14 +132,14 @@ const cardImageEagerAmount = 4
     <div class="boxers-layout mx-auto w-full max-w-7xl">
       <header class="boxers-page-header">
         <h1
-          class="boxers-page-title mb-3 font-cinzel text-3xl font-black tracking-[0.12em] text-theme-cream not-motion-reduce:animate-fade-in-up sm:text-4xl sm:tracking-[0.16em] md:text-6xl"
+          class="boxers-page-title mb-3 animate-fade-in-up font-cinzel text-3xl font-black tracking-[0.12em] text-theme-cream sm:text-4xl sm:tracking-[0.16em] md:text-6xl"
         >
           <SectionDivider class="boxers-page-header-ornament mb-8 w-full sm:mb-12" />
 
           BOXEADORES
         </h1>
         <p
-          class="boxers-page-lead mb-8 font-cinzel text-xs font-medium tracking-[0.14em] text-balance text-white/55 animate-delay-200 not-motion-reduce:animate-fade-in-up sm:mb-12 sm:text-sm"
+          class="boxers-page-lead mb-8 animate-fade-in-up font-cinzel text-xs font-medium tracking-[0.14em] text-balance text-white/55 animate-delay-200 sm:mb-12 sm:text-sm"
         >
           Los {totalBoxers} contendientes de La Velada del Año VI
         </p>
@@ -722,6 +722,11 @@ const cardImageEagerAmount = 4
   }
 
   @media (prefers-reduced-motion: reduce) {
+    .boxers-page-title,
+    .boxers-page-lead {
+      animation: none;
+    }
+
     .boxer-card,
     .boxer-card-img,
     .boxer-card-bg-gold,


### PR DESCRIPTION
## Type

- [x] fix

## Related Issue

Closes #

## Changes

Mejoras de la cabecera de la página de **Boxeadores** (`/boxeadores`):

- `src/pages/boxeadores.astro`:
  - **Centrado en escritorio**: el título, subtítulo y divisor se centraban solo sobre la columna del grid (por el sidebar de filtros); ahora se centran respecto al ancho completo de la página (`grid-column: 1 / -1`).
  - **Animación de entrada**: el título y subtítulo usaban `not-motion-reduce:animate-fade-in-up`, una variante que no compila a una regla válida aquí, así que no animaban. Se cambia a `animate-fade-in-up` (clase plana, igual que `/combates`) con guardia de `prefers-reduced-motion`.

## Dependencies

- Added: None
- Removed: None

## Screenshots

> Pendiente de añadir capturas before/after (escritorio).

| View | Before | After |
|------|--------|-------|
| Mobile |<img width="2160" height="840" alt="boxeadores-before" src="https://github.com/user-attachments/assets/801904ee-0324-4d2e-8bec-acc37ba08142" />|<img width="2160" height="840" alt="boxeadores-after" src="https://github.com/user-attachments/assets/7c26a628-bd8a-4fa8-9abe-c5a0f07c2ff4" />|

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **Style**
  * Animaciones de entrada mejoradas en la página de boxeadores para encabezado y controles.
  * Ajuste del layout del encabezado para mejor alineación visual.

* **Accesibilidad**
  * Mejor respeto a las preferencias de movimiento reducido del sistema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->