### PR TITLE
fix(live): evita pantalla blanca en iOS diferiendo el iframe de YouTube

### DIFF
--- a/src/sections/LiveStream.astro
+++ b/src/sections/LiveStream.astro
@@ -1,4 +1,6 @@
 ---
+import PlayIcon from '@/assets/svg/play.svg'
+
 /** ID del directo de YouTube (https://www.youtube.com/live/IskkmNPJdUk). */
 const LIVE_VIDEO_ID = 'IskkmNPJdUk'
 
@@ -7,6 +9,9 @@ embedSrc.searchParams.set('autoplay', '1')
 embedSrc.searchParams.set('mute', '1')
 embedSrc.searchParams.set('playsinline', '1')
 embedSrc.searchParams.set('rel', '0')
+
+const posterJpg = `https://i.ytimg.com/vi/${LIVE_VIDEO_ID}/maxresdefault.jpg`
+const posterFallback = `https://i.ytimg.com/vi/${LIVE_VIDEO_ID}/hqdefault.jpg`
 ---
 
 <section
@@ -29,20 +34,104 @@ embedSrc.searchParams.set('rel', '0')
       </h2>
     </div>
 
-    <!-- Contenedor con ratio fijo: evita CLS y mantiene el embed responsivo. -->
+    <!--
+      Contenedor con ratio fijo: evita CLS.
+      El iframe NO va en el HTML inicial: un YouTube autoplay eager arriba del
+      todo compite con el resto de la home (CSS, hero, roster) y en móviles
+      con poca memoria puede dejar la pestaña en blanco / colgada.
+      Montamos el embed tras el primer pintado (o al pulsar), y lo persistimos
+      en view transitions para no capturar un snapshot vacío del iframe.
+    -->
     <div
       class="relative aspect-video w-full overflow-hidden rounded-xl border border-white/10 bg-black shadow-[0_18px_60px_-24px_rgba(0,0,0,0.85)]"
+      data-live-root
+      data-embed-src={embedSrc.toString()}
+      transition:persist="live-stream"
     >
-      <iframe
-        src={embedSrc.toString()}
-        title="La Velada del Año VI en directo en YouTube"
-        class="absolute inset-0 h-full w-full border-0"
-        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
-        allowfullscreen
-        loading="eager"
-        referrerpolicy="strict-origin-when-cross-origin"
+      <button
+        type="button"
+        data-live-facade
+        class="group absolute inset-0 flex items-center justify-center outline-none focus-visible:ring-2 focus-visible:ring-theme-gold/70 focus-visible:ring-offset-2 focus-visible:ring-offset-black"
+        aria-label="Reproducir el directo de La Velada del Año VI en YouTube"
       >
-      </iframe>
+        <img
+          src={posterJpg}
+          data-img-fallback={posterFallback}
+          alt=""
+          role="presentation"
+          class="absolute inset-0 h-full w-full object-cover opacity-80 transition duration-300 group-hover:opacity-90 group-hover:saturate-110"
+          decoding="async"
+          fetchpriority="high"
+        />
+        <span
+          class="relative z-10 inline-flex size-16 items-center justify-center rounded-full border border-white/25 bg-black/55 text-theme-cream shadow-[0_10px_40px_rgba(0,0,0,0.55)] backdrop-blur-sm transition duration-300 group-hover:scale-105 group-hover:border-theme-gold/50 group-hover:bg-theme-midnight/80 sm:size-20"
+          aria-hidden="true"
+        >
+          <PlayIcon class="ml-0.5 size-7 sm:size-8" />
+        </span>
+      </button>
+
+      <noscript>
+        <iframe
+          src={embedSrc.toString()}
+          title="La Velada del Año VI en directo en YouTube"
+          class="absolute inset-0 h-full w-full border-0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen"
+          allowfullscreen
+          referrerpolicy="strict-origin-when-cross-origin"
+        >
+        </iframe>
+      </noscript>
     </div>
   </div>
 </section>
+
+<script>
+  import { $ } from '@/lib/dom-selector'
+
+  function mountLiveIframe(root: HTMLElement) {
+    if ($('iframe', root)) return
+
+    const src = root.dataset.embedSrc
+    if (!src) return
+
+    const iframe = document.createElement('iframe')
+    iframe.src = src
+    iframe.title = 'La Velada del Año VI en directo en YouTube'
+    iframe.className = 'absolute inset-0 h-full w-full border-0'
+    iframe.allow =
+      'accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; fullscreen'
+    iframe.setAttribute('allowfullscreen', '')
+    iframe.setAttribute('referrerpolicy', 'strict-origin-when-cross-origin')
+
+    root.replaceChildren(iframe)
+  }
+
+  function initLiveStream() {
+    const root = $<HTMLElement>('[data-live-root]')
+    if (!root) return
+
+    // Ya montado (p. ej. tras `transition:persist` al volver a la home).
+    if ($('iframe', root)) return
+
+    const facade = $<HTMLButtonElement>('[data-live-facade]', root)
+    facade?.addEventListener('click', () => mountLiveIframe(root), { once: true })
+
+    // Dos rAF: espera al primer pintado. Luego idle (con tope) para no
+    // aplastar el LCP del hero si el hilo principal sigue ocupado.
+    const scheduleIdle =
+      (
+        window as Window & {
+          requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number
+        }
+      ).requestIdleCallback ?? ((cb: () => void) => window.setTimeout(cb, 1))
+
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        scheduleIdle(() => mountLiveIframe(root), { timeout: 1200 })
+      })
+    })
+  }
+
+  document.addEventListener('astro:page-load', initLiveStream)
+</script>

