### PR TITLE
feat: rediseña la barra de filtros de boxeadores

### DIFF
--- a/src/components/BoxersFilterBar.astro
+++ b/src/components/BoxersFilterBar.astro
@@ -224,10 +224,14 @@ function getVeladaFlagTheme(country: string) {
   .boxer-filters-panel {
     /* `min-width: 0` evita que el contenido del panel (sobre todo las
        pills) expanda al panel y, en cascada, al layout y al body. */
+    box-sizing: border-box;
+    inline-size: 100%;
+    width: 100%;
+    max-width: 100%;
+    justify-self: center;
     min-width: 0;
     z-index: 20;
     overflow: visible;
-    width: 100%;
     background:
       radial-gradient(
         ellipse 80% 100% at 50% 0%,
@@ -245,66 +249,28 @@ function getVeladaFlagTheme(country: string) {
       0 0 60px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
   }
 
-  @media (max-width: 639px) {
-    .boxer-filters-panel {
-      box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent),
-        0 16px 36px rgba(0, 0, 0, 0.38),
-        0 0 40px color-mix(in srgb, var(--color-theme-gold) 9%, transparent);
-    }
-  }
-
   .boxer-filters-body {
     --boxer-filter-control-height: 2.15rem;
-    --boxer-filter-control-font-size: 0.68rem;
-    --boxer-filter-control-letter-spacing: 0.1em;
+    --boxer-filter-control-font-size: clamp(0.4rem, 0.25rem + 0.65vi, 0.68rem);
+    --boxer-filter-control-letter-spacing: clamp(0em, 0.06vi, 0.1em);
     --boxer-filter-label-height: 0.7rem;
-    --boxer-filter-label-gap: 0.5rem;
+    --boxer-filter-label-gap: clamp(0.42rem, 0.34rem + 0.22vw, 0.5rem);
     --boxer-filter-radius: 2px;
     --boxer-filter-inner-radius: 1px;
+    --boxer-filter-column-min: min(100%, 18rem);
+    --boxer-filter-panel-gap: clamp(0.85rem, 0.52rem + 1.1vw, 1.6rem);
+    --boxer-filter-panel-padding-block: clamp(0.8rem, 0.7rem + 0.35vw, 1rem);
+    --boxer-filter-panel-padding-inline: clamp(0.7rem, 0.48rem + 0.75vw, 1.35rem);
+    --boxer-filter-pill-gap: clamp(0.14rem, 0.55vw, 0.55rem);
+    --boxer-filter-pill-padding-block: clamp(0.35rem, 0.32rem + 0.15vw, 0.42rem);
+    --boxer-filter-pill-padding-inline: clamp(0.14rem, 0.7vi, 0.9rem);
+    --segment-gap: clamp(0.1rem, 0.7vi, 1rem);
     min-width: 0;
     display: grid;
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.4rem;
+    grid-template-columns: repeat(auto-fit, minmax(var(--boxer-filter-column-min), 1fr));
+    gap: var(--boxer-filter-panel-gap);
     overflow: visible;
-    padding: 1rem;
-  }
-  @media (max-width: 639px) {
-    .boxer-filters-body {
-      gap: 0.9rem;
-      padding: 0.8rem 0.7rem;
-    }
-  }
-  @media (min-width: 640px) {
-    .boxer-filters-body {
-      padding: 1.05rem 1rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .boxer-filters-body {
-      grid-template-columns: minmax(17rem, 1fr) minmax(28rem, 1.55fr) minmax(17rem, 1fr);
-      align-items: start;
-      justify-content: stretch;
-      column-gap: 1.5rem;
-      row-gap: 1rem;
-      padding: 0.8rem 1.25rem;
-    }
-  }
-
-  @media (min-width: 1280px) {
-    .boxer-filters-body {
-      grid-template-columns: minmax(20rem, 1fr) minmax(30rem, 1.55fr) minmax(20rem, 1fr);
-      column-gap: 1.6rem;
-      padding: 0.85rem 1.35rem;
-    }
-  }
-
-  @media (min-width: 1440px) {
-    .boxer-filters-body {
-      grid-template-columns: minmax(22rem, 1fr) minmax(34rem, 1.55fr) minmax(22rem, 1fr);
-      column-gap: 1.75rem;
-    }
+    padding: var(--boxer-filter-panel-padding-block) var(--boxer-filter-panel-padding-inline);
   }
 
   .boxer-filter-row {
@@ -317,32 +283,7 @@ function getVeladaFlagTheme(country: string) {
     align-items: start;
     border: 0;
     margin: 0;
-    padding: 0.3rem 0;
-  }
-
-  @media (min-width: 1024px) {
-    .boxer-filter-row {
-      position: relative;
-      min-height: 100%;
-      padding: 0;
-    }
-
-    .boxer-filter-row:not(:first-child)::before {
-      content: '';
-      position: absolute;
-      top: 0.05rem;
-      bottom: 0.05rem;
-      left: -0.75rem;
-      width: 1px;
-      background: color-mix(in srgb, var(--color-theme-gold) 16%, transparent);
-      pointer-events: none;
-    }
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-row {
-      padding: 0.15rem 0;
-    }
+    padding: 0;
   }
 
   .boxer-filter-row-label {
@@ -351,9 +292,9 @@ function getVeladaFlagTheme(country: string) {
     min-width: 0;
     height: var(--boxer-filter-label-height);
     gap: 0.45rem;
-    font-size: 0.6rem;
+    font-size: clamp(0.55rem, 0.49rem + 0.18vw, 0.6rem);
     font-weight: 900;
-    letter-spacing: 0.26em;
+    letter-spacing: clamp(0.18em, 0.08em + 0.22vw, 0.26em);
     line-height: 1;
     margin: 0;
     text-transform: uppercase;
@@ -363,16 +304,8 @@ function getVeladaFlagTheme(country: string) {
       0 0 16px color-mix(in srgb, var(--color-theme-gold) 25%, transparent);
   }
 
-  @media (max-width: 639px) {
-    .boxer-filter-row-label {
-      font-size: 0.55rem;
-      letter-spacing: 0.18em;
-    }
-  }
-
   .boxer-segmented {
     --segment-count: 3;
-    --segment-gap: 0.8rem;
     --segment-x: 0px;
     position: relative;
     overflow: hidden;
@@ -416,24 +349,6 @@ function getVeladaFlagTheme(country: string) {
     --segment-x: calc(200% + var(--segment-gap) + var(--segment-gap));
   }
 
-  @media (min-width: 640px) {
-    .boxer-segmented {
-      --segment-gap: 0.85rem;
-    }
-  }
-
-  @media (min-width: 1280px) {
-    .boxer-segmented {
-      --segment-gap: 1rem;
-    }
-  }
-
-  @media (max-width: 639px) {
-    .boxer-segmented {
-      --segment-gap: 0.3rem;
-    }
-  }
-
   .boxer-country-select-shell {
     position: relative;
     display: block;
@@ -455,7 +370,8 @@ function getVeladaFlagTheme(country: string) {
     appearance: none;
     position: relative;
     display: grid;
-    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    grid-template-columns: auto auto auto auto;
+    justify-content: start;
     align-items: center;
     gap: 0.55rem;
     width: 100%;
@@ -544,15 +460,15 @@ function getVeladaFlagTheme(country: string) {
     position: relative;
     display: inline-flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.42rem 0.85rem;
+    gap: var(--boxer-filter-pill-gap);
+    padding: var(--boxer-filter-pill-padding-block) var(--boxer-filter-pill-padding-inline);
     border-radius: var(--boxer-filter-inner-radius);
     background: color-mix(in srgb, var(--color-theme-midnight) 78%, black);
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
     color: color-mix(in srgb, var(--color-theme-cream) 86%, transparent);
-    font-size: 0.6rem;
+    font-size: var(--boxer-filter-control-font-size);
     font-weight: 900;
-    letter-spacing: 0.18em;
+    letter-spacing: var(--boxer-filter-control-letter-spacing);
     line-height: 1;
     cursor: pointer;
     transition:
@@ -560,44 +476,6 @@ function getVeladaFlagTheme(country: string) {
       box-shadow 250ms ease,
       background-color 250ms ease,
       color 250ms ease;
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-pill {
-      gap: 0.3rem;
-      padding: 0.38rem 0.55rem;
-      font-size: 0.52rem;
-      letter-spacing: 0.1em;
-    }
-
-    .boxer-segmented {
-      width: 100%;
-    }
-
-    .boxer-segmented-option {
-      padding-inline: 0.35rem;
-    }
-
-    .boxer-segmented-option .boxer-filter-pill-label {
-      font-size: 0.48rem;
-      letter-spacing: 0;
-    }
-  }
-
-  @media (min-width: 640px) {
-    .boxer-filter-pill {
-      font-size: 0.68rem;
-      padding: 0.5rem 1rem;
-    }
-  }
-
-  @media (min-width: 1024px) {
-    .boxer-filters-body .boxer-filter-pill {
-      gap: 0.55rem;
-      padding: 0.35rem 0.85rem;
-      font-size: var(--boxer-filter-control-font-size);
-      letter-spacing: var(--boxer-filter-control-letter-spacing);
-    }
   }
 
   .boxer-filter-pill::before {
@@ -659,12 +537,19 @@ function getVeladaFlagTheme(country: string) {
     min-width: 0;
     justify-content: center;
     min-height: calc(var(--boxer-filter-control-height) - 0.3rem);
-    gap: 0.65rem;
+    gap: var(--boxer-filter-pill-gap);
     border-radius: var(--boxer-filter-inner-radius);
     box-shadow: none;
     background: transparent;
     letter-spacing: 0.02em;
-    padding: 0.32rem 0.9rem;
+    padding: 0.32rem clamp(0.12rem, 0.62vw, 0.9rem);
+    white-space: nowrap;
+  }
+
+  .boxer-segmented-option .boxer-filter-pill-label {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: clip;
     white-space: nowrap;
   }
 
@@ -687,8 +572,8 @@ function getVeladaFlagTheme(country: string) {
   }
 
   .boxer-segmented-icon {
-    width: 1rem;
-    height: 1rem;
+    width: clamp(0.62rem, 2vw, 1rem);
+    height: clamp(0.62rem, 2vw, 1rem);
     flex: 0 0 auto;
     stroke: currentColor;
     stroke-width: 2.35;
@@ -783,15 +668,15 @@ function getVeladaFlagTheme(country: string) {
 
   .boxer-filter-pill-count {
     display: inline-flex;
-    min-width: 1.25rem;
+    min-width: clamp(0.7rem, 2.4vw, 1.25rem);
     align-items: center;
     justify-content: center;
     overflow: hidden;
-    padding: 0.18rem 0.35rem;
+    padding: clamp(0.08rem, 0.3vw, 0.18rem) clamp(0.14rem, 0.7vw, 0.35rem);
     border-radius: var(--boxer-filter-inner-radius);
     background: color-mix(in srgb, var(--color-theme-midnight) 60%, transparent);
     color: color-mix(in srgb, var(--color-theme-cream) 75%, transparent);
-    font-size: 0.55rem;
+    font-size: clamp(0.38rem, 1.15vw, 0.55rem);
     font-weight: 900;
     letter-spacing: 0.04em;
     font-variant-numeric: tabular-nums;
@@ -804,14 +689,6 @@ function getVeladaFlagTheme(country: string) {
   .boxer-filter-pill-count-value {
     display: inline-block;
     line-height: 1;
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-pill-count {
-      min-width: 0.95rem;
-      padding: 0.12rem 0.24rem;
-      font-size: 0.48rem;
-    }
   }
 
   .boxer-filter-pill-count.is-bumping {

--- a/src/components/BoxersFilterBar.astro
+++ b/src/components/BoxersFilterBar.astro
@@ -1,0 +1,856 @@
+---
+import {
+  ArrowDownUp as SortDefaultIcon,
+  ArrowDownWideNarrow as SortDescIcon,
+  ArrowUpWideNarrow as SortAscIcon,
+  ChevronDown as ChevronDownIcon,
+  Mars as MaleIcon,
+  Venus as FemaleIcon,
+} from '@lucide/astro'
+import type { BoxerGender } from '@/consts/boxers'
+
+type CountryFilter = { code: string; name: string; count: number }
+type GenderFilter = { code: BoxerGender; name: string; count: number }
+type VeladaFlagTheme =
+  | { kind: 'stripe'; emblem?: string; stripes: string[] }
+  | { kind: 'triangle'; emblem?: string; field: string; stripes: string[]; triangle: string }
+
+interface Props {
+  countryFilters: CountryFilter[]
+  genderFilters: GenderFilter[]
+  totalBoxers: number
+}
+
+const { countryFilters, genderFilters, totalBoxers } = Astro.props
+const countryDisplayOptions = [{ code: '', count: totalBoxers, name: 'Todos' }, ...countryFilters]
+
+const GenderIconByCode = {
+  f: FemaleIcon,
+  m: MaleIcon,
+} satisfies Record<BoxerGender, typeof FemaleIcon>
+
+const veladaFlagThemes: Record<string, VeladaFlagTheme> = {
+  all: { kind: 'stripe', emblem: '#080d24', stripes: ['#d7b35d', '#f5e2ad', '#d7b35d'] },
+  ar: { kind: 'stripe', emblem: '#d7a83f', stripes: ['#6fb5df', '#f7f2dd', '#6fb5df'] },
+  co: { kind: 'stripe', stripes: ['#e9c348', '#284e9d', '#b52f32'] },
+  es: { kind: 'stripe', stripes: ['#a9252b', '#d9ae47', '#a9252b'] },
+  mx: { kind: 'stripe', emblem: '#c79d3d', stripes: ['#236c48', '#f4ead2', '#9f252b'] },
+  pr: {
+    kind: 'triangle',
+    emblem: '#f6d778',
+    field: '#f5efe0',
+    stripes: ['#b8202d', '#f7f0df', '#b8202d', '#f7f0df', '#b8202d'],
+    triangle: '#234f92',
+  },
+  sv: { kind: 'stripe', emblem: '#d7a83f', stripes: ['#2757a4', '#f4eedc', '#2757a4'] },
+}
+
+function getVeladaFlagTheme(country: string) {
+  return veladaFlagThemes[country || 'all'] ?? veladaFlagThemes.all
+}
+---
+
+<form
+  data-boxers-filters
+  class="boxer-filters-panel relative w-full not-motion-reduce:animate-fade-in-up not-motion-reduce:animate-delay-300"
+  aria-label="Filtros de boxeadores"
+  onsubmit="return false"
+>
+  <div class="boxer-filters-body relative flex flex-col">
+    <div class="boxer-filter-row" data-filter-row="country">
+      <div class="boxer-filter-row-label">País</div>
+      <div class="boxer-country-select-shell" data-country-dropdown>
+        <select
+          data-country-select
+          class="boxer-country-native-select"
+          aria-label="Filtrar por país"
+        >
+          <option value="" data-label="Todos">Todos · {totalBoxers}</option>
+          {
+            countryFilters.map(({ code, name, count }) => (
+              <option value={code} data-label={name}>
+                {name} · {count}
+              </option>
+            ))
+          }
+        </select>
+        <div class="boxer-country-select" aria-hidden="true">
+          <span class="boxer-country-selected-flags" aria-hidden="true">
+            {
+              countryDisplayOptions.map(({ code }) => {
+                const flag = getVeladaFlagTheme(code)
+                const stripeHeight = flag.kind === 'stripe' ? 18 / flag.stripes.length : 0
+                const bandHeight = flag.kind === 'triangle' ? 18 / flag.stripes.length : 0
+
+                return (
+                  <span
+                    data-country-selected-flag={code}
+                    class="boxer-country-selected-flag"
+                    hidden={code !== ''}
+                  >
+                    <svg viewBox="0 0 32 24" class="boxer-country-flag-svg">
+                      <rect x="1" y="1" width="30" height="22" rx="1.5" fill="#080d24" />
+                      {flag.kind === 'stripe' ? (
+                        flag.stripes.map((color, index) => (
+                          <rect
+                            x="4"
+                            y={3 + index * stripeHeight}
+                            width="24"
+                            height={stripeHeight}
+                            fill={color}
+                          />
+                        ))
+                      ) : (
+                        <>
+                          <rect x="4" y="3" width="24" height="18" fill={flag.field} />
+                          {flag.stripes.map((color, index) => (
+                            <rect
+                              x="4"
+                              y={3 + index * bandHeight}
+                              width="24"
+                              height={bandHeight}
+                              fill={color}
+                            />
+                          ))}
+                          <path d="M4 3 17 12 4 21Z" fill={flag.triangle} />
+                        </>
+                      )}
+                      {flag.emblem && <circle cx="16" cy="12" r="2.1" fill={flag.emblem} />}
+                    </svg>
+                  </span>
+                )
+              })
+            }
+          </span>
+          <span data-country-selected-label class="boxer-country-selected-label">Todos</span>
+          <span
+            data-country-count
+            class="boxer-filter-pill-count boxer-country-select-count"
+            aria-hidden="true"
+          >
+            {totalBoxers}
+          </span>
+          <ChevronDownIcon class="boxer-country-select-arrow" aria-hidden="true" />
+        </div>
+      </div>
+    </div>
+
+    <div class="boxer-filter-row" data-filter-row="gender">
+      <div class="boxer-filter-row-label">Género</div>
+      <div
+        data-gender-segmented
+        data-active="all"
+        class="boxer-segmented"
+        role="group"
+        aria-label="Filtrar por género"
+      >
+        <button
+          type="button"
+          data-filter="gender"
+          data-value=""
+          aria-pressed="true"
+          aria-label="Mostrar todos los géneros"
+          class="boxer-filter-pill boxer-segmented-option boxer-filter-pill-all"
+        >
+          <svg viewBox="0 0 24 24" class="boxer-segmented-icon" aria-hidden="true" fill="none">
+            <path
+              d="M8.5 13.4C6 12.6 4.5 10.5 4.5 8.1C4.5 4.7 7.2 2 10.8 2H12.1C16 2 19 5 19 8.8V12C19 13.7 17.7 15 16 15H14.8"
+            ></path>
+            <path d="M8.4 13.2V17.3C8.4 18.8 9.6 20 11.1 20H15.2C16.7 20 17.9 18.8 17.9 17.3V15"
+            ></path>
+            <path d="M9.7 6.2V10.4"></path>
+            <path d="M13 5.7V10.4"></path>
+            <path d="M16.2 7.1V10.4"></path>
+            <path d="M8.4 17H17.8"></path>
+          </svg>
+          <span class="boxer-filter-pill-label">Todos</span>
+          <span class="boxer-filter-pill-count" aria-hidden="true">{totalBoxers}</span>
+        </button>
+        {
+          genderFilters.map(({ code, name, count }) => {
+            const GenderIcon = GenderIconByCode[code]
+
+            return (
+              <button
+                type="button"
+                data-filter="gender"
+                data-value={code}
+                aria-pressed="false"
+                aria-label={`Filtrar por género ${name}`}
+                class="boxer-filter-pill boxer-segmented-option"
+              >
+                <GenderIcon class="boxer-segmented-icon" aria-hidden="true" />
+                <span class="boxer-filter-pill-label">{name}</span>
+                <span class="boxer-filter-pill-count" aria-hidden="true">
+                  {count}
+                </span>
+              </button>
+            )
+          })
+        }
+      </div>
+    </div>
+
+    <div
+      data-boxers-sort
+      class="boxer-filter-row boxer-sort-row"
+      role="region"
+      aria-label="Ordenar boxeadores"
+    >
+      <div class="boxer-filter-row-label">
+        <span>Ordenar por</span>
+      </div>
+
+      <button
+        type="button"
+        data-sort-cycle
+        data-sort="cartel"
+        class="boxer-sort-cycle"
+        aria-label="Ordenar por cartelera. Pulsa para cambiar el orden."
+      >
+        <span class="boxer-sort-cycle-icon" aria-hidden="true">
+          <SortDefaultIcon class="boxer-sort-icon boxer-sort-icon-default" />
+          <SortDescIcon class="boxer-sort-icon boxer-sort-icon-desc" />
+          <SortAscIcon class="boxer-sort-icon boxer-sort-icon-asc" />
+        </span>
+        <span data-sort-cycle-label class="boxer-sort-cycle-label">Cartelera</span>
+      </button>
+    </div>
+  </div>
+</form>
+
+<style>
+  /* ---------- Filtros (command panel) ---------- */
+  .boxer-filters-panel {
+    /* `min-width: 0` evita que el contenido del panel (sobre todo las
+       pills) expanda al panel y, en cascada, al layout y al body. */
+    min-width: 0;
+    z-index: 20;
+    overflow: visible;
+    width: 100%;
+    background:
+      radial-gradient(
+        ellipse 80% 100% at 50% 0%,
+        color-mix(in srgb, var(--color-theme-gold) 10%, transparent) 0%,
+        transparent 70%
+      ),
+      linear-gradient(
+        180deg,
+        color-mix(in srgb, var(--color-velada-navy) 35%, var(--color-theme-midnight)) 0%,
+        color-mix(in srgb, var(--color-theme-midnight) 92%, black) 100%
+      );
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 26%, transparent),
+      0 24px 60px rgba(0, 0, 0, 0.45),
+      0 0 60px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
+  }
+
+  @media (max-width: 639px) {
+    .boxer-filters-panel {
+      box-shadow:
+        inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent),
+        0 16px 36px rgba(0, 0, 0, 0.38),
+        0 0 40px color-mix(in srgb, var(--color-theme-gold) 9%, transparent);
+    }
+  }
+
+  .boxer-filters-body {
+    --boxer-filter-control-height: 2.15rem;
+    --boxer-filter-control-font-size: 0.68rem;
+    --boxer-filter-control-letter-spacing: 0.1em;
+    --boxer-filter-label-height: 0.7rem;
+    --boxer-filter-label-gap: 0.5rem;
+    --boxer-filter-radius: 2px;
+    --boxer-filter-inner-radius: 1px;
+    min-width: 0;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 1.4rem;
+    overflow: visible;
+    padding: 1rem;
+  }
+  @media (max-width: 639px) {
+    .boxer-filters-body {
+      gap: 0.9rem;
+      padding: 0.8rem 0.7rem;
+    }
+  }
+  @media (min-width: 640px) {
+    .boxer-filters-body {
+      padding: 1.05rem 1rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .boxer-filters-body {
+      grid-template-columns: minmax(17rem, 1fr) minmax(28rem, 1.55fr) minmax(17rem, 1fr);
+      align-items: start;
+      justify-content: stretch;
+      column-gap: 1.5rem;
+      row-gap: 1rem;
+      padding: 0.8rem 1.25rem;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .boxer-filters-body {
+      grid-template-columns: minmax(20rem, 1fr) minmax(30rem, 1.55fr) minmax(20rem, 1fr);
+      column-gap: 1.6rem;
+      padding: 0.85rem 1.35rem;
+    }
+  }
+
+  @media (min-width: 1440px) {
+    .boxer-filters-body {
+      grid-template-columns: minmax(22rem, 1fr) minmax(34rem, 1.55fr) minmax(22rem, 1fr);
+      column-gap: 1.75rem;
+    }
+  }
+
+  .boxer-filter-row {
+    min-width: 0;
+    min-inline-size: 0;
+    display: grid;
+    grid-template-rows: var(--boxer-filter-label-height) auto;
+    row-gap: var(--boxer-filter-label-gap);
+    align-content: start;
+    align-items: start;
+    border: 0;
+    margin: 0;
+    padding: 0.3rem 0;
+  }
+
+  @media (min-width: 1024px) {
+    .boxer-filter-row {
+      position: relative;
+      min-height: 100%;
+      padding: 0;
+    }
+
+    .boxer-filter-row:not(:first-child)::before {
+      content: '';
+      position: absolute;
+      top: 0.05rem;
+      bottom: 0.05rem;
+      left: -0.75rem;
+      width: 1px;
+      background: color-mix(in srgb, var(--color-theme-gold) 16%, transparent);
+      pointer-events: none;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .boxer-filter-row {
+      padding: 0.15rem 0;
+    }
+  }
+
+  .boxer-filter-row-label {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    height: var(--boxer-filter-label-height);
+    gap: 0.45rem;
+    font-size: 0.6rem;
+    font-weight: 900;
+    letter-spacing: 0.26em;
+    line-height: 1;
+    margin: 0;
+    text-transform: uppercase;
+    color: color-mix(in srgb, var(--color-theme-gold) 90%, var(--color-theme-cream));
+    text-shadow:
+      0 1px 0 rgba(0, 0, 0, 0.6),
+      0 0 16px color-mix(in srgb, var(--color-theme-gold) 25%, transparent);
+  }
+
+  @media (max-width: 639px) {
+    .boxer-filter-row-label {
+      font-size: 0.55rem;
+      letter-spacing: 0.18em;
+    }
+  }
+
+  .boxer-segmented {
+    --segment-count: 3;
+    --segment-gap: 0.8rem;
+    --segment-x: 0px;
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: repeat(var(--segment-count), minmax(0, 1fr));
+    gap: var(--segment-gap);
+    width: 100%;
+    min-height: var(--boxer-filter-control-height);
+    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 26%, transparent);
+    border-radius: var(--boxer-filter-radius);
+    padding: 0.15rem;
+    background: color-mix(in srgb, var(--color-theme-midnight) 82%, black);
+  }
+
+  .boxer-segmented::before {
+    content: '';
+    position: absolute;
+    z-index: 0;
+    top: 0.15rem;
+    bottom: 0.15rem;
+    left: 0.15rem;
+    width: calc((100% - 0.3rem - var(--segment-gap) - var(--segment-gap)) / var(--segment-count));
+    border-radius: var(--boxer-filter-inner-radius);
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-theme-gold) 96%, white) 0%,
+      var(--color-theme-gold) 62%,
+      color-mix(in srgb, var(--color-theme-gold) 76%, black) 100%
+    );
+    transform: translateX(var(--segment-x));
+    transition:
+      transform 260ms cubic-bezier(0.22, 1, 0.36, 1),
+      width 260ms cubic-bezier(0.22, 1, 0.36, 1);
+  }
+
+  .boxer-segmented[data-active='f'] {
+    --segment-x: calc(100% + var(--segment-gap));
+  }
+
+  .boxer-segmented[data-active='m'] {
+    --segment-x: calc(200% + var(--segment-gap) + var(--segment-gap));
+  }
+
+  @media (min-width: 640px) {
+    .boxer-segmented {
+      --segment-gap: 0.85rem;
+    }
+  }
+
+  @media (min-width: 1280px) {
+    .boxer-segmented {
+      --segment-gap: 1rem;
+    }
+  }
+
+  @media (max-width: 639px) {
+    .boxer-segmented {
+      --segment-gap: 0.3rem;
+    }
+  }
+
+  .boxer-country-select-shell {
+    position: relative;
+    display: block;
+    min-width: 0;
+    width: 100%;
+  }
+
+  .boxer-country-native-select {
+    position: absolute;
+    z-index: 2;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
+    cursor: pointer;
+  }
+
+  .boxer-country-select {
+    appearance: none;
+    position: relative;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 0.55rem;
+    width: 100%;
+    min-height: var(--boxer-filter-control-height);
+    min-width: 0;
+    border: 0;
+    border-radius: var(--boxer-filter-radius);
+    padding: 0.4rem 0.62rem;
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-theme-midnight) 88%, black) 0%,
+      color-mix(in srgb, var(--color-velada-navy) 42%, black) 100%
+    );
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 28%, transparent);
+    color: var(--color-theme-cream);
+    font-size: var(--boxer-filter-control-font-size);
+    font-weight: 900;
+    letter-spacing: var(--boxer-filter-control-letter-spacing);
+    line-height: 1;
+    text-align: left;
+    text-transform: uppercase;
+    cursor: pointer;
+    pointer-events: none;
+    transition:
+      box-shadow 250ms ease,
+      background-color 250ms ease,
+      color 250ms ease;
+  }
+
+  .boxer-country-select-shell:hover .boxer-country-select,
+  .boxer-country-select-shell:has(.boxer-country-native-select:focus-visible)
+    .boxer-country-select {
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 66%, transparent);
+  }
+
+  .boxer-country-select-arrow {
+    position: static;
+    display: grid;
+    width: 1rem;
+    height: 1rem;
+    place-items: center;
+    color: var(--color-theme-gold);
+    stroke-width: 2.4;
+    pointer-events: none;
+    transition: transform 180ms ease;
+  }
+
+  .boxer-country-selected-flags,
+  .boxer-country-selected-flag {
+    display: inline-grid;
+    width: 2rem;
+    height: 1.5rem;
+    place-items: center;
+    flex: 0 0 auto;
+  }
+
+  .boxer-country-selected-flag[hidden] {
+    display: none;
+  }
+
+  .boxer-country-flag-svg {
+    display: block;
+    width: 2rem;
+    height: 1.5rem;
+    filter: saturate(0.9) contrast(1.05);
+  }
+
+  .boxer-country-selected-label {
+    overflow: hidden;
+    min-width: 0;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .boxer-country-select-shell .boxer-country-select-count {
+    min-height: 1.65rem;
+    min-width: 1.65rem;
+    border-radius: var(--boxer-filter-radius);
+    background: color-mix(in srgb, var(--color-theme-gold) 92%, white);
+    color: var(--color-theme-midnight);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, white 28%, transparent);
+  }
+
+  /* ---------- Pills ---------- */
+  .boxer-filter-pill {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.42rem 0.85rem;
+    border-radius: var(--boxer-filter-inner-radius);
+    background: color-mix(in srgb, var(--color-theme-midnight) 78%, black);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+    color: color-mix(in srgb, var(--color-theme-cream) 86%, transparent);
+    font-size: 0.6rem;
+    font-weight: 900;
+    letter-spacing: 0.18em;
+    line-height: 1;
+    cursor: pointer;
+    transition:
+      transform 250ms ease,
+      box-shadow 250ms ease,
+      background-color 250ms ease,
+      color 250ms ease;
+  }
+
+  @media (max-width: 639px) {
+    .boxer-filter-pill {
+      gap: 0.3rem;
+      padding: 0.38rem 0.55rem;
+      font-size: 0.52rem;
+      letter-spacing: 0.1em;
+    }
+
+    .boxer-segmented {
+      width: 100%;
+    }
+
+    .boxer-segmented-option {
+      padding-inline: 0.35rem;
+    }
+
+    .boxer-segmented-option .boxer-filter-pill-label {
+      font-size: 0.48rem;
+      letter-spacing: 0;
+    }
+  }
+
+  @media (min-width: 640px) {
+    .boxer-filter-pill {
+      font-size: 0.68rem;
+      padding: 0.5rem 1rem;
+    }
+  }
+
+  @media (min-width: 1024px) {
+    .boxer-filters-body .boxer-filter-pill {
+      gap: 0.55rem;
+      padding: 0.35rem 0.85rem;
+      font-size: var(--boxer-filter-control-font-size);
+      letter-spacing: var(--boxer-filter-control-letter-spacing);
+    }
+  }
+
+  .boxer-filter-pill::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    background: radial-gradient(
+      ellipse 100% 100% at 50% 0%,
+      color-mix(in srgb, var(--color-theme-gold) 18%, transparent) 0%,
+      transparent 80%
+    );
+    opacity: 0;
+    transition: opacity 250ms ease;
+    pointer-events: none;
+  }
+
+  .boxer-filter-pill:hover::before,
+  .boxer-filter-pill:focus-visible::before {
+    opacity: 1;
+  }
+
+  .boxer-filter-pill:hover,
+  .boxer-filter-pill:focus-visible {
+    color: var(--color-theme-cream);
+    box-shadow:
+      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 58%, transparent),
+      0 6px 18px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+    transform: translateY(-1px);
+    outline: none;
+  }
+
+  .boxer-filter-pill[aria-pressed='true'] {
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-theme-gold) 95%, white) 0%,
+      var(--color-theme-gold) 65%,
+      color-mix(in srgb, var(--color-theme-gold) 75%, black) 100%
+    );
+    color: var(--color-theme-midnight);
+    box-shadow:
+      inset 0 1px 0 color-mix(in srgb, white 35%, transparent),
+      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 100%, white),
+      0 8px 24px color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
+    transform: translateY(0);
+  }
+
+  .boxer-filter-pill[aria-pressed='true']::before {
+    opacity: 0;
+  }
+
+  .boxer-filter-pill[aria-pressed='true']:hover,
+  .boxer-filter-pill[aria-pressed='true']:focus-visible {
+    transform: translateY(-1px);
+  }
+
+  .boxer-segmented-option {
+    z-index: 1;
+    min-width: 0;
+    justify-content: center;
+    min-height: calc(var(--boxer-filter-control-height) - 0.3rem);
+    gap: 0.65rem;
+    border-radius: var(--boxer-filter-inner-radius);
+    box-shadow: none;
+    background: transparent;
+    letter-spacing: 0.02em;
+    padding: 0.32rem 0.9rem;
+    white-space: nowrap;
+  }
+
+  .boxer-segmented-option[aria-pressed='true'] {
+    background: transparent;
+    box-shadow: none;
+    color: var(--color-theme-midnight);
+  }
+
+  .boxer-segmented .boxer-filter-pill[aria-pressed='true'],
+  .boxer-segmented .boxer-filter-pill[aria-pressed='true']:hover,
+  .boxer-segmented .boxer-filter-pill[aria-pressed='true']:focus-visible {
+    background: transparent;
+    box-shadow: none;
+  }
+
+  .boxer-segmented-option[aria-pressed='true'] .boxer-filter-pill-count {
+    background: color-mix(in srgb, var(--color-theme-midnight) 95%, black);
+    color: var(--color-theme-cream);
+  }
+
+  .boxer-segmented-icon {
+    width: 1rem;
+    height: 1rem;
+    flex: 0 0 auto;
+    stroke: currentColor;
+    stroke-width: 2.35;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+
+  .boxer-sort-cycle {
+    appearance: none;
+    position: relative;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    width: 100%;
+    min-height: var(--boxer-filter-control-height);
+    gap: 0.62rem;
+    border: 0;
+    border-radius: var(--boxer-filter-radius);
+    padding: 0.42rem 0.62rem;
+    background: linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--color-theme-midnight) 84%, black) 0%,
+      color-mix(in srgb, var(--color-velada-navy) 45%, black) 100%
+    );
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
+    color: var(--color-theme-cream);
+    cursor: pointer;
+    text-align: left;
+    transition:
+      transform 250ms ease,
+      box-shadow 250ms ease,
+      color 250ms ease;
+  }
+
+  .boxer-sort-cycle:hover,
+  .boxer-sort-cycle:focus-visible {
+    outline: none;
+    color: white;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 66%, transparent);
+    transform: translateY(-1px);
+  }
+
+  .boxer-sort-cycle-icon {
+    display: grid;
+    width: 1.45rem;
+    height: 1.45rem;
+    place-items: center;
+    border-radius: var(--boxer-filter-inner-radius);
+    background: color-mix(in srgb, var(--color-theme-gold) 92%, white);
+    color: var(--color-theme-midnight);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, white 28%, transparent);
+  }
+
+  .boxer-sort-icon {
+    display: none;
+    width: 0.95rem;
+    height: 0.95rem;
+    stroke-width: 2.5;
+  }
+
+  .boxer-sort-cycle[data-sort='cartel'] .boxer-sort-icon-default,
+  .boxer-sort-cycle[data-sort='followers-desc'] .boxer-sort-icon-desc,
+  .boxer-sort-cycle[data-sort='followers-asc'] .boxer-sort-icon-asc {
+    display: block;
+  }
+
+  .boxer-sort-cycle-label {
+    overflow: hidden;
+    font-size: var(--boxer-filter-control-font-size);
+    font-weight: 900;
+    letter-spacing: var(--boxer-filter-control-letter-spacing);
+    line-height: 1;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .boxer-filter-pill:disabled,
+  .boxer-filter-pill[data-disabled='true'] {
+    opacity: 0.32;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
+  }
+
+  .boxer-filter-pill:disabled:hover,
+  .boxer-filter-pill[data-disabled='true']:hover {
+    transform: none;
+    color: color-mix(in srgb, var(--color-theme-cream) 86%, transparent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
+  }
+
+  .boxer-filter-pill-count {
+    display: inline-flex;
+    min-width: 1.25rem;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+    padding: 0.18rem 0.35rem;
+    border-radius: var(--boxer-filter-inner-radius);
+    background: color-mix(in srgb, var(--color-theme-midnight) 60%, transparent);
+    color: color-mix(in srgb, var(--color-theme-cream) 75%, transparent);
+    font-size: 0.55rem;
+    font-weight: 900;
+    letter-spacing: 0.04em;
+    font-variant-numeric: tabular-nums;
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+    transition:
+      background-color 250ms ease,
+      color 250ms ease;
+  }
+
+  .boxer-filter-pill-count-value {
+    display: inline-block;
+    line-height: 1;
+  }
+
+  @media (max-width: 639px) {
+    .boxer-filter-pill-count {
+      min-width: 0.95rem;
+      padding: 0.12rem 0.24rem;
+      font-size: 0.48rem;
+    }
+  }
+
+  .boxer-filter-pill-count.is-bumping {
+    transform: none;
+  }
+
+  .boxer-filter-pill-count.is-bumping .boxer-filter-pill-count-value {
+    animation: boxer-count-change 180ms ease-out both;
+  }
+
+  @keyframes boxer-count-change {
+    0% {
+      opacity: 0;
+      transform: translateY(-0.35em);
+    }
+    100% {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  .boxer-filter-pill[aria-pressed='true'] .boxer-filter-pill-count {
+    background: color-mix(in srgb, var(--color-theme-midnight) 95%, black);
+    color: var(--color-theme-cream);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-midnight) 100%, transparent);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .boxer-filter-pill,
+    .boxer-filter-pill-count,
+    .boxer-segmented::before,
+    .boxer-country-select,
+    .boxer-sort-cycle,
+    .boxer-filters-panel {
+      transition: none;
+    }
+
+    .boxer-filter-pill-count.is-bumping .boxer-filter-pill-count-value {
+      animation: none;
+    }
+  }
+</style>

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -856,6 +856,7 @@ const cardImageEagerAmount = 4
       for (const card of Array.from(gridEl.children) as HTMLElement[]) {
         if (card.dataset.hidden === 'true') continue
 
+        card.dataset.ready = 'true'
         card.classList.remove(ANIM_CLASS)
 
         void card.offsetWidth

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -1,6 +1,6 @@
 ---
-import ResetIcon from '@/assets/svg/reset.svg'
 import BoxerWinsBadge from '@/components/BoxerWinsBadge.astro'
+import BoxersFilterBar from '@/components/BoxersFilterBar.astro'
 import CountryFlag from '@/components/CountryFlag.astro'
 import SectionDivider from '@/components/SectionDivider.astro'
 import Layout from '@/layouts/Layout.astro'
@@ -129,7 +129,7 @@ const cardImageEagerAmount = 4
     <div aria-hidden="true" class="boxers-bg absolute inset-0 -z-20"></div>
     <div aria-hidden="true" class="boxers-grain pointer-events-none absolute inset-0 -z-10"></div>
 
-    <div class="boxers-layout mx-auto w-full max-w-7xl">
+    <div class="boxers-layout mx-auto w-full max-w-[88rem]">
       <header class="boxers-page-header">
         <h1
           class="boxers-page-title mb-3 font-cinzel text-3xl font-black tracking-[0.12em] text-theme-cream not-motion-reduce:animate-fade-in-up sm:text-4xl sm:tracking-[0.16em] md:text-6xl"
@@ -145,178 +145,16 @@ const cardImageEagerAmount = 4
         </p>
       </header>
 
-      <form
-        data-boxers-filters
-        class="boxer-filters-panel relative w-full not-motion-reduce:animate-fade-in-up not-motion-reduce:animate-delay-300"
-        aria-label="Filtros de boxeadores"
-        onsubmit="return false"
-      >
-        <span aria-hidden="true" class="boxer-filters-corner boxer-filters-corner-tl"></span>
-        <span aria-hidden="true" class="boxer-filters-corner boxer-filters-corner-tr"></span>
-        <span aria-hidden="true" class="boxer-filters-corner boxer-filters-corner-bl"></span>
-        <span aria-hidden="true" class="boxer-filters-corner boxer-filters-corner-br"></span>
-
-        <div
-          class="boxer-filters-eyebrow absolute -top-3 left-1/2 flex -translate-x-1/2 items-center gap-2 px-3 py-1"
-          aria-hidden="true"
-        >
-          <span class="size-1 rotate-45 bg-theme-gold/85"></span>
-          <span
-            class="font-cinzel text-[0.55rem] font-black tracking-[0.26em] text-theme-gold/95 sm:text-[0.65rem]"
-          >
-            FILTROS
-          </span>
-          <span class="size-1 rotate-45 bg-theme-gold/85"></span>
-        </div>
-
-        <div class="boxer-filters-body relative flex flex-col">
-          <fieldset class="boxer-filter-row" data-filter-row="country">
-            <legend class="boxer-filter-row-label">
-              <span aria-hidden="true" class="boxer-filter-row-label-mark"></span>
-              País
-            </legend>
-            <div class="boxer-filter-row-pills" role="group" aria-label="Filtrar por país">
-              <button
-                type="button"
-                data-filter="country"
-                data-value=""
-                aria-pressed="true"
-                class="boxer-filter-pill boxer-filter-pill-all"
-              >
-                <span class="boxer-filter-pill-label">Todos</span>
-                <span class="boxer-filter-pill-count" aria-hidden="true">{totalBoxers}</span>
-              </button>
-              {
-                countryFilters.map(({ code, name, count }) => (
-                  <button
-                    type="button"
-                    data-filter="country"
-                    data-value={code}
-                    aria-pressed="false"
-                    aria-label={`Filtrar por ${name}`}
-                    class="boxer-filter-pill"
-                  >
-                    <CountryFlag
-                      country={code}
-                      size={16}
-                      decorative
-                      class="boxer-filter-pill-flag"
-                    />
-                    <span class="boxer-filter-pill-label">{name}</span>
-                    <span class="boxer-filter-pill-count" aria-hidden="true">
-                      {count}
-                    </span>
-                  </button>
-                ))
-              }
-            </div>
-          </fieldset>
-
-          <fieldset class="boxer-filter-row" data-filter-row="gender">
-            <legend class="boxer-filter-row-label">
-              <span aria-hidden="true" class="boxer-filter-row-label-mark"></span>
-              Género
-            </legend>
-            <div class="boxer-filter-row-pills" role="group" aria-label="Filtrar por género">
-              <button
-                type="button"
-                data-filter="gender"
-                data-value=""
-                aria-pressed="true"
-                class="boxer-filter-pill boxer-filter-pill-all"
-              >
-                <span class="boxer-filter-pill-label">Todos</span>
-                <span class="boxer-filter-pill-count" aria-hidden="true">{totalBoxers}</span>
-              </button>
-              {
-                genderFilters.map(({ code, name, count }) => (
-                  <button
-                    type="button"
-                    data-filter="gender"
-                    data-value={code}
-                    aria-pressed="false"
-                    aria-label={`Filtrar por género ${name}`}
-                    class="boxer-filter-pill"
-                  >
-                    <span class="boxer-filter-pill-label">{name}</span>
-                    <span class="boxer-filter-pill-count" aria-hidden="true">
-                      {count}
-                    </span>
-                  </button>
-                ))
-              }
-            </div>
-          </fieldset>
-
-          <div data-boxers-footer hidden>
-            <span aria-hidden="true" class="boxer-filters-rule"></span>
-            <div class="boxer-filters-footer">
-              <button
-                type="button"
-                data-boxers-reset
-                class="boxer-filter-reset"
-                aria-label="Restablecer filtros"
-              >
-                <ResetIcon class="size-3.5" aria-hidden="true" />
-                Limpiar filtros
-              </button>
-            </div>
-          </div>
-        </div>
-      </form>
+      <BoxersFilterBar
+        countryFilters={countryFilters}
+        genderFilters={genderFilters}
+        totalBoxers={totalBoxers}
+      />
 
       <div class="boxers-results w-full">
-        <div
-          data-boxers-sort
-          class="boxer-sort-bar relative not-motion-reduce:animate-fade-in-up not-motion-reduce:animate-delay-300"
-          role="region"
-          aria-label="Ordenar boxeadores"
-        >
-          <span aria-hidden="true" class="boxer-sort-corner boxer-sort-corner-tl"></span>
-          <span aria-hidden="true" class="boxer-sort-corner boxer-sort-corner-tr"></span>
-          <span aria-hidden="true" class="boxer-sort-corner boxer-sort-corner-bl"></span>
-          <span aria-hidden="true" class="boxer-sort-corner boxer-sort-corner-br"></span>
-
-          <div class="boxer-sort-label">
-            <span aria-hidden="true" class="boxer-sort-label-mark"></span>
-            <span>Ordenar por</span>
-          </div>
-
-          <div class="boxer-sort-pills" role="group" aria-label="Modo de ordenación">
-            <button
-              type="button"
-              data-sort="cartel"
-              aria-pressed="true"
-              class="boxer-filter-pill boxer-sort-pill"
-            >
-              <span class="boxer-filter-pill-label">Cartelera</span>
-            </button>
-            <button
-              type="button"
-              data-sort="followers-desc"
-              aria-pressed="false"
-              aria-label="Ordenar por más seguidores en redes sociales"
-              class="boxer-filter-pill boxer-sort-pill"
-            >
-              <span aria-hidden="true" class="boxer-sort-pill-icon">▾</span>
-              <span class="boxer-filter-pill-label">Más seguidores</span>
-            </button>
-            <button
-              type="button"
-              data-sort="followers-asc"
-              aria-pressed="false"
-              aria-label="Ordenar por menos seguidores en redes sociales"
-              class="boxer-filter-pill boxer-sort-pill"
-            >
-              <span aria-hidden="true" class="boxer-sort-pill-icon">▴</span>
-              <span class="boxer-filter-pill-label">Menos seguidores</span>
-            </button>
-          </div>
-        </div>
-
         <ul
           data-boxers-grid
-          class="boxers-grid grid w-full grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-3 lg:gap-5 xl:grid-cols-4"
+          class="boxers-grid grid w-full grid-cols-2 gap-3 sm:gap-4 md:grid-cols-3 lg:grid-cols-4 lg:gap-5"
           role="list"
         >
           {
@@ -420,13 +258,6 @@ const cardImageEagerAmount = 4
           >
             Ningún contendiente coincide con los filtros seleccionados.
           </p>
-          <button
-            type="button"
-            data-boxers-reset
-            class="boxer-filter-reset boxer-filter-reset-strong"
-          >
-            Limpiar filtros
-          </button>
         </div>
       </div>
     </div>
@@ -739,13 +570,8 @@ const cardImageEagerAmount = 4
     }
   }
 
-  /* ---------- Layout: sidebar + resultados ---------- */
-  /* Usamos `minmax(0, 1fr)` en lugar de `1fr` para que ningún hijo
-     pueda expandir la columna por encima del viewport (clave para que
-     las pills del filtro con scroll horizontal no rompan el ancho del
-     documento entero en mobile). */
+  /* ---------- Layout: top command bar + resultados ---------- */
   .boxers-layout {
-    --boxers-sidebar-width: 236px;
     display: grid;
     grid-template-columns: minmax(0, 1fr);
     gap: 1.25rem;
@@ -758,51 +584,22 @@ const cardImageEagerAmount = 4
   }
 
   @media (min-width: 1024px) {
-    .boxers-layout:not([data-view='combates']) {
-      grid-template-columns: var(--boxers-sidebar-width) minmax(0, 1fr);
-      align-items: start;
+    .boxers-layout {
       gap: 2rem;
-    }
-
-    /* Título en la misma columna que el grid (f4e0c631: justify-self center, no stretch). */
-    .boxers-page-header {
-      display: grid;
-      grid-template-columns: var(--boxers-sidebar-width) minmax(0, 1fr);
-      column-gap: 2rem;
-      grid-column: 1 / -1;
-      grid-row: 1;
-    }
-
-    .boxers-page-header > * {
-      grid-column: 2;
-      justify-self: center;
-    }
-
-    .boxer-filters-panel {
-      grid-column: 1;
-      grid-row: 2;
-    }
-
-    .boxers-results {
-      grid-column: 2;
-      grid-row: 2;
     }
   }
 
   @media (min-width: 1280px) {
-    .boxers-layout:not([data-view='combates']) {
-      --boxers-sidebar-width: 252px;
+    .boxers-layout {
       gap: 2.5rem;
-    }
-
-    .boxers-page-header {
-      column-gap: 2.5rem;
     }
   }
 
   /* Contenedor de resultados con animación al filtrar (queda atado al
      grid del lado derecho). */
   .boxers-results {
+    position: relative;
+    z-index: 1;
     min-width: 0;
   }
 
@@ -812,452 +609,6 @@ const cardImageEagerAmount = 4
   @media (max-width: 639px) {
     .boxers-grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-  }
-
-  /* ---------- Filtros (command panel) ---------- */
-  .boxer-filters-panel {
-    /* `min-width: 0` evita que el contenido del panel (sobre todo las
-       pills) expanda al panel y, en cascada, al layout y al body. */
-    min-width: 0;
-    background:
-      radial-gradient(
-        ellipse 80% 100% at 50% 0%,
-        color-mix(in srgb, var(--color-theme-gold) 10%, transparent) 0%,
-        transparent 70%
-      ),
-      linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--color-velada-navy) 35%, var(--color-theme-midnight)) 0%,
-        color-mix(in srgb, var(--color-theme-midnight) 92%, black) 100%
-      );
-    box-shadow:
-      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 26%, transparent),
-      0 24px 60px rgba(0, 0, 0, 0.45),
-      0 0 60px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filters-panel {
-      box-shadow:
-        inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent),
-        0 16px 36px rgba(0, 0, 0, 0.38),
-        0 0 40px color-mix(in srgb, var(--color-theme-gold) 9%, transparent);
-    }
-  }
-
-  /* En desktop el panel viaja con el scroll (sticky) para que los filtros
-     estén siempre accesibles sin perder espacio vertical de resultados. */
-  @media (min-width: 1024px) {
-    .boxer-filters-panel {
-      position: sticky;
-      top: 6rem;
-    }
-  }
-
-  .boxer-filters-eyebrow {
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--color-velada-navy) 35%, var(--color-theme-midnight)) 0%,
-      color-mix(in srgb, var(--color-theme-midnight) 95%, black) 100%
-    );
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
-    border-radius: 9999px;
-    text-shadow:
-      0 1px 0 rgba(0, 0, 0, 0.6),
-      0 0 14px color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
-  }
-
-  .boxer-filters-corner {
-    position: absolute;
-    width: 14px;
-    height: 14px;
-    border: 1.5px solid color-mix(in srgb, var(--color-theme-gold) 80%, transparent);
-    pointer-events: none;
-  }
-  .boxer-filters-corner-tl {
-    top: -1px;
-    left: -1px;
-    border-right: 0;
-    border-bottom: 0;
-  }
-  .boxer-filters-corner-tr {
-    top: -1px;
-    right: -1px;
-    border-left: 0;
-    border-bottom: 0;
-  }
-  .boxer-filters-corner-bl {
-    bottom: -1px;
-    left: -1px;
-    border-right: 0;
-    border-top: 0;
-  }
-  .boxer-filters-corner-br {
-    bottom: -1px;
-    right: -1px;
-    border-left: 0;
-    border-top: 0;
-  }
-
-  .boxer-filters-body {
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 1.4rem;
-    padding: 1.3rem 1rem 1rem;
-  }
-  @media (max-width: 639px) {
-    .boxer-filters-body {
-      gap: 0.9rem;
-      padding: 1.1rem 0.7rem 0.7rem;
-    }
-  }
-  @media (min-width: 640px) {
-    .boxer-filters-body {
-      padding: 1.4rem 1rem 1.1rem;
-    }
-  }
-
-  .boxer-filter-row {
-    min-width: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.7rem;
-    padding: 0.3rem 0;
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-row {
-      gap: 0.45rem;
-      padding: 0.15rem 0;
-    }
-  }
-
-  .boxer-filter-row-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    font-size: 0.6rem;
-    font-weight: 900;
-    letter-spacing: 0.26em;
-    text-transform: uppercase;
-    color: color-mix(in srgb, var(--color-theme-gold) 90%, var(--color-theme-cream));
-    text-shadow:
-      0 1px 0 rgba(0, 0, 0, 0.6),
-      0 0 16px color-mix(in srgb, var(--color-theme-gold) 25%, transparent);
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-row-label {
-      font-size: 0.55rem;
-      letter-spacing: 0.18em;
-    }
-  }
-
-  .boxer-filter-row-label-mark {
-    display: inline-block;
-    width: 5px;
-    height: 5px;
-    background: var(--color-theme-gold);
-    transform: rotate(45deg);
-    box-shadow: 0 0 6px color-mix(in srgb, var(--color-theme-gold) 60%, transparent);
-  }
-
-  .boxer-filter-row-pills {
-    min-width: 0;
-    max-width: 100%;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: flex-start;
-    gap: 0.4rem;
-  }
-  @media (min-width: 640px) {
-    .boxer-filter-row-pills {
-      gap: 0.5rem;
-    }
-  }
-
-  /* En mobile mantenemos `flex-wrap: wrap` para que las pills nunca
-     ensanchen el panel (un scroll horizontal aquí desbordaba al
-     documento entero porque su padre no podía limitarlas). Compactamos
-     padding y tipografía para que entren bien en 2-3 filas. */
-  @media (max-width: 639px) {
-    .boxer-filter-row-pills {
-      gap: 0.3rem;
-    }
-  }
-
-  .boxer-filters-rule {
-    display: block;
-    height: 1px;
-    margin: 1rem 0 0.9rem;
-    background: linear-gradient(
-      90deg,
-      transparent 0%,
-      color-mix(in srgb, var(--color-theme-gold) 28%, transparent) 50%,
-      transparent 100%
-    );
-  }
-
-  .boxer-filters-footer {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: center;
-    gap: 0.6rem;
-    padding-top: 0.4rem;
-    padding-bottom: 0.2rem;
-  }
-
-  /* ---------- Sort bar ---------- */
-  /* Toolbar de ordenación que vive arriba del grid de resultados. Reusa
-     el lenguaje visual del panel de filtros (esquinas doradas, eyebrow
-     en mayúsculas y pills idénticas) para que ambos controles se sientan
-     parte del mismo "panel de comando". */
-  .boxer-sort-bar {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem 1.25rem;
-    margin-bottom: 1.25rem;
-    padding: 0.75rem 1rem;
-    background:
-      radial-gradient(
-        ellipse 90% 100% at 50% 0%,
-        color-mix(in srgb, var(--color-theme-gold) 8%, transparent) 0%,
-        transparent 70%
-      ),
-      linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--color-velada-navy) 28%, var(--color-theme-midnight)) 0%,
-        color-mix(in srgb, var(--color-theme-midnight) 94%, black) 100%
-      );
-    box-shadow:
-      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent),
-      0 14px 36px rgba(0, 0, 0, 0.4);
-  }
-
-  @media (min-width: 640px) {
-    .boxer-sort-bar {
-      padding: 0.85rem 1.25rem;
-      margin-bottom: 1.5rem;
-    }
-  }
-
-  .boxer-sort-corner {
-    position: absolute;
-    width: 10px;
-    height: 10px;
-    border: 1.5px solid color-mix(in srgb, var(--color-theme-gold) 75%, transparent);
-    pointer-events: none;
-  }
-  .boxer-sort-corner-tl {
-    top: -1px;
-    left: -1px;
-    border-right: 0;
-    border-bottom: 0;
-  }
-  .boxer-sort-corner-tr {
-    top: -1px;
-    right: -1px;
-    border-left: 0;
-    border-bottom: 0;
-  }
-  .boxer-sort-corner-bl {
-    bottom: -1px;
-    left: -1px;
-    border-right: 0;
-    border-top: 0;
-  }
-  .boxer-sort-corner-br {
-    bottom: -1px;
-    right: -1px;
-    border-left: 0;
-    border-top: 0;
-  }
-
-  .boxer-sort-label {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.55rem;
-    font-size: 0.6rem;
-    font-weight: 900;
-    letter-spacing: 0.26em;
-    text-transform: uppercase;
-    color: color-mix(in srgb, var(--color-theme-gold) 92%, var(--color-theme-cream));
-    text-shadow:
-      0 1px 0 rgba(0, 0, 0, 0.6),
-      0 0 14px color-mix(in srgb, var(--color-theme-gold) 25%, transparent);
-  }
-
-  @media (max-width: 639px) {
-    .boxer-sort-label {
-      font-size: 0.55rem;
-      letter-spacing: 0.18em;
-    }
-  }
-
-  .boxer-sort-label-mark {
-    display: inline-block;
-    width: 5px;
-    height: 5px;
-    background: var(--color-theme-gold);
-    transform: rotate(45deg);
-    box-shadow: 0 0 6px color-mix(in srgb, var(--color-theme-gold) 60%, transparent);
-  }
-
-  .boxer-sort-pills {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.4rem;
-  }
-  @media (min-width: 640px) {
-    .boxer-sort-pills {
-      gap: 0.5rem;
-    }
-  }
-
-  .boxer-sort-pill-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 0.85rem;
-    font-size: 0.7rem;
-    line-height: 1;
-    color: color-mix(in srgb, var(--color-theme-gold) 85%, var(--color-theme-cream));
-    text-shadow: 0 0 8px color-mix(in srgb, var(--color-theme-gold) 45%, transparent);
-    transition: color 250ms ease;
-  }
-
-  /* Al estar activa la pill (fondo dorado), el glifo invierte color para
-     mantener contraste con el oro brillante. */
-  .boxer-filter-pill[aria-pressed='true'] .boxer-sort-pill-icon {
-    color: var(--color-theme-midnight);
-    text-shadow: none;
-  }
-
-  /* ---------- Pills ---------- */
-  .boxer-filter-pill {
-    position: relative;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.42rem 0.85rem;
-    border-radius: 4px;
-    background: color-mix(in srgb, var(--color-theme-midnight) 78%, black);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
-    color: color-mix(in srgb, var(--color-theme-cream) 86%, transparent);
-    font-size: 0.6rem;
-    font-weight: 900;
-    letter-spacing: 0.18em;
-    line-height: 1;
-    cursor: pointer;
-    transition:
-      transform 250ms ease,
-      box-shadow 250ms ease,
-      background-color 250ms ease,
-      color 250ms ease;
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-pill {
-      gap: 0.3rem;
-      padding: 0.38rem 0.55rem;
-      font-size: 0.52rem;
-      letter-spacing: 0.1em;
-    }
-  }
-
-  @media (min-width: 640px) {
-    .boxer-filter-pill {
-      font-size: 0.68rem;
-      padding: 0.5rem 1rem;
-    }
-  }
-
-  .boxer-filter-pill::before {
-    content: '';
-    position: absolute;
-    inset: 0;
-    border-radius: inherit;
-    background: radial-gradient(
-      ellipse 100% 100% at 50% 0%,
-      color-mix(in srgb, var(--color-theme-gold) 18%, transparent) 0%,
-      transparent 80%
-    );
-    opacity: 0;
-    transition: opacity 250ms ease;
-    pointer-events: none;
-  }
-
-  .boxer-filter-pill:hover::before,
-  .boxer-filter-pill:focus-visible::before {
-    opacity: 1;
-  }
-
-  .boxer-filter-pill:hover,
-  .boxer-filter-pill:focus-visible {
-    color: var(--color-theme-cream);
-    box-shadow:
-      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 58%, transparent),
-      0 6px 18px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
-    transform: translateY(-1px);
-    outline: none;
-  }
-
-  .boxer-filter-pill[aria-pressed='true'] {
-    background: linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--color-theme-gold) 95%, white) 0%,
-      var(--color-theme-gold) 65%,
-      color-mix(in srgb, var(--color-theme-gold) 75%, black) 100%
-    );
-    color: var(--color-theme-midnight);
-    box-shadow:
-      inset 0 1px 0 color-mix(in srgb, white 35%, transparent),
-      inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 100%, white),
-      0 8px 24px color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
-    transform: translateY(0);
-  }
-
-  .boxer-filter-pill[aria-pressed='true']::before {
-    opacity: 0;
-  }
-
-  .boxer-filter-pill[aria-pressed='true']:hover,
-  .boxer-filter-pill[aria-pressed='true']:focus-visible {
-    transform: translateY(-1px);
-  }
-
-  .boxer-filter-pill:disabled,
-  .boxer-filter-pill[data-disabled='true'] {
-    opacity: 0.32;
-    cursor: not-allowed;
-    transform: none;
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
-  }
-
-  .boxer-filter-pill:disabled:hover,
-  .boxer-filter-pill[data-disabled='true']:hover {
-    transform: none;
-    color: color-mix(in srgb, var(--color-theme-cream) 86%, transparent);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 12%, transparent);
-  }
-
-  :global(.boxer-filter-pill-flag) {
-    width: 1rem;
-    height: 1rem;
-    flex-shrink: 0;
-  }
-
-  @media (max-width: 639px) {
-    :global(.boxer-filter-pill-flag) {
-      width: 0.875rem;
-      height: 0.875rem;
     }
   }
 
