### PR TITLE
fix(seguridad): escapa "<" en los datos JSON-LD

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -6,6 +6,7 @@ import '@/styles/global.css'
 
 import { fixedTitle } from '@/consts/pageTitles'
 import Header from '@/sections/Header.astro'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 const SITE_URL = 'https://www.infolavelada.com'
 const DEFAULT_OG_IMAGE = `https://cdn.infolavelada.com/og.jpg`
@@ -140,12 +141,12 @@ const organizationJsonLd = {
     <script
       type="application/ld+json"
       is:inline
-      set:html={JSON.stringify(websiteJsonLd)}
+      set:html={serializeJsonLd(websiteJsonLd)}
     />
     <script
       type="application/ld+json"
       is:inline
-      set:html={JSON.stringify(organizationJsonLd)}
+      set:html={serializeJsonLd(organizationJsonLd)}
     />
     <slot name="head" />
     <ClientRouter />

--- a/src/pages/artistas.astro
+++ b/src/pages/artistas.astro
@@ -3,6 +3,7 @@ import SectionDivider from '@/components/SectionDivider.astro'
 import Layout from '@/layouts/Layout.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 const SITE_URL = 'https://www.infolavelada.com'
 const title = 'Artistas | La Velada del Año VI'
@@ -30,7 +31,7 @@ const breadcrumbJsonLd = {
     <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(breadcrumbJsonLd)}
+    set:html={serializeJsonLd(breadcrumbJsonLd)}
     slot="head"
     />
 

--- a/src/pages/boxeadores.astro
+++ b/src/pages/boxeadores.astro
@@ -14,6 +14,7 @@ import {
   getBoxerHeroImages,
   type BoxerGender,
 } from '@/consts/boxers'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 const SITE_URL = 'https://www.infolavelada.com'
 const title = 'Boxeadores y boxeadoras | La Velada del Año VI'
@@ -110,13 +111,13 @@ const cardImageEagerAmount = 4
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(breadcrumbJsonLd)}
+    set:html={serializeJsonLd(breadcrumbJsonLd)}
     slot="head"
   />
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(itemListJsonLd)}
+    set:html={serializeJsonLd(itemListJsonLd)}
     slot="head"
   />
   <script is:inline>

--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -25,6 +25,7 @@ import { formatFollowers } from '@/lib/socials'
 import Layout from '@/layouts/Layout.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 export const prerender = true
 
@@ -202,13 +203,13 @@ const breadcrumbJsonLd = {
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(personJsonLd)}
+    set:html={serializeJsonLd(personJsonLd)}
     slot="head"
   />
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(breadcrumbJsonLd)}
+    set:html={serializeJsonLd(breadcrumbJsonLd)}
     slot="head"
   />
 

--- a/src/pages/combate/[id].astro
+++ b/src/pages/combate/[id].astro
@@ -13,6 +13,7 @@ import {
 import Layout from '@/layouts/Layout.astro'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 const { id = '' } = Astro.params
 const battle = battlesById[id]
@@ -116,13 +117,13 @@ const breadcrumbJsonLd = {
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(sportsEventJsonLd)}
+    set:html={serializeJsonLd(sportsEventJsonLd)}
     slot="head"
   />
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(breadcrumbJsonLd)}
+    set:html={serializeJsonLd(breadcrumbJsonLd)}
     slot="head"
   />
 

--- a/src/pages/combates.astro
+++ b/src/pages/combates.astro
@@ -6,6 +6,7 @@ import CombatCard from '@/components/CombatCard.astro'
 import SectionDivider from '@/components/SectionDivider.astro'
 import { battles } from '@/consts/battles'
 import { BOXERS_BY_ID, COUNTRY_NAMES, getBoxerHeroImages, type Boxer } from '@/consts/boxers'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 const SITE_URL = 'https://www.infolavelada.com'
 const title = 'Combates | La Velada del Año VI'
