### PR TITLE
style(artistas): muestra cursor de no permitido en las tarjetas de artistas

### DIFF
--- a/src/pages/artistas.astro
+++ b/src/pages/artistas.astro
@@ -72,7 +72,7 @@ const breadcrumbJsonLd = {
                 class="artist-card-wrap animate-fade-in-up"
                 style={`animation-delay: ${index * 45}ms; --idx: ${index}`}
             >
-                <div class="artist-flip relative block w-full">
+                <div class="artist-flip relative block w-full cursor-not-allowed">
                 <span
                     aria-hidden="true"
                     class="artist-face artist-face-front absolute inset-0 grid place-items-center overflow-hidden rounded-md"


### PR DESCRIPTION


> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [x] feat

## Related Issue

Closes #
This pull request introduces a minor UI update by modifying the cursor style for artist cards on the `artistas.astro` page.

- Added the `cursor-not-allowed` class to the `artist-flip` container to visually indicate that the artist cards are not interactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Mejoras de interfaz**
  * Los placeholders de artistas ahora muestran el cursor “no disponible” al pasar el mouse, dejando más claro que no son interactivos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->