### PR TITLE
Update z-index of tow-fill class

### DIFF
--- a/src/components/PredictionOption.astro
+++ b/src/components/PredictionOption.astro
@@ -361,6 +361,7 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     );
   }
   .tow-side.b .tow-fill {
+    z-index: 3;
     right: 0;
     background: linear-gradient(
       270deg,


### PR DESCRIPTION
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

Tow fill is cut by the progess bar, now with this change tow-fill we can see fully and progress bar is under that bar

## Type

<!-- Select exactly one. -->

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

<!-- List each file changed with a one-line description. -->

- `src/components/PredictionOption.astro`: z-index to 3 in tow-fill class

## Dependencies

<!-- New or removed packages. "None" if not applicable. -->

- Added: None
- Removed: None

## Screenshots

<!-- Delete if not applicable. -->

| View | Before | After |
|------|--------|-------|
| Mobile | 
<img width="397" height="282" alt="image" src="https://github.com/user-attachments/assets/7dd5e9aa-fe8c-4824-8831-d479f3c47f01" />
 | 
<img width="387" height="296" alt="image" src="https://github.com/user-attachments/assets/6c6cf956-a577-4667-87d2-531c2811259e" />
 |
| Desktop | 
<img width="356" height="205" alt="image" src="https://github.com/user-attachments/assets/e1915825-69a9-472e-ba24-30576ea5f75a" />
 |  
<img width="396" height="204" alt="image" src="https://github.com/user-attachments/assets/35ccef23-7219-423e-9994-6967fb756f89" />
|

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

<!-- Removed props, renamed files, or API changes. "None" if not applicable. -->
