### PR TITLE
[BUG] Solves bug when loading CSS logic for Maps

### DIFF
--- a/src/sections/Map.astro
+++ b/src/sections/Map.astro
@@ -307,7 +307,6 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
 
   let mapInstance: any = null
   let mapObserver: IntersectionObserver | null = null
-  let leafletCssLoaded = false
   let mapContainer: HTMLElement | null = null
   let onMapMouseEnter: (() => void) | null = null
   let onMapMouseLeave: (() => void) | null = null
@@ -315,9 +314,6 @@ const VENUE_WEB_MAP_URL = `https://www.google.com/maps/search/?api=1&query=${VEN
   // El CSS de Leaflet se inyecta solo cuando el mapa va a inicializarse, en
   // lugar de bloquear el render de la página entera desde el <head>.
   function loadLeafletCss() {
-    if (leafletCssLoaded) return
-    leafletCssLoaded = true
-
     const link = document.createElement('link')
     link.rel = 'stylesheet'
     link.href = 'https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'


### PR DESCRIPTION
Remove conditional check for loading Leaflet CSS. It is already loaded by IntersectionObserver

## Type

<!-- Select exactly one. -->

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Changes

<!-- List each file changed with a one-line description. -->

- `src/sections/Map.astro`: removed leafletCssLoaded variable and validation

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added:
- Removed:

## Screenshots

### Issue details:
When user:
1. Goes to https://www.infolavelada.com/
2. Scrolls to Maps section.
3. Goes (tap or click) to another path e.g. Combates (menu navbar)
4. Press go back or returns:

Then:
- The map does not load properly


https://github.com/user-attachments/assets/0eeae1cf-c21c-47ba-bddc-a184637ea043


## Checklist

- [ ] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [ ] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Se mejoró la carga de estilos del mapa para que se aplique de forma más consistente al mostrar esta sección.
  * Se ajustó la inicialización interna del mapa para evitar problemas al interactuar con él.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->