### PR TITLE
feat: compartir pronóstico con Web Share API nativa en móvil

### DIFF
--- a/src/components/PredictionShareModal.astro
+++ b/src/components/PredictionShareModal.astro
@@ -38,9 +38,43 @@ const { totalFights } = Astro.props
       ¡Hiciste tu pronóstico para la velada!
     </h2>
 
-    <p class="prediction-share-description animate-fade-in animate-delay-500">
+    <p
+      class="prediction-share-description animate-fade-in animate-delay-500"
+      data-share-description
+      data-total-fights={totalFights}
+    >
       Generamos una imagen con tus {totalFights} votos. Descárgala y compártela en X.
     </p>
+
+    <!-- Camino nativo (Web Share API nivel 2): imagen + texto en un solo toque.
+         Oculto por defecto; el script lo revela solo donde el navegador soporta
+         compartir ficheros (móvil moderno) y oculta el flujo de pasos. -->
+    <div class="prediction-share-native animate-fade-in-up animate-delay-700" data-native-share hidden>
+      <button
+        type="button"
+        class="prediction-share-pill prediction-share-pill-primary prediction-share-native-btn"
+        data-native-share-btn
+      >
+        <svg
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="2"
+          aria-hidden="true"
+        >
+          <circle cx="18" cy="5" r="3"></circle>
+          <circle cx="6" cy="12" r="3"></circle>
+          <circle cx="18" cy="19" r="3"></circle>
+          <path d="M8.59 13.51l6.83 3.98M15.41 6.51l-6.82 3.98"></path>
+        </svg>
+        Compartir pronóstico
+      </button>
+      <p class="prediction-share-native-hint" data-native-share-hint>
+        Imagen y texto juntos, en un solo toque.
+      </p>
+    </div>
 
     <div class="prediction-share-steps" data-share-steps>
       <div
@@ -391,6 +425,32 @@ const { totalFights } = Astro.props
     gap: 1rem;
   }
 
+  .prediction-share-native {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+  }
+
+  .prediction-share-native[hidden] {
+    display: none;
+  }
+
+  .prediction-share-native-btn {
+    width: 100%;
+    padding: 0.85rem 1rem;
+    font-size: 0.72rem;
+  }
+
+  .prediction-share-native-hint {
+    margin: 0;
+    font-family: var(--font-fallback);
+    font-size: 0.78rem;
+    text-transform: none;
+    text-align: center;
+    color: color-mix(in srgb, var(--color-theme-cream) 62%, transparent);
+  }
+
   .prediction-share-step {
     position: relative;
     border-radius: var(--radius-sharp);
@@ -648,7 +708,14 @@ const { totalFights } = Astro.props
 
 <script>
   import { $, $$ } from '@/lib/dom-selector'
-  import { buildPredictionBlob, downloadBlob, openXIntent } from '@/lib/share-image'
+  import {
+    buildPredictionBlob,
+    canShareImageFile,
+    downloadBlob,
+    isShareAbort,
+    openXIntent,
+    shareImageFile,
+  } from '@/lib/share-image'
   import {
     PREDICTION_SHARE_OPEN_EVENT,
     PREDICTION_COMPLETE_EVENT,
@@ -669,6 +736,10 @@ const { totalFights } = Astro.props
     step2: HTMLElement | null
     content: HTMLElement | null
     attachmentLabel: HTMLElement | null
+    nativeShare: HTMLElement | null
+    nativeShareBtn: HTMLButtonElement | null
+    shareSteps: HTMLElement | null
+    description: HTMLElement | null
   }
 
   function collectRefs(modal: HTMLDialogElement): ModalRefs {
@@ -680,6 +751,10 @@ const { totalFights } = Astro.props
       step2: $<HTMLElement>('[data-step="2"]', modal),
       content: $<HTMLElement>('.prediction-share-content', modal),
       attachmentLabel: $<HTMLElement>('[data-attachment-label]', modal),
+      nativeShare: $<HTMLElement>('[data-native-share]', modal),
+      nativeShareBtn: $<HTMLButtonElement>('[data-native-share-btn]', modal),
+      shareSteps: $<HTMLElement>('[data-share-steps]', modal),
+      description: $<HTMLElement>('[data-share-description]', modal),
     }
   }
 
@@ -831,6 +906,39 @@ const { totalFights } = Astro.props
       }
     }
 