--- a/src/sections/LiveStream.astro
+++ b/src/sections/LiveStream.astro
@@ -36,11 +36,10 @@ const posterFallback = `https://i.ytimg.com/vi/${LIVE_VIDEO_ID}/hqdefault.jpg`
 
     <!--
       Contenedor con ratio fijo: evita CLS.
-      El iframe NO va en el HTML inicial: un YouTube autoplay eager arriba del
-      todo compite con el resto de la home (CSS, hero, roster) y en móviles
-      con poca memoria puede dejar la pestaña en blanco / colgada.
-      Montamos el embed tras el primer pintado (o al pulsar), y lo persistimos
-      en view transitions para no capturar un snapshot vacío del iframe.
+      Nunca metemos el iframe de YouTube en el HTML inicial ni lo autoinyectamos:
+      en iPhone (sobre todo con Low Power Mode) el player autoplay arriba de la
+      home puede tumbar WebKit y dejar la pestaña en blanco. Solo se monta al
+      pulsar; `transition:persist` evita snapshots vacíos con ClientRouter.
     -->
     <div
       class="relative aspect-video w-full overflow-hidden rounded-xl border border-white/10 bg-black shadow-[0_18px_60px_-24px_rgba(0,0,0,0.85)]"
@@ -61,7 +60,7 @@ const posterFallback = `https://i.ytimg.com/vi/${LIVE_VIDEO_ID}/hqdefault.jpg`
           role="presentation"
           class="absolute inset-0 h-full w-full object-cover opacity-80 transition duration-300 group-hover:opacity-90 group-hover:saturate-110"
           decoding="async"
-          fetchpriority="high"
+          fetchpriority="low"
         />
         <span
           class="relative z-10 inline-flex size-16 items-center justify-center rounded-full border border-white/25 bg-black/55 text-theme-cream shadow-[0_10px_40px_rgba(0,0,0,0.55)] backdrop-blur-sm transition duration-300 group-hover:scale-105 group-hover:border-theme-gold/50 group-hover:bg-theme-midnight/80 sm:size-20"
@@ -116,21 +115,6 @@ const posterFallback = `https://i.ytimg.com/vi/${LIVE_VIDEO_ID}/hqdefault.jpg`
 
     const facade = $<HTMLButtonElement>('[data-live-facade]', root)
     facade?.addEventListener('click', () => mountLiveIframe(root), { once: true })
-
-    // Dos rAF: espera al primer pintado. Luego idle (con tope) para no
-    // aplastar el LCP del hero si el hilo principal sigue ocupado.
-    const scheduleIdle =
-      (
-        window as Window & {
-          requestIdleCallback?: (cb: () => void, opts?: { timeout: number }) => number
-        }
-      ).requestIdleCallback ?? ((cb: () => void) => window.setTimeout(cb, 1))
-
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        scheduleIdle(() => mountLiveIframe(root), { timeout: 1200 })
-      })
-    })
   }
 
   document.addEventListener('astro:page-load', initLiveStream)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

N/A — reporte de pantalla totalmente blanca en iPhone al abrir `infolavelada.com` (Low Power Mode / Safari).

## Changes

- `src/sections/LiveStream.astro`: elimina el iframe autoplay del HTML inicial. Muestra un facade con poster + botón play; el embed de YouTube **solo se monta al pulsar**. Usa `transition:persist` para no romper ClientRouter y deja fallback `<noscript>`.

## Dependencies

- Added: None
- Removed: None

## Screenshots

| View | Before (prod, iframe eager) | After (facade, sin iframe) |
|------|--------|-------|
| Mobile | [Antes mobile](https://cursor.com/agents/bc-019f9a7a-0045-7fa0-895b-f18a843732b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-prod-mobile.png) | [Después mobile](https://cursor.com/agents/bc-019f9a7a-0045-7fa0-895b-f18a843732b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-facade-mobile.png) |
| Desktop | — | [Después desktop](https://cursor.com/agents/bc-019f9a7a-0045-7fa0-895b-f18a843732b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-facade-desktop.png) |

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None

## Why

En producción la home sirve un `<iframe youtube-nocookie autoplay>` arriba del todo, junto con ~444 KB de HTML y ~147 imágenes. En iPhone (sobre todo con Low Power Mode) ese player en el first load puede tumbar WebKit y dejar la pestaña **completamente blanca**.

Cargar el player solo tras el tap evita ese coste. Complementa #1665 (fondo crítico inline para no mostrar el blanco por defecto del navegador mientras llega el CSS).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a7a-0045-7fa0-895b-f18a843732b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a7a-0045-7fa0-895b-f18a843732b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

