### PR TITLE
Cambiar id por slug del artista en la página de detail

### DIFF
--- a/src/components/ArtistNextCard.astro
+++ b/src/components/ArtistNextCard.astro
@@ -30,7 +30,7 @@ const cardClass =
       // única presente, para que el hueco de la derecha quede vacío en vez de
       // recolocarse al centro.
       <a
-        href={`/artistas/${prevArtist.id}`}
+        href={`/artistas/${prevArtist.slug}`}
         class:list={[cardClass, 'sm:col-start-1']}
         aria-label={`Ver la ficha de ${prevArtist.name}, artista anterior`}
       >
@@ -59,7 +59,7 @@ const cardClass =
       // única presente, para que el hueco de la izquierda quede vacío en vez
       // de recolocarse al centro.
       <a
-        href={`/artistas/${nextArtist.id}`}
+        href={`/artistas/${nextArtist.slug}`}
         class:list={[cardClass, 'sm:col-start-2']}
         aria-label={`Ver la ficha de ${nextArtist.name}, siguiente artista`}
       >

--- a/src/consts/artists.ts
+++ b/src/consts/artists.ts
@@ -9,6 +9,7 @@ import AnuelAAImage from '@/assets/artists/anuel-aa.webp'
 export const ARTISTS: Artist[] = [
   {
     id: '0eHQ9o50hj6ZDNBt6Ys1sD',
+    slug: 'yandel',
     name: 'Yandel',
     image: YandelImage,
     followers: 24_562_821,
@@ -50,6 +51,7 @@ export const ARTISTS: Artist[] = [
   },
   {
     id: '0UWZUmn7sybxMCqrw9tGa7',
+    slug: 'juanes',
     name: 'Juanes',
     image: JuanesImage,
     followers: 20_114_452,
@@ -93,6 +95,7 @@ export const ARTISTS: Artist[] = [
     // Dúo: id compuesto (uno por cada miembro) para poder enlazar a una
     // única ficha; seguidores sumados y popularidad media de ambos.
     id: ['1y6tVxTqgNfqxTayfohSKJ', '0IEzMvarfVycBJAXjjEZOL'].join('-'),
+    slug: 'lucho-rk-la-pantera',
     name: 'Lucho Rk & La Pantera',
     image: LuchoRkLaPanteraImage,
     followers: 332_320,
@@ -135,6 +138,7 @@ export const ARTISTS: Artist[] = [
   },
   {
     id: '4F4pp8NUW08JuXwnoxglpN',
+    slug: 'bad-gyal',
     name: 'Bad Gyal',
     image: BadGyalImage,
     followers: 13_381_846,
@@ -176,6 +180,7 @@ export const ARTISTS: Artist[] = [
   },
   {
     id: '2R21vXR83lH98kGeO99Y66',
+    slug: 'anuel-aa',
     name: 'Anuel AA',
     image: AnuelAAImage,
     followers: 43_957_388,

--- a/src/pages/artistas.astro
+++ b/src/pages/artistas.astro
@@ -73,7 +73,7 @@ const musicEventJsonLd = {
     performer: ARTISTS.map((artist, index) => ({
     '@type': 'MusicGroup',
     name: artist.name,
-    url: `${SITE_URL}/artistas/${artist.id}`,
+    url: `${SITE_URL}/artistas/${artist.slug}`,
     image: `${SITE_URL}${artistImages[index].src}`,
     genre: artist.genres,
     sameAs: artist.spotifyLinks.map((link) => link.url),
@@ -140,7 +140,7 @@ const musicEventJsonLd = {
                 style={`animation-delay: ${index * 45}ms`}
             >
                 <a
-                    href={`/artistas/${artist.id}`}
+                    href={`/artistas/${artist.slug}`}
                     aria-label={`Ver la ficha de ${artist.name}`}
                     class="group relative block aspect-[4/5] w-full outline-offset-4 focus-visible:outline-2 focus-visible:outline-theme-gold sm:aspect-[3/4]"
                 >

--- a/src/pages/artistas/[id].astro
+++ b/src/pages/artistas/[id].astro
@@ -17,11 +17,13 @@ import { serializeJsonLd } from '@/utils/serialize-json-ld'
 
 export const prerender = true
 
+// Cada artista es accesible tanto por su id de Spotify (compatibilidad con
+// enlaces existentes) como por un slug legible (p. ej. "anuel-aa").
 export const getStaticPaths = (() => {
-  return ARTISTS.map((artist) => ({
-    params: { id: artist.id },
-    props: { artistId: artist.id },
-  }))
+  return ARTISTS.flatMap((artist) => [
+    { params: { id: artist.id }, props: { artistId: artist.id } },
+    { params: { id: artist.slug }, props: { artistId: artist.slug } },
+  ])
 }) satisfies GetStaticPaths
 
 interface Props {
@@ -29,7 +31,7 @@ interface Props {
 }
 
 const { artistId } = Astro.props
-const artist = ARTISTS.find((a) => a.id === artistId)
+const artist = ARTISTS.find((a) => a.id === artistId || a.slug === artistId)
 
 if (!artist) return Astro.redirect('/404')
 
@@ -46,7 +48,7 @@ const nextArtist = currentIndex < ARTISTS.length - 1 ? ARTISTS[currentIndex + 1]
 const hasArtistNav = prevArtist !== null || nextArtist !== null
 
 const SITE_URL = 'https://www.infolavelada.com'
-const canonical = `${SITE_URL}/artistas/${artist.id}`
+const canonical = `${SITE_URL}/artistas/${artist.slug}`
 const title = `${artist.name} | Artistas de La Velada del Año VI`
 const description = isGroup
   ? `Conoce a ${artist.name}, parte del cartel musical de La Velada del Año VI, el evento de boxeo de Ibai Llanos en Sevilla el 25 de julio de 2026.`

--- a/src/types/artists.ts
+++ b/src/types/artists.ts
@@ -17,6 +17,8 @@ export interface ArtistSpotifyLink {
 
 export interface Artist {
   id: string
+  /** Slug legible usado en la URL (p. ej. "anuel-aa"), alternativo al id de Spotify. */
+  slug: string
   name: string
   image: ImageMetadata
   /** Seguidores (agregados si es un dúo/grupo). */


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

<!-- List each file changed with a one-line description. -->

- `src/types/artists.ts`: añadido el campo `slug` a la interfaz `Artist`
- `src/consts/artists.ts`: añadido un `slug` legible (p. ej. `anuel-aa`) a cada artista
- `src/pages/artistas/[id].astro`: `getStaticPaths` genera ahora una ruta por id de Spotify y otra por slug para cada artista; la búsqueda del artista acepta cualquiera de los dos; la URL canónica pasa a usar el slug
- `src/pages/artistas.astro`: los enlaces de las tarjetas de artista y las URLs del JSON-LD usan `artist.slug` en vez de `artist.id`
- `src/components/ArtistNextCard.astro`: los enlaces de navegación anterior/siguiente usan `artist.slug`

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added: None
- Removed: None

## Checklist

- [ ] Tested on mobile (<768px)
- [ ] Tested on desktop (≥1024px)
- [ ] No console errors
- [ ] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->

None. Las URLs `/artistas/{spotifyId}` existentes se siguen generando y funcionando; el slug es una vía de acceso adicional, no un reemplazo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funciones**
  * Se añadieron URLs más legibles para artistas, usando *slugs* en lugar de identificadores numéricos.
  * Ahora los perfiles de artistas se pueden abrir tanto por su ID como por su nombre en la URL.

* **Mejoras**
  * Los enlaces de navegación entre artista anterior/siguiente ahora apuntan a rutas más claras.
  * El listado de artistas y sus metadatos públicos también usan las nuevas rutas legibles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->