### PR TITLE
fix(layout): fondo crítico inline para evitar flash blanco en iOS

### DIFF
--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -84,6 +84,17 @@ const organizationJsonLd = {
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    {/* Color de fondo crítico inline: el CSS completo (~150 KB) se descubre
+        tarde en el <head> (tras JSON-LD y scripts). Sin esto, iOS Safari
+        muestra el blanco por defecto del navegador hasta que llega la hoja
+        de estilos — y con la home pesada eso puede parecer “página en blanco”. */}
+    <style is:inline>
+      html,
+      body {
+        background: #0a1024;
+        color: #f4e4c9;
+      }
+    </style>
     <title>
       {title}
     </title>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Type

- [ ] feat
- [x] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

N/A — reporte de pantalla en blanco en iPhone (`infolavelada.com`).

## Changes

- `src/layouts/Layout.astro`: añade un `<style is:inline>` mínimo al inicio del `<head>` con `background: #0a1024` y color de texto de marca, para no depender del CSS completo (~150 KB) que se descubre tarde (tras JSON-LD y scripts).

## Dependencies

- Added: None
- Removed: None

## Screenshots

Cambio no visual del layout final (mismo color `#0a1024` que ya define `global.css`); solo elimina el flash/permanencia del blanco por defecto del navegador mientras carga la hoja de estilos.

## Checklist

- [x] Tested on mobile (<768px)
- [x] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None

## Why

En la home el HTML pesa ~444 KB y las hojas `/_astro/*.css` aparecen al final del `<head>`. Hasta que llegan, Safari muestra fondo blanco. En redes móviles / Low Power Mode eso se confunde con “página en blanco”. Este inline pinta el color de marca desde el primer byte de HTML.

Complementa #1664 (quitar el iframe autoplay de YouTube del first load).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a7a-0045-7fa0-895b-f18a843732b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a7a-0045-7fa0-895b-f18a843732b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