+    async function handleNativeShare() {
+      setBusy(refs.nativeShareBtn, true)
+      setStatus('Preparando para compartir...', 'info')
+      try {
+        const blob = await getImageBlob()
+        await shareImageFile(blob, FILE_NAME, SHARE_TEXT)
+        setStatus('¡Listo! Gracias por compartir tu pronóstico.', 'success')
+      } catch (err) {
+        // Cancelar la hoja de compartir no es un error: limpiamos el estado.
+        if (isShareAbort(err)) {
+          setStatus('', 'info')
+        } else {
+          setStatus('No se pudo compartir. Probá descargando la imagen.', 'error')
+          console.error(err)
+        }
+      } finally {
+        setBusy(refs.nativeShareBtn, false)
+      }
+    }
+
+    // En navegadores con Web Share API nivel 2 (móvil moderno) ofrecemos el
+    // camino de un solo toque y ocultamos el flujo manual de descarga + X.
+    function enableNativeShareIfSupported() {
+      if (!canShareImageFile()) return
+      refs.nativeShare?.removeAttribute('hidden')
+      if (refs.shareSteps) refs.shareSteps.hidden = true
+      if (refs.description) {
+        const totalFights = refs.description.dataset.totalFights ?? ''
+        const votos = totalFights ? `tus ${totalFights} votos` : 'tus votos'
+        refs.description.textContent = `Generamos una imagen con ${votos}. Compartila donde quieras en un solo toque.`
+      }
+    }
+
     function openModal() {
       if (modal?.open) return
       resetModalState()
@@ -843,6 +951,9 @@ const { totalFights } = Astro.props
     refs.downloadBtn?.addEventListener('click', () => void handleDownload())
     refs.copyBtn?.addEventListener('click', () => void handleCopy())
     refs.shareBtn?.addEventListener('click', handleShare)
+    refs.nativeShareBtn?.addEventListener('click', () => void handleNativeShare())
+
+    enableNativeShareIfSupported()
 
     document.addEventListener(PREDICTION_COMPLETE_EVENT, openModal)
     document.addEventListener(PREDICTION_SHARE_OPEN_EVENT, openModal)

--- a/src/lib/share-image.ts
+++ b/src/lib/share-image.ts
@@ -146,6 +146,47 @@ export function openXIntent(shareText: string): void {
   window.open(intentUrl, '_blank', 'noopener,noreferrer')
 }
 
+/**
+ * Comprueba si el navegador soporta compartir archivos con la Web Share API
+ * nivel 2 (`navigator.share` + `navigator.canShare({ files })`). Es el camino
+ * de un solo toque en móvil moderno: adjunta imagen + texto sin descargas
+ * manuales. Devuelve `false` en desktop o donde no haya soporte de ficheros.
+ */
+export function canShareImageFile(): boolean {
+  if (typeof navigator === 'undefined') return false
+  if (typeof navigator.share !== 'function' || typeof navigator.canShare !== 'function') {
+    return false
+  }
+  try {
+    const probe = new File([new Uint8Array()], FILE_PROBE_NAME, { type: 'image/png' })
+    return navigator.canShare({ files: [probe] })
+  } catch {
+    return false
+  }
+}
+
+const FILE_PROBE_NAME = 'probe.png'
+
+/**
+ * Comparte la imagen del pronóstico de forma nativa (Web Share API nivel 2).
+ * El llamador debe haber verificado el soporte con {@link canShareImageFile}.
+ * Si el usuario cancela la hoja de compartir, el navegador lanza un
+ * `AbortError`; el llamador debe tratarlo como cancelación, no como fallo.
+ */
+export async function shareImageFile(
+  blob: Blob,
+  fileName: string,
+  shareText: string,
+): Promise<void> {
+  const file = new File([blob], fileName, { type: 'image/png' })
+  await navigator.share({ files: [file], text: shareText })
+}
+
+/** True cuando el rechazo del share nativo proviene de que el usuario lo canceló. */
+export function isShareAbort(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError'
+}
+
 export async function buildPredictionBlob(userVotes: Record<string, string>): Promise<Blob> {
   const canvas = await buildPredictionCanvas(userVotes)
   return canvasToBlob(canvas)


### PR DESCRIPTION
## Contexto

Resuelve el issue #1615. El modal de compartir pronóstico exigía en móvil un flujo de fricción: **descargar imagen → abrir X → adjuntar a mano**. Como el grueso del tráfico es móvil, esto produce abandono.

## Cambios

- **`src/lib/share-image.ts`** — utilidades nuevas:
  - `canShareImageFile()`: detecta soporte real de Web Share API nivel 2 con un `File` de prueba (`navigator.canShare({ files })`); seguro en SSR/desktop.
  - `shareImageFile(blob, fileName, shareText)`: comparte imagen + texto en un toque con `navigator.share({ files, text })`.
  - `isShareAbort(error)`: distingue la cancelación del usuario (`AbortError`) de un fallo real.
- **`src/components/PredictionShareModal.astro`**:
  - Botón nativo "Compartir pronóstico" (oculto por defecto), con CSS alineado al sistema de diseño.
  - `enableNativeShareIfSupported()` revela el botón nativo **solo** donde hay soporte, oculta el flujo de pasos y adapta el texto descriptivo (conserva el conteo de votos vía `data-total-fights`).
  - `handleNativeShare()` reusa el blob cacheado y trata la cancelación como no-error.

## Comportamiento

- **Móvil moderno:** un toque → adjunta imagen + texto.
- **Desktop / sin soporte:** flujo actual intacto (descargar / copiar + abrir X) como fallback.

## Test plan

- [x] ESLint limpio en el `.astro`.
- [x] `tsc --noEmit --strict` limpio en `share-image.ts`.
- [ ] Probar en móvil real (Android/iOS): el botón nativo aparece y comparte imagen + texto.
- [ ] Probar en desktop: se mantiene el flujo de pasos (descargar/copiar + abrir X).
- [ ] Cancelar la hoja de compartir no muestra error.

Closes #1615


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funciones**
  * Se habilitó el compartido nativo de pronósticos en navegadores compatibles, con una experiencia más rápida en móvil.
  * Se añadió un límite de uso para evitar envíos demasiado frecuentes de votos.

* **Mejoras**
  * El flujo de voto ahora informa cuando se supera el ritmo permitido y revierte cambios temporales para mantener el estado correcto.
  * La respuesta de la API incluye indicaciones para reintentar más tarde cuando se alcanza el límite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->