@@ -1274,89 +625,12 @@ const cardImageEagerAmount = 4
     }
   }
 
-  .boxer-filter-pill-count {
-    display: inline-flex;
-    min-width: 1.25rem;
-    align-items: center;
-    justify-content: center;
-    padding: 0.18rem 0.35rem;
-    border-radius: 3px;
-    background: color-mix(in srgb, var(--color-theme-midnight) 60%, transparent);
-    color: color-mix(in srgb, var(--color-theme-cream) 75%, transparent);
-    font-size: 0.55rem;
-    font-weight: 900;
-    letter-spacing: 0.04em;
-    font-variant-numeric: tabular-nums;
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
-    transition:
-      transform 250ms ease,
-      background-color 250ms ease,
-      color 250ms ease;
-  }
-
-  @media (max-width: 639px) {
-    .boxer-filter-pill-count {
-      min-width: 0.95rem;
-      padding: 0.12rem 0.24rem;
-      font-size: 0.48rem;
-    }
-  }
-
-  .boxer-filter-pill-count.is-bumping {
-    transform: scale(1.22);
-  }
-
-  .boxer-filter-pill[aria-pressed='true'] .boxer-filter-pill-count {
-    background: color-mix(in srgb, var(--color-theme-midnight) 95%, black);
-    color: var(--color-theme-cream);
-    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-midnight) 100%, transparent);
-  }
-
-  .boxer-filter-reset {
-    appearance: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    background: transparent;
-    border: 1px solid color-mix(in srgb, var(--color-theme-gold) 35%, transparent);
-    border-radius: 9999px;
-    padding: 0.45rem 0.95rem;
-    color: color-mix(in srgb, var(--color-theme-cream) 80%, transparent);
-    font-size: 0.55rem;
-    font-weight: 900;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    cursor: pointer;
-    transition:
-      color 250ms ease,
-      border-color 250ms ease,
-      background-color 250ms ease,
-      transform 250ms ease;
-  }
-
-  @media (min-width: 640px) {
-    .boxer-filter-reset {
-      font-size: 0.65rem;
-    }
-  }
-
-  .boxer-filter-reset:hover,
-  .boxer-filter-reset:focus-visible {
-    color: var(--color-theme-midnight);
-    background: color-mix(in srgb, var(--color-theme-gold) 92%, white);
-    border-color: var(--color-theme-gold);
-    transform: translateY(-1px);
-    outline: none;
-  }
-
-  .boxer-filter-reset-strong {
-    padding: 0.55rem 1.2rem;
-    border-color: color-mix(in srgb, var(--color-theme-gold) 55%, transparent);
-    color: var(--color-theme-cream);
-  }
-
   :global(.js) .boxer-card-wrap {
     opacity: 0;
+  }
+
+  :global(.js) .boxer-card-wrap[data-ready='true'] {
+    opacity: 1;
   }
 
   .boxer-card-wrap {
@@ -1403,7 +677,7 @@ const cardImageEagerAmount = 4
       color-mix(in srgb, var(--color-theme-gold), transparent 88%) 0%,
       transparent 80%
     );
