### PR TITLE
fix(seguridad): limita los votos por usuario en /api/predictions

### DIFF
--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -504,6 +504,21 @@ const controllerConfig = JSON.stringify({
         return
       }
 
+      // El servidor limita los votos por usuario: revertimos el voto optimista
+      // y avisamos sin tratarlo como un error inesperado (no ensuciamos la
+      // consola, es una respuesta esperable ante ráfagas).
+      if (response.status === 429) {
+        if (latestVoteRequestByBattle.get(battleId) === requestId && snapshot) {
+          restoreFightSnapshot(snapshot)
+        }
+        const announcer = $<HTMLElement>('[data-prediction-announcer]')
+        if (announcer) {
+          announcer.textContent =
+            'Estás votando demasiado rápido. Espera unos segundos e inténtalo de nuevo.'
+        }
+        return
+      }
+
       if (!response.ok) {
         throw new Error(`No se pudo registrar el voto: ${response.status}`)
       }

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,79 @@
+/**
+ * Rate limiter en memoria con ventana deslizante, pensado para frenar el abuso
+ * de un usuario autenticado que envíe peticiones en bucle (p. ej. votos en
+ * /api/predictions).
+ *
+ * Guarda, por clave (normalmente el userId), las marcas de tiempo de las
+ * peticiones recientes y solo cuenta las que caen dentro de la ventana. Es
+ * deliberadamente sencillo y sin dependencias.
+ *
+ * Limitación conocida: en un despliegue serverless el estado vive en cada
+ * instancia, así que el límite es por instancia, no global. Aun así mitiga muy
+ * bien el caso real (las ráfagas de un mismo cliente suelen reutilizar la misma
+ * instancia caliente). Si en el futuro hace falta un límite global y exacto,
+ * el sitio natural para migrar es a un store compartido (Redis/Upstash) detrás
+ * de esta misma interfaz.
+ */
+
+export interface RateLimitOptions {
+  /** Peticiones permitidas dentro de la ventana. */
+  limit: number
+  /** Tamaño de la ventana en milisegundos. */
+  windowMs: number
+}
+
+export interface RateLimitResult {
+  /** `true` si la petición está dentro del límite. */
+  allowed: boolean
+  /** Peticiones que aún se pueden hacer en la ventana actual. */
+  remaining: number
+  /** Segundos hasta que se libere un hueco (0 cuando `allowed` es `true`). */
+  retryAfter: number
+}
+
+const hitsByKey = new Map<string, number[]>()
+
+// Evita que el Map crezca sin control con claves que ya no tienen peticiones
+// vivas: cada cierto tiempo barremos las entradas caducadas.
+let lastSweep = Date.now()
+
+function sweepExpired(now: number, windowMs: number): void {
+  if (now - lastSweep < windowMs) return
+  lastSweep = now
+
+  for (const [key, timestamps] of hitsByKey) {
+    const fresh = timestamps.filter((timestamp) => timestamp > now - windowMs)
+    if (fresh.length === 0) {
+      hitsByKey.delete(key)
+    } else {
+      hitsByKey.set(key, fresh)
+    }
+  }
+}
+
+/**
+ * Registra una petición para `key` y dice si está dentro del límite.
+ *
+ * Cada llamada consume un hueco cuando se permite; las peticiones bloqueadas no
+ * cuentan para no extender la ventana de forma indefinida ante un bucle.
+ */
+export function rateLimit(key: string, { limit, windowMs }: RateLimitOptions): RateLimitResult {
+  const now = Date.now()
+  sweepExpired(now, windowMs)
+
+  const windowStart = now - windowMs
+  const recentHits = (hitsByKey.get(key) ?? []).filter((timestamp) => timestamp > windowStart)
+
+  if (recentHits.length >= limit) {
+    hitsByKey.set(key, recentHits)
+    const oldestHit = recentHits[0]
+    const retryAfter = Math.max(1, Math.ceil((oldestHit + windowMs - now) / 1000))
+
+    return { allowed: false, remaining: 0, retryAfter }
+  }
+
+  recentHits.push(now)
+  hitsByKey.set(key, recentHits)
+
+  return { allowed: true, remaining: limit - recentHits.length, retryAfter: 0 }
+}

--- a/src/pages/api/predictions.ts
+++ b/src/pages/api/predictions.ts
@@ -6,15 +6,21 @@ import {
   PredictionDataError,
   registerVote,
 } from '@/lib/predictions'
+import { rateLimit } from '@/lib/rate-limit'
 import type { APIRoute } from 'astro'
 
 export const prerender = false
 
-function json(data: unknown, status = 200) {
+// Un usuario honesto pronostica 10 combates y rara vez cambia de opinión más de
+// un par de veces; 20 votos por minuto deja margen de sobra y corta los bucles.
+const VOTE_RATE_LIMIT = { limit: 20, windowMs: 60_000 }
+
+function json(data: unknown, status = 200, headers: Record<string, string> = {}) {
   return new Response(JSON.stringify(data), {
     status,
     headers: {
       'Content-Type': 'application/json',
+      ...headers,
     },
   })
 }
@@ -64,6 +70,16 @@ export const POST: APIRoute = async ({ request }) => {
 
     if (!userId) {
       return json({ error: 'Usuario no autenticado' }, 401)
+    }
+
+    const { allowed, retryAfter } = rateLimit(`predictions:${userId}`, VOTE_RATE_LIMIT)
+
+    if (!allowed) {
+      return json(
+        { error: 'Demasiados votos en poco tiempo. Espera unos segundos e inténtalo de nuevo.' },
+        429,
+        { 'Retry-After': String(retryAfter) },
+      )
     }
 
     const body = await request.json().catch(() => null)


### PR DESCRIPTION
## Qué problema resuelve

El endpoint `POST /api/predictions` ya exige sesión, así que el abuso anónimo estaba cubierto. Pero un usuario **autenticado** podía mandar votos en bucle sin ningún freno.

Y cada voto no es gratis: por debajo asegura las filas del combate, hace un `upsert` en `user_votes` y lanza un `UPDATE` que recuenta los votos con una subconsulta. Un bucle de votos genera muchas escrituras innecesarias en la base de datos y puede provocar condiciones de carrera en ese recálculo.

## Cómo lo he resuelto

He añadido un limitador en memoria con ventana deslizante (nuevo módulo `src/lib/rate-limit.ts`) y lo he aplicado al `POST`:

- **20 votos por minuto y por usuario.** Un votante honesto pronostica los 10 combates y cambia de idea un par de veces como mucho, así que el margen sobra. Pasado el límite, el servidor responde **429** con la cabecera `Retry-After`.
- En el **cliente**, el controlador de votos ya revertía el voto optimista cuando la respuesta no era correcta. Ahora trata el 429 de forma explícita: deshace el voto y avisa al usuario (mensaje accesible vía `aria-live`) sin ensuciar la consola, porque es una respuesta esperable ante una ráfaga, no un error inesperado.

## Una nota honesta sobre el alcance

El limitador vive en memoria y es a propósito sencillo y sin dependencias nuevas (encaja con el patrón de caché en memoria que ya usa `predictions.ts`).

En serverless eso significa que el límite es **por instancia**, no global. Aun así mitiga muy bien el caso real que describía el issue: las ráfagas de un mismo cliente suelen reutilizar la instancia caliente. Si algún día hace falta un límite global y exacto, basta con mover el almacén a Redis/Upstash **detrás de esta misma interfaz**, sin tocar el endpoint.

Lo dejé documentado así porque me pareció más sincero que vender un límite "perfecto" que en serverless no lo sería.

## Contexto

Es el punto 2 del issue #1613. Va por separado del punto 3 (que ya estaba resuelto) y del endurecimiento de JSON-LD (PR #1633). El punto 1 (CSP) sigue pendiente.

## Cómo lo he probado

- Build de producción completo (`astro build`): compila sin errores.
- Test de la ventana deslizante sobre el módulo real: comprueba el límite, el bloqueo, el `Retry-After`, que cada usuario tiene su propio cupo y que la ventana se libera al expirar (13/13 OK).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas funciones**
  * Se incorporó un límite de frecuencia para los votos para evitar envíos demasiado rápidos.
  * Cuando se supera el límite, la app muestra un aviso e incluye un tiempo de espera antes de reintentar.

* **Correcciones**
  * Si un voto optimista falla por exceso de solicitudes (rate limit), ahora se revierte correctamente al estado anterior para mantener la interfaz sincronizada.
  * El usuario recibe una indicación inmediata cuando está votando demasiado rápido.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->