@@ -57,7 +58,7 @@ const breadcrumbJsonLd = {
   <script
     type="application/ld+json"
     is:inline
-    set:html={JSON.stringify(breadcrumbJsonLd)}
+    set:html={serializeJsonLd(breadcrumbJsonLd)}
     slot="head"
   />
 

--- a/src/sections/HomeStructuredData.astro
+++ b/src/sections/HomeStructuredData.astro
@@ -4,6 +4,7 @@ import { BOXERS, BOXERS_BY_ID, COUNTRY_NAMES, getBoxerPhoto } from '@/consts/box
 import { EVENT_END_ISO, EVENT_ISO } from '@/consts/event'
 import { HOME_FAQS } from '@/consts/home-faq'
 import { HOME_CANONICAL, HOME_DESCRIPTION, SITE_URL } from '@/consts/home-seo'
+import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 const sportsEventJsonLd = {
   '@context': 'https://schema.org',
@@ -103,5 +104,5 @@ const faqJsonLd = {
 }
 ---
 
-<script type="application/ld+json" is:inline set:html={JSON.stringify(sportsEventJsonLd)} />
-<script type="application/ld+json" is:inline set:html={JSON.stringify(faqJsonLd)} />
+<script type="application/ld+json" is:inline set:html={serializeJsonLd(sportsEventJsonLd)} />
+<script type="application/ld+json" is:inline set:html={serializeJsonLd(faqJsonLd)} />

--- a/src/utils/serialize-json-ld.ts
+++ b/src/utils/serialize-json-ld.ts
@@ -1,0 +1,15 @@
+/**
+ * Serializa datos JSON-LD para inyectarlos de forma segura en un
+ * `<script type="application/ld+json">` vía `set:html`.
+ *
+ * Escapa `<` como `<` para que ningún valor pueda cerrar el bloque
+ * (`</script>`) ni abrir un comentario HTML (`<!--`). Es el mismo criterio
+ * que aplica PredictionVoteController al inyectar su config como JSON.
+ *
+ * Hoy estos datos provienen de constantes de build (evento, boxeadores, FAQ),
+ * pero el escape garantiza que añadir contenido con `<` en el futuro no rompa
+ * el marcado ni abra una vía de XSS.
+ */
+export function serializeJsonLd(data: unknown): string {
+  return JSON.stringify(data).replaceAll('<', '\\u003c')
+}


### PR DESCRIPTION
## Qué hace este cambio

Hasta ahora los bloques de datos estructurados JSON-LD de la web se inyectaban con `JSON.stringify` directamente dentro del `set:html`, sin escapar nada.

El controlador de predicciones ya tenía la precaución de escapar el carácter `<` antes de meter su configuración en un `<script>`, para que ningún valor pudiera cerrar la etiqueta por accidente. Pero los bloques JSON-LD no seguían ese mismo criterio, así que había una pequeña incoherencia de seguridad entre una parte de la web y la otra.

## Cómo lo he resuelto

He creado un helper pequeñito, `serializeJsonLd`, que se encarga de ese escape en un único sitio, y lo he aplicado a los doce bloques JSON-LD que hay repartidos por la web:

- La portada (`HomeStructuredData`) y el layout general (`Layout`)
- Las páginas de boxeadores (listado y detalle)
- Las páginas de combates (listado y detalle)
- La página de artistas

Hoy por hoy todos esos datos vienen de constantes del proyecto, así que el riesgo real es nulo. Pero con este cambio nos aseguramos de que el día de mañana, si a alguien se le cuela un `<` dentro de un nombre, una pregunta del FAQ o cualquier otro texto, no se rompa el marcado ni se abra una vía de XSS.

## Contexto

Sale de la auditoría del issue #1613. De paso confirmé que el punto 3 de ese issue (el `innerHTML` en la sección de FAQ) **ya estaba resuelto** en la edición VI: el FAQ se reescribió y ahora construye los nodos con `createElement` + `textContent`, sin `innerHTML`. Lo dejé documentado en un comentario del propio issue.

Los puntos 1 (CSP) y 2 (rate-limit en `/api/predictions`) del issue siguen pendientes y van por separado.

## Cómo lo he probado

- Build de producción completo (`astro build`): todas las páginas compilan y prerenderizan sin errores.
- Revisado el HTML generado: los cuatro bloques JSON-LD (WebSite, Organization, SportsEvent y FAQPage) se renderizan correctamente y siguen siendo JSON válido.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mejorada la generación de datos estructurados en varias páginas y secciones del sitio.
  * Se reforzó la seguridad del contenido incrustado en JSON-LD para evitar problemas de renderizado.
  * Los breadcrumbs y otros metadatos ahora se insertan de forma más fiable en las páginas públicas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->