### PR TITLE
feat(videos): activa El Pesaje como vídeo principal

### DIFF
--- a/src/sections/Videos.astro
+++ b/src/sections/Videos.astro
@@ -12,14 +12,26 @@ interface Video {
   title: string
   videoId: string | null
   poster: {
-    avif: string
+    avif?: string
     webp: string
+    jpg?: string
   } | null
   active: boolean
   span: Span
 }
 
 const VIDEOS: Video[] = [
+  {
+    id: 'pesaje',
+    title: 'El Pesaje',
+    videoId: 'u8dSOKoNJp0',
+    poster: {
+      webp: 'https://i.ytimg.com/vi_webp/u8dSOKoNJp0/maxresdefault.webp',
+      jpg: 'https://i.ytimg.com/vi/u8dSOKoNJp0/maxresdefault.jpg',
+    },
+    active: true,
+    span: 'big',
+  },
   {
     id: 'cara-a-cara',
     title: 'Cara a Cara',
@@ -29,7 +41,7 @@ const VIDEOS: Video[] = [
       webp: 'https://cdn.infolavelada.com/videos/thumbnails/cara-a-cara.webp',
     },
     active: true,
-    span: 'big',
+    span: 'small',
   },
   {
     id: 'presentacion',
@@ -40,14 +52,6 @@ const VIDEOS: Video[] = [
       webp: 'https://cdn.infolavelada.com/videos/thumbnails/presentacion.webp',
     },
     active: true,
-    span: 'small',
-  },
-  {
-    id: 'pesaje',
-    title: 'El Pesaje',
-    videoId: null,
-    poster: null,
-    active: false,
     span: 'small',
   },
 ]
@@ -95,15 +99,20 @@ const SPAN_CLASSES: Record<Span, string> = {
             >
               {active && poster ? (
                 <picture class="absolute inset-0 -z-10 scale-105 brightness-90 transition duration-700 ease-out group-hover:scale-110 group-hover:brightness-110 group-focus-visible:scale-110 group-focus-visible:brightness-110">
-                  <source srcset={poster.avif} type="image/avif" />
+                  {poster.avif && <source srcset={poster.avif} type="image/avif" />}
                   <source srcset={poster.webp} type="image/webp" />
                   <img
-                    src={poster.webp}
+                    src={poster.jpg ?? poster.webp}
                     alt=""
                     aria-hidden="true"
                     loading="lazy"
                     decoding="async"
                     class="h-full w-full object-cover"
+                    data-img-fallback={
+                      poster.jpg
+                        ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
+                        : undefined
+                    }
                   />
                 </picture>
               ) : (

--- a/src/sections/Videos.astro
+++ b/src/sections/Videos.astro
@@ -13,7 +13,7 @@ interface Video {
   videoId: string | null
   poster: {
     avif?: string
-    webp: string
+    webp?: string
     jpg?: string
   } | null
   active: boolean
@@ -26,8 +26,7 @@ const VIDEOS: Video[] = [
     title: 'El Pesaje',
     videoId: 'u8dSOKoNJp0',
     poster: {
-      webp: 'https://i.ytimg.com/vi_webp/u8dSOKoNJp0/maxresdefault.webp',
-      jpg: 'https://i.ytimg.com/vi/u8dSOKoNJp0/maxresdefault.jpg',
+      jpg: 'https://img.youtube.com/vi/u8dSOKoNJp0/maxresdefault.jpg',
     },
     active: true,
     span: 'big',
@@ -100,17 +99,17 @@ const SPAN_CLASSES: Record<Span, string> = {
               {active && poster ? (
                 <picture class="absolute inset-0 -z-10 scale-105 brightness-90 transition duration-700 ease-out group-hover:scale-110 group-hover:brightness-110 group-focus-visible:scale-110 group-focus-visible:brightness-110">
                   {poster.avif && <source srcset={poster.avif} type="image/avif" />}
-                  <source srcset={poster.webp} type="image/webp" />
+                  {poster.webp && <source srcset={poster.webp} type="image/webp" />}
                   <img
-                    src={poster.jpg ?? poster.webp}
+                    src={poster.jpg ?? poster.webp ?? poster.avif}
                     alt=""
                     aria-hidden="true"
                     loading="lazy"
                     decoding="async"
                     class="h-full w-full object-cover"
                     data-img-fallback={
-                      poster.jpg
-                        ? `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`
+                      poster.jpg && videoId
+                        ? `https://img.youtube.com/vi/${videoId}/hqdefault.jpg`
                         : undefined
                     }
                   />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

- `src/sections/Videos.astro`: activa el vídeo de El Pesaje (`u8dSOKoNJp0`), lo coloca como tile grande por ser el más reciente, degrada Cara a Cara a tamaño pequeño y usa la portada `https://img.youtube.com/vi/u8dSOKoNJp0/maxresdefault.jpg`.

## Dependencies

- Added: None
- Removed: None

## Screenshots

Pendiente de revisión visual en preview.

## Checklist

- [ ] Tested on mobile (<768px)
- [ ] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a0e-e9ad-74ea-be68-9795eb7b6e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a0e-e9ad-74ea-be68-9795eb7b6e46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