-    border-radius: 4px;
+    border-radius: 2px;
     line-height: normal;
     border: 1px solid color-mix(in srgb, var(--color-theme-gold) 30%, transparent);
     animation: blurred-fade-in 0.4s ease-in-out both calc(var(--animation-delay) + 0.6s);
@@ -1433,11 +707,7 @@ const cardImageEagerAmount = 4
       animation: none;
     }
 
-    .boxer-filter-pill,
-    .boxer-filter-pill-count,
-    .boxer-filter-reset,
-    .boxer-card-wrap,
-    .boxer-filters-panel {
+    .boxer-card-wrap {
       transition: none;
     }
   }
@@ -1452,22 +722,46 @@ const cardImageEagerAmount = 4
     const form = $<HTMLFormElement>('[data-boxers-filters]')
     const grid = $<HTMLElement>('[data-boxers-grid]')
     const empty = $<HTMLElement>('[data-boxers-empty]')
-    const footerBlock = $<HTMLElement>('[data-boxers-footer]')
     const sortBar = $<HTMLElement>('[data-boxers-sort]')
     if (!form || !grid) return
+    if (form.dataset.boxersFiltersReady === 'true') return
+    form.dataset.boxersFiltersReady = 'true'
+
     const gridEl: HTMLElement = grid
 
     const cards = Array.from($$<HTMLElement>('[data-boxer-card]', grid))
