### PR TITLE
Corrige el overflow en la página de artista

### DIFF
--- a/src/components/ArtistTopTracks.astro
+++ b/src/components/ArtistTopTracks.astro
@@ -11,7 +11,7 @@ interface Props {
 const { class: className, tracks } = Astro.props
 ---
 
-<div class:list={['w-[min(100%,34rem)]', className]}>
+<div class:list={['w-full sm:w-[min(100%,34rem)]', className]}>
   <p class="m-0 mb-[0.6rem] font-cinzel text-[0.65rem] font-black tracking-[0.2em] text-theme-cream/55">
     Canciones más populares
   </p>
@@ -37,11 +37,11 @@ const { class: className, tracks } = Astro.props
                 {track.album}
               </span>
             </span>
-            <span class="flex shrink-0 flex-col items-end gap-[0.1rem]">
+            <span class="flex min-w-0 shrink flex-col items-end gap-[0.1rem]">
               <span class="tabular-nums text-[0.75rem] text-theme-cream/60">
                 {formatTrackDuration(track.durationMs)}
               </span>
-              <span class="whitespace-nowrap tabular-nums text-[0.62rem] text-theme-cream/45">
+              <span class="overflow-hidden text-ellipsis whitespace-nowrap tabular-nums text-[0.62rem] text-theme-cream/45">
                 {formatTrackStreams(track.streams)} reproducciones
               </span>
             </span>

--- a/src/pages/artistas/[id].astro
+++ b/src/pages/artistas/[id].astro
@@ -142,7 +142,7 @@ const breadcrumbJsonLd = {
       </a>
 
       <div
-        class="artist-hero relative mt-8 grid items-start gap-10 sm:mt-10 md:grid-cols-[minmax(0,0.82fr)_minmax(0,1fr)] md:gap-10 lg:gap-14"
+        class="artist-hero relative mt-8 grid grid-cols-1 items-start gap-10 sm:mt-10 md:grid-cols-[minmax(0,0.82fr)_minmax(0,1fr)] md:gap-10 lg:gap-14"
       >
         {/*
           Sentinel invisible que marca dónde estaría el retrato si NO fuera


### PR DESCRIPTION
Si seleccionas desde la página de artistas Bad Gyal o Yandel, el contenido de las 2 primeras secciones (imagen y Escuchas/Redes) se sale del viewport en dispositivos como iPhone 17 pro, con el fix esta página vuelve al formato seguido con otros artistas

> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

<!-- Select exactly one. -->

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

<!-- List each file changed with a one-line description. -->

  - src/components/ArtistTopTracks.astro: Fix layout
  - src/pages/artistas/[id].astro: Fix layout

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added:
- Removed:

## Screenshots

<!-- Delete if not applicable. -->

| View | Before | After |
|------|--------|-------|
| Mobile | 
<img width="324" height="696" alt="image" src="https://github.com/user-attachments/assets/bf14ebdd-928b-4698-b555-30fc1082a840" />
|
<img width="313" height="692" alt="image" src="https://github.com/user-attachments/assets/5207529a-e4e4-401a-b672-5d52ab08364e" />
 |
| Desktop | 
<img width="1222" height="836" alt="image" src="https://github.com/user-attachments/assets/64bb1a87-309f-4300-90f4-e93883545639" />
| 
<img width="1296" height="848" alt="image" src="https://github.com/user-attachments/assets/070f2ca4-c73b-421f-8b1b-1d94bc09ba53" />
|

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mejoras**
  * Se ajustó la distribución visual en la página de artista para que el bloque principal use una estructura de una sola columna de forma consistente.
  * La sección de pistas destacadas ahora se adapta mejor a distintos tamaños de pantalla, ocupando todo el ancho en móviles y manteniendo un ancho cómodo en pantallas grandes.
  * También se mejoró el comportamiento de los elementos de duración y reproducciones para evitar desbordes en layouts más ajustados.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->