### PR TITLE
Artist astro transition

### DIFF
--- a/src/components/ArtistNextCard.astro
+++ b/src/components/ArtistNextCard.astro
@@ -35,7 +35,14 @@ const cardClass =
         aria-label={`Ver la ficha de ${prevArtist.name}, artista anterior`}
       >
         <span class="relative size-11 shrink-0 overflow-hidden rounded-full ring-1 ring-inset ring-theme-gold/30 sm:size-12">
-          <Image src={prevArtist.image} alt="" class="size-full object-cover" loading="lazy" decoding="async" />
+          <Image
+            src={prevArtist.image}
+            alt=""
+            class="size-full object-cover"
+            loading="lazy"
+            decoding="async"
+            transition:name={`artist-hero-${prevArtist.id}`}
+          />
         </span>
         <span class="flex min-w-0 flex-1 flex-col gap-[0.1rem]">
           <span class="font-cinzel text-[0.5rem] font-black tracking-[0.16em] text-theme-cream/55 uppercase">
@@ -64,7 +71,14 @@ const cardClass =
         aria-label={`Ver la ficha de ${nextArtist.name}, siguiente artista`}
       >
         <span class="relative size-11 shrink-0 overflow-hidden rounded-full ring-1 ring-inset ring-theme-gold/30 sm:size-12">
-          <Image src={nextArtist.image} alt="" class="size-full object-cover" loading="lazy" decoding="async" />
+          <Image
+            src={nextArtist.image}
+            alt=""
+            class="size-full object-cover"
+            loading="lazy"
+            decoding="async"
+            transition:name={`artist-hero-${nextArtist.id}`}
+          />
         </span>
         <span class="flex min-w-0 flex-1 flex-col gap-[0.1rem]">
           <span class="font-cinzel text-[0.5rem] font-black tracking-[0.16em] text-theme-cream/55 uppercase">

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -173,6 +173,14 @@ const organizationJsonLd = {
       const COMBATS_INDEX_PATH = '/combates'
       const BOXER_DETAIL_PATH_RE = /^\/boxeadores\/[^/]+$/
 
+      // Mismo mecanismo que los boxeadores, pero para la ficha de artista:
+      // su imagen comparte `transition:name="artist-hero-*"` con la card del
+      // listado, y sin este flag la card recibiría a la vez el morph de la
+      // view transition y su animación de entrada `animate-fade-in-up`.
+      const SKIP_ARTISTS_ENTER_ATTR = 'data-skip-artists-enter'
+      const ARTISTS_INDEX_PATH = '/artistas'
+      const ARTIST_DETAIL_PATH_RE = /^\/artistas\/[^/]+$/
+
       // Imágenes que comparten `transition:name="boxer-hero-*"` entre páginas:
       // los recortes de los combates y las tarjetas del listado de boxeadores.
       const SHARED_HERO_SELECTOR = '.boxer-pic, .boxer-card-img'
@@ -188,6 +196,13 @@ const organizationJsonLd = {
         const toPath = getNormalizedPathname(event.to)
 
         return toPath === BOXERS_INDEX_PATH && BOXER_DETAIL_PATH_RE.test(fromPath)
+      }
+
+      const isReturningFromArtistDetail = (event: AstroNavigationEvent) => {
+        const fromPath = getNormalizedPathname(event.from)
+        const toPath = getNormalizedPathname(event.to)
+
+        return toPath === ARTISTS_INDEX_PATH && ARTIST_DETAIL_PATH_RE.test(fromPath)
       }
 
       // Navegación directa entre los dos listados (combates ↔ boxeadores). Ahí
@@ -222,10 +237,15 @@ const organizationJsonLd = {
       document.addEventListener('astro:before-swap', (event) => {
         const transitionEvent = event as AstroBeforeSwapEvent
         const shouldSkipBoxersEnter = isReturningFromBoxerDetail(transitionEvent)
+        const shouldSkipArtistsEnter = isReturningFromArtistDetail(transitionEvent)
 
         transitionEvent.newDocument.documentElement.toggleAttribute(
           SKIP_BOXERS_ENTER_ATTR,
           shouldSkipBoxersEnter,
+        )
+        transitionEvent.newDocument.documentElement.toggleAttribute(
+          SKIP_ARTISTS_ENTER_ATTR,
+          shouldSkipArtistsEnter,
         )
 
         // Y la página entrante se limpia antes de capturar el snapshot «nuevo».

--- a/src/pages/artistas.astro
+++ b/src/pages/artistas.astro
@@ -153,6 +153,7 @@ const musicEventJsonLd = {
                     alt=""
                     loading="lazy"
                     decoding="async"
+                    transition:name={`artist-hero-${artist.id}`}
                     class="absolute inset-0 size-full object-cover"
                     />
                     <span

--- a/src/pages/artistas.astro
+++ b/src/pages/artistas.astro
@@ -198,4 +198,18 @@ const musicEventJsonLd = {
     filter: saturate(1.08) brightness(1.05);
   }
 }
+
+/*
+  Al volver desde la ficha de un artista, la imagen ya está haciendo la
+  view transition de morph (misma `transition:name`); si además le
+  aplicásemos la animación de entrada `animate-fade-in-up` quedaría un
+  doble movimiento (la card "cae" mientras la imagen todavía está
+  volando a su sitio). `Layout.astro` marca este atributo en el
+  `<html>` entrante durante `astro:before-swap` cuando detecta que
+  venimos de `/artistas/[slug]` hacia `/artistas`.
+*/
+html[data-skip-artists-enter] .artist-card-wrap {
+  animation: none;
+  opacity: 1;
+}
 </style>

--- a/src/pages/artistas/[id].astro
+++ b/src/pages/artistas/[id].astro
@@ -158,6 +158,7 @@ const breadcrumbJsonLd = {
               loading="eager"
               fetchpriority="high"
               decoding="async"
+              transition:name={`artist-hero-${artist.id}`}
             />
             <span class="absolute top-3 left-3 z-[2] size-5 border-2 border-r-0 border-b-0 border-theme-gold/75" />
             <span class="absolute top-3 right-3 z-[2] size-5 border-2 border-b-0 border-l-0 border-theme-gold/75" />


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

<!-- List each file changed with a one-line description. -->

Include an artist asro transition between artist page and artist detail page

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added:
- Removed:

## Screenshots

<!-- Delete if not applicable. -->

| View | Before | After |
|------|--------|-------|
| Mobile | | |
| Desktop | | |

## Checklist

- [ ] Tested on mobile (<768px)
- [ ] Tested on desktop (≥1024px)
- [ ] No console errors
- [ ] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Se mejoran las transiciones visuales entre el listado de artistas y la ficha de cada artista, con animaciones mejor identificadas y más consistentes en las imágenes.
  * Las tarjetas anterior/siguiente y la portada del artista ahora participan en transiciones con nombres dinámicos basados en el artista.

* **Bug Fixes**
  * Se evita un doble movimiento al volver desde una ficha de artista al listado.
  * Al regresar a la vista de artistas, la animación de entrada se desactiva para una presentación más estable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->