+    const countrySelect = $<HTMLSelectElement>('[data-country-select]', form)
+    const countrySelectedLabel = $<HTMLElement>('[data-country-selected-label]', form)
+    const countrySelectedFlags = Array.from($$<HTMLElement>('[data-country-selected-flag]', form))
+    const countryCount = $<HTMLElement>('[data-country-count]', form)
+    const genderSegmented = $<HTMLElement>('[data-gender-segmented]', form)
     const filterButtons = Array.from($$<HTMLButtonElement>('[data-filter]', form))
-    const resetButtons = Array.from($$<HTMLButtonElement>('[data-boxers-reset]'))
-    const sortButtons = sortBar ? Array.from($$<HTMLButtonElement>('[data-sort]', sortBar)) : []
+    const sortCycleButton = sortBar ? $<HTMLButtonElement>('[data-sort-cycle]', sortBar) : null
+    const sortCycleLabel = sortCycleButton
+      ? $<HTMLElement>('[data-sort-cycle-label]', sortCycleButton)
+      : null
 
     const reduceMotionQuery = window.matchMedia('(prefers-reduced-motion: reduce)')
+    const SORT_MODES: SortMode[] = ['cartel', 'followers-desc', 'followers-asc']
+    const SORT_META: Record<SortMode, { label: string; aria: string }> = {
+      cartel: {
+        label: 'Cartelera',
+        aria: 'Ordenar por cartelera. Pulsa para ordenar por más seguidores.',
+      },
+      'followers-desc': {
+        label: 'Más seguidores',
+        aria: 'Ordenar por más seguidores. Pulsa para ordenar por menos seguidores.',
+      },
+      'followers-asc': {
+        label: 'Menos seguidores',
+        aria: 'Ordenar por menos seguidores. Pulsa para ordenar por cartelera.',
+      },
+    }
 
     // Lee el estado inicial desde la URL
     function getStateFromURL(buttons: HTMLButtonElement[]) {
       const validCountries = new Set(
-        buttons.filter((b) => b.dataset.filter === 'country').map((b) => b.dataset.value ?? ''),
+        countrySelect ? Array.from(countrySelect.options).map((option) => option.value) : [''],
       )
       const validGenders = new Set(
         buttons.filter((b) => b.dataset.filter === 'gender').map((b) => b.dataset.value ?? ''),
@@ -1538,11 +832,26 @@ const cardImageEagerAmount = 4
 
     const ANIM_CLASS = 'animate-fade-in-up'
     const ANIM_DELAY = 35
+    let cardsReady = false
 
-    function retriggerAnimations() {
+    function prepareCardsForLayoutChange() {
+      if (!cardsReady) return
+
+      for (const card of cards) {
+        card.classList.remove(ANIM_CLASS)
+        card.dataset.ready = 'true'
+      }
+    }
+
+    function revealInitialCards() {
       let visibleIndex = 0
+      allowBoxerCardAnimations()
 
-      if (reduceMotionQuery.matches) return
+      if (reduceMotionQuery.matches) {
+        cardsReady = true
+        for (const card of cards) card.dataset.ready = 'true'
+        return
+      }
 
       for (const card of Array.from(gridEl.children) as HTMLElement[]) {
         if (card.dataset.hidden === 'true') continue
@@ -1557,24 +866,21 @@ const cardImageEagerAmount = 4
 
         visibleIndex++
       }
+
+      cardsReady = true
     }
 
-    // Remueve el atributo 'data-skip-boxers-enter' añádido en el script de 'Layout.astro'
-    // que impide las animaciones de entrada en las tarjetas de los boxeadores
     function allowBoxerCardAnimations() {
       document.documentElement.removeAttribute('data-skip-boxers-enter')
     }
 
-    // Reordena el DOM (no sólo CSS `order`) para que el orden de
-    // tabulación coincida con el visual. Con 20 cards el coste es
-    // despreciable y mantenemos la accesibilidad correcta.
-    function applySort() {
+    function updateGridState() {
       const hasActiveFilter = state.country !== '' || state.gender !== ''
       const isDefaultSortMode = sortMode === 'cartel'
-      const gridState = !hasActiveFilter && isDefaultSortMode ? 'default' : 'modified'
+      setGridState(!hasActiveFilter && isDefaultSortMode ? 'default' : 'modified')
+    }
 
-      setGridState(gridState)
-
+    function updateSortOrder() {
       const ordered = [...cards]
       if (sortMode === 'followers-desc') {
         ordered.sort(
@@ -1592,6 +898,14 @@ const cardImageEagerAmount = 4
       }
 
       for (const card of ordered) gridEl.appendChild(card)
+
+      syncSortCycleControl()
+    }
+
+    function applySort() {
+      prepareCardsForLayoutChange()
+      updateGridState()
+      updateSortOrder()
     }
 
     // Cuenta cards que coinciden con un par (country, gender). Pasar '' en
@@ -1608,7 +922,7 @@ const cardImageEagerAmount = 4
 
     // Animación visual al presionar un filtro.
     function bump(el: HTMLElement | null) {
-      if (!el) return
+      if (!el || reduceMotionQuery.matches) return
       el.classList.remove('is-bumping')
       // Forzamos reflow para reiniciar la transición si se está pulsando rápido.
       void el.offsetWidth
@@ -1616,13 +930,73 @@ const cardImageEagerAmount = 4
       window.setTimeout(() => el.classList.remove('is-bumping'), 260)
     }
 
-    function applyFilters() {
-      const hasActiveFilter = state.country !== '' || state.gender !== ''
-      const isDefaultSortMode = sortMode === 'cartel'
-      const gridState = !hasActiveFilter && isDefaultSortMode ? 'default' : 'modified'
+    function setCountText(el: HTMLElement, value: string) {
+      const countValue = $<HTMLElement>('.boxer-filter-pill-count-value', el)
+      if (countValue) {
+        countValue.textContent = value
+        return
+      }
 
-      setGridState(gridState)
-      // Mantiene el contenido dentro del viewport al aplicar filtros. Esto evita que los cambios en la altura del contenedor de las cards, ya sea por crecimiento o reducción de su contenido, provoquen desplazamientos inesperados que puedan enviar al usuario a la siguiente sección o dejar contenido parcialmente cortado.
+      el.textContent = ''
+      const valueNode = document.createElement('span')
+      valueNode.className = 'boxer-filter-pill-count-value'
+      valueNode.textContent = value
+      el.appendChild(valueNode)
+    }
+
+    function getCountText(el: HTMLElement) {
+      return (
+        $<HTMLElement>('.boxer-filter-pill-count-value', el)?.textContent?.trim() ??
+        el.textContent?.trim()
+      )
+    }
+
+    function syncCountryControl() {
+      if (!countrySelect) return
+
+      countrySelect.value = state.country
+      const selectedOption = countrySelect.selectedOptions[0]
+      if (countrySelectedLabel) {
+        countrySelectedLabel.textContent =
+          selectedOption?.dataset.label ??
+          selectedOption?.textContent?.split('·')[0]?.trim() ??
+          'Todos'
+      }
+
+      for (const flag of countrySelectedFlags) {
+        flag.hidden = (flag.dataset.countrySelectedFlag ?? '') !== state.country
+      }
+
+      for (const option of Array.from(countrySelect.options)) {
+        const value = option.value
+        const label = option.dataset.label ?? option.textContent?.split('·')[0]?.trim() ?? ''
+        const projectedCount = countMatching(value, state.gender)
+        option.textContent = `${label} · ${projectedCount}`
+        option.disabled = projectedCount === 0 && state.country !== value
+      }
+
+      if (countryCount) {
+        const selectedCount = countMatching(state.country, state.gender)
+        const next = String(selectedCount)
+        if (getCountText(countryCount) !== next) {
+          setCountText(countryCount, next)
+          bump(countryCount)
+        }
+      }
+    }
+
+    function syncSortCycleControl() {
+      if (!sortCycleButton) return
+
+      const meta = SORT_META[sortMode]
+      sortCycleButton.dataset.sort = sortMode
+      sortCycleButton.setAttribute('aria-label', meta.aria)
+      if (sortCycleLabel) sortCycleLabel.textContent = meta.label
+    }
+
+    function updateFilters() {
+      updateGridState()
+      // Keep the grid anchored when filtering changes page height.
       keepContentInView(sortBar)
 
       let visible = 0
@@ -1639,14 +1013,13 @@ const cardImageEagerAmount = 4
       if (empty) empty.classList.toggle('hidden', visible !== 0)
       if (empty) empty.classList.toggle('flex', visible === 0)
 
-      // Mostramos el footer (con su separador) y los botones de reset
-      // sólo cuando hay algún filtro activo.
-      if (footerBlock) footerBlock.hidden = !hasActiveFilter
-      for (const btn of resetButtons) btn.hidden = !hasActiveFilter
+      syncCountryControl()
 
       // Para cada pill: recalculamos su conteo SIN aplicar el filtro de su
       // propio grupo (así se muestra cuántos quedarían si se activase
       // sobre los filtros actuales del resto). Y sincronizamos aria-pressed.
+      if (genderSegmented) genderSegmented.dataset.active = state.gender || 'all'
+
       for (const btn of filterButtons) {
         const group = btn.dataset.filter as 'country' | 'gender' | undefined
         const value = btn.dataset.value ?? ''
@@ -1662,10 +1035,9 @@ const cardImageEagerAmount = 4
 
         const countNode = $<HTMLElement>('.boxer-filter-pill-count', btn)
         if (countNode) {
-          const previous = countNode.textContent
           const next = String(projectedCount)
-          if (previous !== next) {
-            countNode.textContent = next
+          if (getCountText(countNode) !== next) {
+            setCountText(countNode, next)
             bump(countNode)
           }
         }
@@ -1679,6 +1051,19 @@ const cardImageEagerAmount = 4
       }
     }
 
+    function applyFilters() {
+      prepareCardsForLayoutChange()
+      updateFilters()
+    }
+
+    if (countrySelect) {
+      countrySelect.addEventListener('change', () => {
+        state.country = countrySelect.value
+        applyFilters()
+        syncStateToURL()
+      })
+    }
+
     for (const btn of filterButtons) {
       btn.addEventListener('click', () => {
         const group = btn.dataset.filter as 'country' | 'gender' | undefined
@@ -1689,46 +1074,22 @@ const cardImageEagerAmount = 4
         if (state[group] === value) return
         state[group] = value
         applyFilters()
-        allowBoxerCardAnimations()
-        retriggerAnimations()
         syncStateToURL()
       })
     }
 
-    for (const btn of resetButtons) {
-      btn.addEventListener('click', () => {
-        state.country = ''
-        state.gender = ''
-        applyFilters()
-        allowBoxerCardAnimations()
-        retriggerAnimations()
-        syncStateToURL()
-      })
-    }
-
-    for (const btn of sortButtons) {
-      btn.addEventListener('click', () => {
-        const next = (btn.dataset.sort as SortMode | undefined) ?? 'cartel'
-        if (sortMode === next) return
-        sortMode = next
-        for (const b of sortButtons) {
-          b.setAttribute('aria-pressed', String(b.dataset.sort === sortMode))
-        }
+    if (sortCycleButton) {
+      sortCycleButton.addEventListener('click', () => {
+        const currentIndex = SORT_MODES.indexOf(sortMode)
+        sortMode = SORT_MODES[(currentIndex + 1) % SORT_MODES.length]
         applySort()
-        allowBoxerCardAnimations()
-        retriggerAnimations()
         syncStateToURL()
       })
     }
 
-    // Sincroniza aria-pressed en los botones de ordenación al cargar
-    for (const b of sortButtons) {
-      b.setAttribute('aria-pressed', String(b.dataset.sort === sortMode))
-    }
-
-    applyFilters()
-    applySort()
-    retriggerAnimations()
+    updateFilters()
+    updateSortOrder()
+    revealInitialCards()
   }
 
   document.addEventListener('astro:page-load', setupBoxersFilters)


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

- `src/components/BoxersFilterBar.astro`: añade una barra horizontal de filtros para país, género y ordenación, con select nativo accesible, flags inline en estilo Velada, toggle segmentado e iconos.
- `src/pages/boxeadores.astro`: sustituye el panel lateral por la nueva barra superior alineada con la grid y adapta el comportamiento de filtros/ordenación al nuevo componente.

## Por qué mejora

La barra pasa de ocupar una columna lateral a usar una franja horizontal encima de la grid. Eso deja más ancho útil para las cards, alinea los controles con el contenido y hace más claro el flujo: país, género y ordenación se leen en una sola línea en desktop y se apilan de forma compacta en mobile.

El país usa un `<select>` nativo real para mantener teclado y lectores de pantalla correctos, mientras la capa visual conserva el tratamiento de flags y conteos. El género queda como control segmentado porque el conjunto de opciones es fijo y pequeño.

## Dependencies

- Added: None
- Removed: None

## Screenshots

Las capturas viven en una rama separada del fork (`pr-captures-boxers-filter-20260621`) para no meter archivos de screenshots en este PR.

| View | Before | After |
|------|--------|-------|
| Mobile | <img src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/pr-captures-boxers-filter-20260621/docs/pr/boxers-filter/before-main-mobile.png" width="260" alt="Before mobile" /> | <img src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/pr-captures-boxers-filter-20260621/docs/pr/boxers-filter/after-filter-bar-mobile.png" width="260" alt="After mobile" /> |
| Desktop | <img src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/pr-captures-boxers-filter-20260621/docs/pr/boxers-filter/before-main-desktop.png" width="420" alt="Before desktop" /> | <img src="https://raw.githubusercontent.com/tonyblu331/la-velada-web-oficial/pr-captures-boxers-filter-20260621/docs/pr/boxers-filter/after-filter-bar-desktop.png" width="420" alt="After desktop" /> |

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Nuevas Características**
  * Barra de filtros rediseñada para boxeadores con selector de país (con conteos y banderas) y segmentación por género.
  * Ordenamiento de resultados con un control en ciclo (“Cartelera”).

* **Mejoras Visuales**
  * Carga y presentación de tarjetas más consistente: revelado progresivo según disponibilidad y sincronización de estado de filtros/orden.
  * Ajustes de estilos y estados de interacción (incluye soporte para menos animaciones cuando se solicita reducción de movimiento).
  * El estado vacío “Sin boxeadores” se simplifica (sin botón de reseteo).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->