### PR TITLE
perf(predictions): reduce timeouts bajo carga cortando hits a Turso

### DIFF
--- a/src/components/LivePrediction.astro
+++ b/src/components/LivePrediction.astro
@@ -324,7 +324,9 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     total_votes: number
   }
 
-  const REFRESH_MS = 15_000
+  // Alineado con s-maxage del CDN (~15s): no tiene sentido martillar origen
+  // más a menudo; con credentials:omit los polls reutilizan la respuesta edge.
+  const REFRESH_MS = 30_000
 
   let timer: number | null = null
   let abort: AbortController | null = null
@@ -375,7 +377,10 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     abort = controller
 
     try {
-      const response = await fetch('/api/predictions', { signal: controller.signal })
+      const response = await fetch('/api/predictions', {
+        signal: controller.signal,
+        credentials: 'omit',
+      })
       if (!response.ok) return
 
       const data = (await response.json()) as { predictions?: ApiCombat[] }

--- a/src/components/PredictionVoteController.astro
+++ b/src/components/PredictionVoteController.astro
@@ -562,7 +562,9 @@ const controllerConfig = JSON.stringify({
   // ── Refresco en vivo de los pronósticos ───────────────────────────────
   // Polling de cliente: funciona igual en SSG y SSR, y queda aislado en
   // refreshPredictions para poder cambiar a SSE más adelante.
-  const LIVE_REFRESH_INTERVAL_MS = 15_000
+  // Alineado con s-maxage del CDN (~15s). credentials:omit evita mandar la
+  // cookie de sesión en un GET público que no la necesita.
+  const LIVE_REFRESH_INTERVAL_MS = 30_000
 
   let liveRefreshTimer: number | null = null
   let liveRefreshAbort: AbortController | null = null
@@ -581,7 +583,10 @@ const controllerConfig = JSON.stringify({
     liveRefreshAbort = abort
 
     try {
-      const response = await fetch('/api/predictions', { signal: abort.signal })
+      const response = await fetch('/api/predictions', {
+        signal: abort.signal,
+        credentials: 'omit',
+      })
       if (!response.ok) return
 
       const data = (await response.json()) as {

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { LibsqlDialect } from '@libsql/kysely-libsql'
+import { TimeoutError, withTimeout } from '@/lib/with-timeout'
 import { betterAuth } from 'better-auth'
 
 const isProduction = import.meta.env.PROD
@@ -73,6 +74,11 @@ type SessionResult = Awaited<ReturnType<typeof auth.api.getSession>>
 const SESSION_CACHE_TTL_MS = 30_000
 const MAX_SESSION_CACHE_ENTRIES = 10_000
 
+// Si Turso no responde a tiempo preferimos "sin sesión" a colgar la función
+// serverless hasta el timeout de Vercel (que es lo que infla el % de Timeouts
+// en Analytics con Error Rate ~0%).
+const SESSION_LOOKUP_TIMEOUT_MS = 2_500
+
 const sessionCache = new Map<string, { session: SessionResult; expiresAt: number }>()
 
 // La clave es la(s) cookie(s) `session_token` que identifican la credencial:
@@ -116,7 +122,11 @@ export async function getSessionFromHeaders(
   }
 
   try {
-    const session = await auth.api.getSession({ headers })
+    const session = await withTimeout(
+      auth.api.getSession({ headers }),
+      SESSION_LOOKUP_TIMEOUT_MS,
+      'Timeout al leer la sesión de better-auth',
+    )
 
     // Solo cacheamos lecturas correctas (nunca el caso `failed`, que debe seguir
     // limpiando cookies en cada request) y solo cuando hay token de sesión.
@@ -127,6 +137,13 @@ export async function getSessionFromHeaders(
 
     return { session, failed: false }
   } catch (error) {
+    // Turso lento/saturado: degradamos a anónimo sin borrar cookies (no es una
+    // cookie corrupta). Así la siguiente petición puede recuperar la sesión.
+    if (error instanceof TimeoutError) {
+      console.error('Timeout al leer la sesión de better-auth (Turso lento):', error)
+      return { session: null, failed: false }
+    }
+
     console.error('No se pudo leer la sesión de better-auth (cookie inválida):', error)
     return { session: null, failed: true }
   }

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -32,6 +32,10 @@ let memoryCache: MemoryCache = {
   allPredictions: null,
 }
 
+// Coalesce concurrent cache-misses in the same isolate: under a CDN revalidation
+// stampede, N parallel GETs would otherwise open N identical Turso reads.
+let allPredictionsInFlight: Promise<CombatPrediction[]> | null = null
+
 export class PredictionDataError extends Error {
   status: number
 
@@ -217,15 +221,9 @@ export async function getPredictionsByCombat(combatId: string): Promise<Predicti
   }
 }
 
-/**
- * Obtiene todas las predicciones agrupadas por combate.
- */
-export async function getAllPredictions(): Promise<CombatPrediction[]> {
-  const cachedAll = memoryCache.allPredictions
-  if (cachedAll && isCacheValid(cachedAll.timestamp)) {
-    return cachedAll.data
-  }
-
+async function fetchAllPredictionsFromDb(
+  stale: CacheEntry<CombatPrediction[]> | null,
+): Promise<CombatPrediction[]> {
   try {
     const result = await withTimeout(
       turso.execute({
@@ -264,9 +262,9 @@ export async function getAllPredictions(): Promise<CombatPrediction[]> {
 
     return allPredictionsData
   } catch (error) {
-    if (cachedAll) {
+    if (stale) {
       console.error('Turso lento/error; sirviendo predicciones stale:', error)
-      return cachedAll.data
+      return stale.data
     }
 
     console.error('Error al obtener todas las predicciones:', error)
@@ -275,6 +273,24 @@ export async function getAllPredictions(): Promise<CombatPrediction[]> {
     }
     throw new Error('Error al obtener todas las predicciones')
   }
+}
+
+/**
+ * Obtiene todas las predicciones agrupadas por combate.
+ */
+export async function getAllPredictions(): Promise<CombatPrediction[]> {
+  const cachedAll = memoryCache.allPredictions
+  if (cachedAll && isCacheValid(cachedAll.timestamp)) {
+    return cachedAll.data
+  }
+
+  if (!allPredictionsInFlight) {
+    allPredictionsInFlight = fetchAllPredictionsFromDb(cachedAll).finally(() => {
+      allPredictionsInFlight = null
+    })
+  }
+
+  return allPredictionsInFlight
 }
 
 /**

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -1,6 +1,7 @@
 import { battles, battlesById, type Battle } from '@/consts/battles'
 import { BOXERS_BY_ID } from '@/consts/boxers'
 import { turso } from '@/lib/database'
+import { TimeoutError, withTimeout } from '@/lib/with-timeout'
 
 interface CacheEntry<T> {
   data: T
@@ -19,6 +20,12 @@ interface PredictionRow {
 }
 
 const CACHE_DURATION = 30 * 1000
+
+// Lecturas públicas bajo el polling del evento: si Turso tarda más que esto,
+// devolvemos caché stale (si hay) o fallamos rápido. Evita que la función
+// serverless se quede colgada hasta el timeout de Vercel (~25% en picos).
+const TURSO_READ_TIMEOUT_MS = 2_500
+const TURSO_WRITE_TIMEOUT_MS = 4_000
 
 let memoryCache: MemoryCache = {
   predictionsByCombat: {},
@@ -164,15 +171,19 @@ export async function getPredictionsByCombat(combatId: string): Promise<Predicti
     // `Object.hasOwn` y no `battlesById[combatId]`: ver assertValidPredictionTarget.
     if (!Object.hasOwn(battlesById, combatId)) return null
 
-    const result = await turso.execute({
-      sql: `
-        SELECT combat_id, fighter_id, votes
-        FROM predictions
-        WHERE combat_id = ?
-        ORDER BY fighter_id
-      `,
-      args: [combatId],
-    })
+    const result = await withTimeout(
+      turso.execute({
+        sql: `
+          SELECT combat_id, fighter_id, votes
+          FROM predictions
+          WHERE combat_id = ?
+          ORDER BY fighter_id
+        `,
+        args: [combatId],
+      }),
+      TURSO_READ_TIMEOUT_MS,
+      'Timeout al leer predicciones por combate',
+    )
 
     const predictionData = createPredictionResponse(
       combatId,
@@ -192,7 +203,16 @@ export async function getPredictionsByCombat(combatId: string): Promise<Predicti
 
     return predictionData
   } catch (error) {
+    // Instancia caliente con dato previo: mejor servir stale que tumbar el poll.
+    if (cachedData) {
+      console.error('Turso lento/error; sirviendo predicción stale por combate:', error)
+      return cachedData.data
+    }
+
     console.error('Error al obtener predicciones por combate:', error)
+    if (error instanceof TimeoutError) {
+      throw new PredictionDataError('Servicio de predicciones saturado, reintenta', 503)
+    }
     throw new Error('Error al obtener predicciones por combate')
   }
 }
@@ -201,18 +221,23 @@ export async function getPredictionsByCombat(combatId: string): Promise<Predicti
  * Obtiene todas las predicciones agrupadas por combate.
  */
 export async function getAllPredictions(): Promise<CombatPrediction[]> {
-  if (memoryCache.allPredictions && isCacheValid(memoryCache.allPredictions.timestamp)) {
-    return memoryCache.allPredictions.data
+  const cachedAll = memoryCache.allPredictions
+  if (cachedAll && isCacheValid(cachedAll.timestamp)) {
+    return cachedAll.data
   }
 
   try {
-    const result = await turso.execute({
-      sql: `
-        SELECT combat_id, fighter_id, votes
-        FROM predictions
-        ORDER BY combat_id, fighter_id
-      `,
-    })
+    const result = await withTimeout(
+      turso.execute({
+        sql: `
+          SELECT combat_id, fighter_id, votes
+          FROM predictions
+          ORDER BY combat_id, fighter_id
+        `,
+      }),
+      TURSO_READ_TIMEOUT_MS,
+      'Timeout al leer todas las predicciones',
+    )
 
     const rowsByCombat = new Map<string, PredictionRow[]>()
     result.rows.forEach((row) => {
@@ -239,7 +264,15 @@ export async function getAllPredictions(): Promise<CombatPrediction[]> {
 
     return allPredictionsData
   } catch (error) {
+    if (cachedAll) {
+      console.error('Turso lento/error; sirviendo predicciones stale:', error)
+      return cachedAll.data
+    }
+
     console.error('Error al obtener todas las predicciones:', error)
+    if (error instanceof TimeoutError) {
+      throw new PredictionDataError('Servicio de predicciones saturado, reintenta', 503)
+    }
     throw new Error('Error al obtener todas las predicciones')
   }
 }
@@ -260,20 +293,24 @@ export async function registerVote(
     // triggers `user_votes_after_*` de forma incremental (+1/-1), así que ya no
     // recontamos todos los votos del combate en cada voto (lo que disparaba las
     // "rows read" de Turso de forma cuadrática).
-    await turso.batch([
-      ...ensurePredictionRowsStatements(battle),
-      {
-        sql: `
-          INSERT INTO user_votes (combat_id, fighter_id, user_id, created_at)
-          VALUES (?, ?, ?, CURRENT_TIMESTAMP)
-          ON CONFLICT(combat_id, user_id)
-          DO UPDATE SET
-            fighter_id = excluded.fighter_id,
-            created_at = CURRENT_TIMESTAMP
-        `,
-        args: [combatId, fighterId, userId],
-      },
-    ])
+    await withTimeout(
+      turso.batch([
+        ...ensurePredictionRowsStatements(battle),
+        {
+          sql: `
+            INSERT INTO user_votes (combat_id, fighter_id, user_id, created_at)
+            VALUES (?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(combat_id, user_id)
+            DO UPDATE SET
+              fighter_id = excluded.fighter_id,
+              created_at = CURRENT_TIMESTAMP
+          `,
+          args: [combatId, fighterId, userId],
+        },
+      ]),
+      TURSO_WRITE_TIMEOUT_MS,
+      'Timeout al registrar voto',
+    )
     invalidateCache(combatId)
 
     const prediction = await getPredictionsByCombat(combatId)
@@ -291,6 +328,9 @@ export async function registerVote(
     }
   } catch (error) {
     if (error instanceof PredictionDataError) throw error
+    if (error instanceof TimeoutError) {
+      throw new PredictionDataError('Servicio de predicciones saturado, reintenta', 503)
+    }
 
     console.error('Error al registrar voto:', error)
     throw new Error('Error al registrar voto')
@@ -309,15 +349,19 @@ export async function getCombatStats(combatId: string): Promise<CombatPrediction
  */
 export async function getUserVotes(userId: string): Promise<UserPredictionVote[]> {
   try {
-    const result = await turso.execute({
-      sql: `
-        SELECT combat_id, fighter_id, created_at
-        FROM user_votes
-        WHERE user_id = ?
-        ORDER BY created_at DESC
-      `,
-      args: [userId],
-    })
+    const result = await withTimeout(
+      turso.execute({
+        sql: `
+          SELECT combat_id, fighter_id, created_at
+          FROM user_votes
+          WHERE user_id = ?
+          ORDER BY created_at DESC
+        `,
+        args: [userId],
+      }),
+      TURSO_READ_TIMEOUT_MS,
+      'Timeout al leer votos del usuario',
+    )
 
     return result.rows.map((row) => ({
       combat_id: row.combat_id as string,
@@ -326,6 +370,9 @@ export async function getUserVotes(userId: string): Promise<UserPredictionVote[]
     }))
   } catch (error) {
     console.error('Error al obtener votos del usuario:', error)
+    if (error instanceof TimeoutError) {
+      throw new PredictionDataError('Servicio de predicciones saturado, reintenta', 503)
+    }
     throw new Error('Error al obtener votos del usuario')
   }
 }

--- a/src/lib/with-timeout.ts
+++ b/src/lib/with-timeout.ts
@@ -1,0 +1,26 @@
+/**
+ * Envuelve una promesa con un tiempo máximo. Si la operación no termina a
+ * tiempo (p. ej. Turso saturado), rechaza con un error tipado para que el
+ * caller pueda degradar (caché stale / 503) en lugar de colgar la función
+ * serverless hasta el timeout de Vercel.
+ */
+export class TimeoutError extends Error {
+  constructor(message = 'Operación agotó el tiempo de espera') {
+    super(message)
+    this.name = 'TimeoutError'
+  }
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number, message?: string): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      reject(new TimeoutError(message))
+    }, ms)
+  })
+
+  return Promise.race([promise, timeout]).finally(() => {
+    if (timer !== undefined) clearTimeout(timer)
+  })
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -22,11 +22,38 @@ function expireBetterAuthCookies(request: Request, response: Response) {
   }
 }
 
+function hasSessionTokenCookie(request: Request): boolean {
+  const cookieHeader = request.headers.get("cookie")
+  if (!cookieHeader) return false
+  return cookieHeader.includes("session_token")
+}
+
+// GET público de predicciones: lo cachea el CDN y no necesita sesión. Resolver
+// sesión aquí (2 lecturas a Turso en miss) multiplica la carga bajo el polling
+// del evento y además un Set-Cookie por cookie corrupta invalidaría el cache.
+function isPublicPredictionsGet(context: { request: Request; url: URL }): boolean {
+  return (
+    context.request.method === "GET" &&
+    context.url.pathname === "/api/predictions" &&
+    context.url.searchParams.get("mine") !== "1"
+  )
+}
+
 export const onRequest = defineMiddleware(async (context, next) => {
   // Prerendered routes (e.g. combates, 404) are built statically and have no
   // real request, so reading `context.request.headers` there is meaningless
   // and makes Astro emit a warning. Skip the session lookup for them.
   if (context.isPrerendered) {
+    context.locals.user = null
+    context.locals.session = null
+    return next()
+  }
+
+  const publicPredictionsGet = isPublicPredictionsGet(context)
+
+  // Sin token de sesión no hay nada que resolver en Turso. El GET público de
+  // predicciones tampoco lo necesita (aunque el navegador mande otras cookies).
+  if (publicPredictionsGet || !hasSessionTokenCookie(context.request)) {
     context.locals.user = null
     context.locals.session = null
     return next()
@@ -41,8 +68,13 @@ export const onRequest = defineMiddleware(async (context, next) => {
 
   // Si la cookie de sesión era ilegible, la caducamos para que el navegador se
   // recupere. No tocamos las rutas de auth: ahí better-auth gestiona sus propias
-  // cookies y no queremos pisar sus `Set-Cookie`.
-  if (failed && !context.url.pathname.startsWith("/api/auth")) {
+  // cookies y no queremos pisar sus `Set-Cookie`. Tampoco tocamos el GET público
+  // de predicciones: un Set-Cookie impediría cachearlo en el CDN de Vercel.
+  if (
+    failed &&
+    !context.url.pathname.startsWith("/api/auth") &&
+    !publicPredictionsGet
+  ) {
     try {
       expireBetterAuthCookies(context.request, response)
     } catch (error) {

--- a/src/pages/api/predictions.ts
+++ b/src/pages/api/predictions.ts
@@ -15,12 +15,16 @@ export const prerender = false
 // un par de veces; 20 votos por minuto deja margen de sobra y corta los bucles.
 const VOTE_RATE_LIMIT = { limit: 20, windowMs: 60_000 }
 
-// Las predicciones públicas las pollea cada cliente cada 15s: dejamos que el CDN
-// de Vercel sirva la respuesta desde el edge durante 10s y revalide en segundo
+// Las predicciones públicas las pollea cada cliente cada ~30s: dejamos que el CDN
+// de Vercel sirva la respuesta desde el edge durante 15s y revalide en segundo
 // plano, de modo que millones de polls se traducen en muy pocos hits a Turso.
 // `stale-while-revalidate` evita que ninguna petición espere a la base de datos.
+// `Vercel-CDN-Cache-Control` fuerza la política en el CDN aunque el navegador
+// mande cookies (los polls públicos van con credentials: 'omit').
 const PUBLIC_CACHE_HEADERS = {
-  'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
+  'Cache-Control': 'public, s-maxage=15, stale-while-revalidate=60',
+  'Vercel-CDN-Cache-Control': 'public, s-maxage=15, stale-while-revalidate=60',
+  'CDN-Cache-Control': 'public, s-maxage=15, stale-while-revalidate=60',
 }
 
 // Las respuestas por-usuario (sus votos) NUNCA deben cachearse en un proxy/CDN
@@ -110,6 +114,15 @@ export const GET: APIRoute = async ({ request, url }) => {
 
     return json({ predictions: await getAllPredictions() }, 200, PUBLIC_CACHE_HEADERS)
   } catch (error) {
+    // 503 en saturación de Turso: el cliente reintenta en el siguiente poll y
+    // el CDN puede seguir sirviendo la respuesta stale-while-revalidate previa.
+    if (error instanceof PredictionDataError) {
+      return json({ error: error.message }, error.status, {
+        'Cache-Control': 'no-store',
+        'Retry-After': '5',
+      })
+    }
+
     console.error('Error en GET /api/predictions:', error)
     return json({ error: 'Error al obtener predicciones' }, 500)
   }

--- a/src/pages/overlay/obs.astro
+++ b/src/pages/overlay/obs.astro
@@ -247,13 +247,15 @@ const cards = selected.map((battle) => {
       })()
     </script>
 
-    {/* Votos en tiempo real: pollea /api/predictions (cacheado en el edge ~10s)
+    {/* Votos en tiempo real: pollea /api/predictions (cacheado en el edge ~15s)
         y actualiza porcentajes, barras, total y líder de TODAS las tarjetas.
         Idempotente: las actualizaciones fijan valores exactos del servidor, así
         que aunque el poller corriera dos veces no se corrompe nada. */}
     <script is:inline>
       ;(function () {
-        var REFRESH_MS = 9000
+        // Un poco por encima del s-maxage del CDN (15s) para no forzar
+        // revalidaciones innecesarias al origen bajo carga.
+        var REFRESH_MS = 20000
         var votesFmt, votesCompactFmt, pctFmt
         try {
           votesFmt = new Intl.NumberFormat('es-ES', { maximumFractionDigits: 0 })
@@ -312,7 +314,7 @@ const cards = selected.map((battle) => {
         function refresh() {
           if (ctrl) ctrl.abort()
           ctrl = new AbortController()
-          fetch('/api/predictions', { signal: ctrl.signal })
+          fetch('/api/predictions', { signal: ctrl.signal, credentials: 'omit' })
             .then(function (r) {
               return r.ok ? r.json() : null
             })


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

- [ ] feat
- [ ] fix
- [ ] refactor
- [x] perf
- [ ] docs
- [ ] chore

## Related Issue

N/A — incidente de producción: ~25% timeouts en Vercel Analytics con Error Rate ~0% y tráfico alto (~10k online).

## Changes

Con ~10k concurrentes el Error Rate estaba en 0% pero Timeout ~23–25%: las funciones serverless se colgaban esperando a Turso, no petaban con 5xx.

- `src/middleware.ts`: no resuelve sesión en `GET /api/predictions` público ni si no hay `session_token` (evita 2 lecturas a Turso por poll / visitante anónimo).
- `src/lib/auth.ts`: timeout 2.5s al leer sesión; si Turso va lento degrada a anónimo sin borrar cookies.
- `src/lib/with-timeout.ts`: helper compartido para fail-fast.
- `src/lib/predictions.ts`: timeout en lecturas/escrituras a Turso; si hay caché en memoria sirve **stale**; singleflight para coalescear lecturas concurrentes del listado público; 503 tipado si no hay fallback.
- `src/pages/api/predictions.ts`: headers CDN más largos (`s-maxage=15`, SWR 60) + manejo de 503.
- `src/components/LivePrediction.astro` / `PredictionVoteController.astro` / `overlay/obs.astro`: polls con `credentials: 'omit'` e intervalo 30s (OBS 20s) para aprovechar el edge cache.

## Dependencies

- Added: None
- Removed: None

## Screenshots

N/A — cambio de resiliencia/backend y polling; sin cambios visuales.

## Checklist

- [ ] Tested on mobile (<768px)
- [ ] Tested on desktop (≥1024px)
- [x] No console errors
- [x] No regressions on affected routes

## Breaking Changes

None

## Follow-ups (no incluidos a propósito)

- Prerenderizar `/pronosticos` como shell estático y cargar votos en cliente (mayor impacto en TTFB de esa ruta).
- Caché compartida (KV/Upstash) para predicciones públicas entre instancias.
- Prerender de `/overlay/obs` leyendo query params en cliente.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9a96-4743-77d7-be52-e71596977551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9a96-4743-77d7-be52-e71596977551"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

