### PR TITLE
feat(pronosticos): cierra la votación y muestra totales estáticos en build

### DIFF
--- a/src/components/AuthButton.astro
+++ b/src/components/AuthButton.astro
@@ -7,129 +7,162 @@ interface Props {
   callbackURL?: string
 }
 
-const { user, callbackURL = '/pronosticos' } = Astro.props
+const { user = null, callbackURL = '/pronosticos' } = Astro.props
 
 // Iniciales de respaldo para el avatar: si la imagen no carga (o no existe),
 // mostramos un círculo con las iniciales en lugar de un icono roto.
-const initials =
-  user?.name
-    ?.trim()
-    .split(/\s+/)
-    .map((part) => part.charAt(0))
-    .slice(0, 2)
-    .join('')
-    .toUpperCase() || 'V'
+function getInitials(name: string | null | undefined) {
+  return (
+    name
+      ?.trim()
+      .split(/\s+/)
+      .map((part) => part.charAt(0))
+      .slice(0, 2)
+      .join('')
+      .toUpperCase() || 'V'
+  )
+}
+
+const initials = getInitials(user?.name)
+// En páginas estáticas `user` llega null y la sesión se hidrata en cliente.
+const initialState = user ? 'in' : 'out'
 ---
 
-{
-  user ? (
-    <div
-      class="flex items-center gap-3 not-motion-reduce:animate-fade-in-up"
-      style="animation-delay:280ms"
-      data-auth-button
-      data-auth-callback-url={callbackURL}
+<div
+  class="contents"
+  data-auth-button
+  data-auth-callback-url={callbackURL}
+  data-auth-state={initialState}
+>
+  <div
+    class:list={[
+      'flex items-center gap-3 not-motion-reduce:animate-fade-in-up',
+      initialState !== 'in' && 'hidden',
+    ]}
+    style="animation-delay:280ms"
+    data-auth-signed-in
+  >
+    <span
+      role="img"
+      aria-label={user?.name ?? 'Usuario'}
+      class="relative grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-pill border border-white/15 bg-theme-navy font-cinzel text-[0.6rem] font-black tracking-[0.04em] text-theme-gold"
+      data-auth-avatar
     >
-      <span
-        role="img"
-        aria-label={user.name}
-        class="relative grid h-8 w-8 shrink-0 place-items-center overflow-hidden rounded-pill border border-white/15 bg-theme-navy font-cinzel text-[0.6rem] font-black tracking-[0.04em] text-theme-gold"
-      >
-        <span aria-hidden="true">{initials}</span>
-        {user.image && (
+      <span aria-hidden="true" data-auth-initials>{initials}</span>
+      {
+        user?.image ? (
           <img
             src={user.image}
             alt=""
             width={32}
             height={32}
             class="absolute inset-0 h-full w-full object-cover"
+            data-auth-avatar-img
             data-img-fallback="remove"
           />
-        )}
-      </span>
-      <span class="hidden font-cinzel text-[0.65rem] font-black tracking-[0.16em] text-theme-cream/85 sm:inline">
-        {user.name}
-      </span>
+        ) : (
+          <img
+            alt=""
+            width={32}
+            height={32}
+            class="absolute inset-0 hidden h-full w-full object-cover"
+            data-auth-avatar-img
+            data-img-fallback="remove"
+          />
+        )
+      }
+    </span>
+    <span
+      class="hidden font-cinzel text-[0.65rem] font-black tracking-[0.16em] text-theme-cream/85 sm:inline"
+      data-auth-name
+    >
+      {user?.name ?? ''}
+    </span>
+    <button
+      type="button"
+      data-auth-sign-out
+      class="inline-flex min-h-11 cursor-pointer items-center rounded-pill border border-white/15 bg-black/20 px-4 py-2 font-cinzel text-[0.6rem] font-black tracking-[0.14em] text-white/70 backdrop-blur-md transition duration-300 hover:border-theme-gold/60 hover:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
+    >
+      SALIR
+    </button>
+  </div>
+
+  <div
+    class:list={[
+      'flex flex-wrap items-center justify-center gap-x-3 gap-y-2',
+      initialState !== 'out' && 'hidden',
+    ]}
+    data-auth-signed-out
+  >
+    <span
+      class="font-cinzel text-[0.6rem] font-black tracking-[0.16em] text-theme-cream/55 uppercase not-motion-reduce:animate-fade-in-up"
+      style="animation-delay:280ms"
+      data-auth-prompt
+    >
+      Inicia sesión para ver tus votos
+    </span>
+
+    <div class="flex items-center gap-2">
       <button
         type="button"
-        data-auth-sign-out
-        class="inline-flex min-h-11 cursor-pointer items-center rounded-pill border border-white/15 bg-black/20 px-4 py-2 font-cinzel text-[0.6rem] font-black tracking-[0.14em] text-white/70 backdrop-blur-md transition duration-300 hover:border-theme-gold/60 hover:text-theme-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
+        data-auth-provider="twitch"
+        aria-label="Iniciar sesión con Twitch"
+        style="animation-delay:360ms"
+        class="group inline-flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-full border border-theme-gold/35 bg-theme-gold/10 px-4 py-2 font-cinzel text-[0.6rem] font-black tracking-[0.14em] text-theme-cream transition duration-300 not-motion-reduce:animate-fade-in-up hover:border-theme-gold hover:bg-theme-gold/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
       >
-        SALIR
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="13"
+          height="13"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          aria-hidden="true"
+          class="shrink-0"
+        >
+          <path
+            d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z"
+          ></path>
+        </svg>
+        Twitch
+      </button>
+
+      <button
+        type="button"
+        data-auth-provider="google"
+        aria-label="Iniciar sesión con Google"
+        style="animation-delay:440ms"
+        class="group inline-flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 font-cinzel text-[0.6rem] font-black tracking-[0.14em] text-theme-cream transition duration-300 not-motion-reduce:animate-fade-in-up hover:border-theme-gold/60 hover:bg-white/[0.1] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="14"
+          height="14"
+          viewBox="0 0 24 24"
+          aria-hidden="true"
+          class="shrink-0"
+        >
+          <path
+            fill="#4285F4"
+            d="M23.49 12.27c0-.79-.07-1.54-.2-2.27H12v4.51h6.47a5.54 5.54 0 0 1-2.4 3.64v2.98h3.83c2.24-2.06 3.54-5.1 3.54-8.86Z"
+          ></path>
+          <path
+            fill="#34A853"
+            d="M12 24c3.24 0 5.96-1.07 7.94-2.91l-3.83-2.98c-1.07.72-2.43 1.14-4.11 1.14-3.15 0-5.82-2.13-6.78-4.99H1.26v3.07A12 12 0 0 0 12 24Z"
+          ></path>
+          <path
+            fill="#FBBC05"
+            d="M5.22 14.26a7.22 7.22 0 0 1 0-4.52V6.67H1.26a12 12 0 0 0 0 10.66l3.96-3.07Z"
+          ></path>
+          <path
+            fill="#EA4335"
+            d="M12 4.75c1.76 0 3.34.61 4.58 1.8l3.44-3.44A11.56 11.56 0 0 0 12 0 12 12 0 0 0 1.26 6.67l3.96 3.07C6.18 6.87 8.85 4.75 12 4.75Z"
+          ></path>
+        </svg>
+        Google
       </button>
     </div>
-  ) : (
-    <div
-      class="flex flex-wrap items-center justify-center gap-x-3 gap-y-2"
-      data-auth-button
-      data-auth-callback-url={callbackURL}
-    >
-      <span
-        class="font-cinzel text-[0.6rem] font-black tracking-[0.16em] text-theme-cream/55 uppercase not-motion-reduce:animate-fade-in-up"
-        style="animation-delay:280ms"
-      >
-        Inicia sesión para votar
-      </span>
-
-      <div class="flex items-center gap-2">
-        <button
-          type="button"
-          data-auth-provider="twitch"
-          aria-label="Iniciar sesión con Twitch"
-          style="animation-delay:360ms"
-          class="group inline-flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-full border border-theme-gold/35 bg-theme-gold/10 px-4 py-2 font-cinzel text-[0.6rem] font-black tracking-[0.14em] text-theme-cream transition duration-300 not-motion-reduce:animate-fade-in-up hover:border-theme-gold hover:bg-theme-gold/20 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="13"
-            height="13"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            aria-hidden="true"
-            class="shrink-0"
-          >
-            <path d="M11.571 4.714h1.715v5.143H11.57zm4.715 0H18v5.143h-1.714zM6 0L1.714 4.286v15.428h5.143V24l4.286-4.286h3.428L22.286 12V0zm14.571 11.143l-3.428 3.428h-3.429l-3 3v-3H6.857V1.714h13.714z" />
-          </svg>
-          Twitch
-        </button>
-
-        <button
-          type="button"
-          data-auth-provider="google"
-          aria-label="Iniciar sesión con Google"
-          style="animation-delay:440ms"
-          class="group inline-flex min-h-11 cursor-pointer items-center justify-center gap-2 rounded-full border border-white/15 bg-white/[0.06] px-4 py-2 font-cinzel text-[0.6rem] font-black tracking-[0.14em] text-theme-cream transition duration-300 not-motion-reduce:animate-fade-in-up hover:border-theme-gold/60 hover:bg-white/[0.1] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-theme-gold"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-            class="shrink-0"
-          >
-            <path
-              fill="#4285F4"
-              d="M23.49 12.27c0-.79-.07-1.54-.2-2.27H12v4.51h6.47a5.54 5.54 0 0 1-2.4 3.64v2.98h3.83c2.24-2.06 3.54-5.1 3.54-8.86Z"
-            />
-            <path
-              fill="#34A853"
-              d="M12 24c3.24 0 5.96-1.07 7.94-2.91l-3.83-2.98c-1.07.72-2.43 1.14-4.11 1.14-3.15 0-5.82-2.13-6.78-4.99H1.26v3.07A12 12 0 0 0 12 24Z"
-            />
-            <path
-              fill="#FBBC05"
-              d="M5.22 14.26a7.22 7.22 0 0 1 0-4.52V6.67H1.26a12 12 0 0 0 0 10.66l3.96-3.07Z"
-            />
-            <path
-              fill="#EA4335"
-              d="M12 4.75c1.76 0 3.34.61 4.58 1.8l3.44-3.44A11.56 11.56 0 0 0 12 0 12 12 0 0 0 1.26 6.67l3.96 3.07C6.18 6.87 8.85 4.75 12 4.75Z"
-            />
-          </svg>
-          Google
-        </button>
-      </div>
-    </div>
-  )
-}
+  </div>
+</div>
 
 <script>
   import { $, $$ } from '@/lib/dom-selector'
@@ -137,9 +170,101 @@ const initials =
 
   const authClient = createAuthClient()
 
+  function initialsFromName(name: string | null | undefined) {
+    return (
+      name
+        ?.trim()
+        .split(/\s+/)
+        .map((part) => part.charAt(0))
+        .slice(0, 2)
+        .join('')
+        .toUpperCase() || 'V'
+    )
+  }
+
+  function setAuthState(
+    root: HTMLElement,
+    state: 'in' | 'out',
+    user?: { name?: string | null; image?: string | null } | null,
+  ) {
+    root.dataset.authState = state
+    const signedIn = $<HTMLElement>('[data-auth-signed-in]', root)
+    const signedOut = $<HTMLElement>('[data-auth-signed-out]', root)
+    signedIn?.classList.toggle('hidden', state !== 'in')
+    signedOut?.classList.toggle('hidden', state !== 'out')
+
+    if (state !== 'in' || !user) return
+
+    const name = user.name?.trim() || 'Usuario'
+    const avatar = $<HTMLElement>('[data-auth-avatar]', root)
+    const initials = $<HTMLElement>('[data-auth-initials]', root)
+    const nameNode = $<HTMLElement>('[data-auth-name]', root)
+    const image = $<HTMLImageElement>('[data-auth-avatar-img]', root)
+
+    if (avatar) avatar.setAttribute('aria-label', name)
+    if (initials) initials.textContent = initialsFromName(name)
+    if (nameNode) nameNode.textContent = name
+
+    if (image) {
+      if (user.image) {
+        image.src = user.image
+        image.classList.remove('hidden')
+      } else {
+        image.removeAttribute('src')
+        image.classList.add('hidden')
+      }
+    }
+  }
+
+  async function hydrateAuthButton(root: HTMLElement) {
+    // Si el HTML ya vino con sesión (SSR), no hace falta otra ida a /api/auth.
+    if (root.dataset.authState === 'in') {
+      root.dataset.authHydrated = 'true'
+      document.dispatchEvent(new CustomEvent('auth:session', { detail: { user: true } }))
+      return
+    }
+
+    root.dataset.authHydrated = 'false'
+    // Mientras resolvemos la cookie, ocultamos el CTA de login para no flashar
+    // "Inicia sesión" a quien ya tiene sesión en una página estática.
+    const signedOut = $<HTMLElement>('[data-auth-signed-out]', root)
+    signedOut?.classList.add('hidden')
+
+    try {
+      const { data } = await authClient.getSession()
+      if (!data?.user) {
+        setAuthState(root, 'out')
+        return
+      }
+
+      setAuthState(root, 'in', {
+        name: data.user.name,
+        image: data.user.image,
+      })
+      document.dispatchEvent(
+        new CustomEvent('auth:session', {
+          detail: {
+            user: {
+              name: data.user.name ?? 'Tú',
+              image: data.user.image ?? null,
+            },
+          },
+        }),
+      )
+    } catch (error) {
+      console.error('No se pudo hidratar la sesión de auth:', error)
+      setAuthState(root, 'out')
+    } finally {
+      root.dataset.authHydrated = 'true'
+    }
+  }
+
   function setupAuthButtons() {
     $$<HTMLElement>('[data-auth-button]').forEach((root) => {
-      if (root.dataset.authReady === 'true') return
+      if (root.dataset.authReady === 'true') {
+        void hydrateAuthButton(root)
+        return
+      }
 
       root.dataset.authReady = 'true'
       const callbackURL = root.dataset.authCallbackUrl || window.location.pathname
@@ -157,6 +282,8 @@ const initials =
         await authClient.signOut()
         window.location.reload()
       })
+
+      void hydrateAuthButton(root)
     })
   }
 

--- a/src/components/LivePrediction.astro
+++ b/src/components/LivePrediction.astro
@@ -1,10 +1,17 @@
 ---
 import ArrowRightIcon from '@/assets/svg/arrow-right.svg'
 import { BOXERS_BY_ID, getBoxerSelectImages } from '@/consts/boxers'
+import { formatPredictionPercent, formatPredictionVotes } from '@/lib/format-votes'
 
 interface BoxerRef {
   id: string
   name: string
+}
+
+interface PredictionSide {
+  fighter_id: string
+  votes: number
+  percentage: number
 }
 
 interface Props {
@@ -13,6 +20,9 @@ interface Props {
   // los colores coincidan con la página de /pronosticos.
   boxerA: BoxerRef
   boxerB: BoxerRef
+  // Totales fijados en build; sin polling ni llamadas a la API en cliente.
+  sides?: readonly PredictionSide[]
+  totalVotes?: number
   href?: string
   class?: string
 }
@@ -21,9 +31,21 @@ const {
   battleId,
   boxerA,
   boxerB,
+  sides = [],
+  totalVotes = 0,
   href = `/pronosticos#pronostico-${battleId}`,
   class: className,
 } = Astro.props
+
+const sideById = new Map(sides.map((side) => [side.fighter_id, side]))
+const sideA = sideById.get(boxerA.id)
+const sideB = sideById.get(boxerB.id)
+const percentageA = sideA?.percentage ?? 0
+const percentageB = sideB?.percentage ?? 0
+const hasVotes = totalVotes > 0
+const isTie = hasVotes && percentageA === percentageB
+const leaderId =
+  hasVotes && !isTie ? (percentageA > percentageB ? boxerA.id : boxerB.id) : ''
 
 // Recortes redondos de cada boxeador (mismos que usa la tarjeta VS).
 const imagesA = getBoxerSelectImages(BOXERS_BY_ID[boxerA.id])
@@ -34,17 +56,17 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
   class:list={['live-pred', className]}
   data-live-prediction
   data-battle-id={battleId}
-  data-has-votes="false"
+  data-has-votes={String(hasVotes)}
   role="group"
   aria-label={`Pronóstico de la comunidad: ${boxerA.name} contra ${boxerB.name}`}
 >
   <div class="live-pred-top font-cinzel">
     <span class="live-pred-eyebrow">Pronóstico de la comunidad</span>
-    <span class="live-pred-total"><span data-live-total>0</span> votos</span>
+    <span class="live-pred-total">{formatPredictionVotes(totalVotes)} votos</span>
   </div>
 
   <div class="live-pred-scores font-cinzel">
-    <div class="live-pred-score a" data-live-side={boxerA.id}>
+    <div class:list={['live-pred-score', 'a', { 'is-leader': leaderId === boxerA.id }]}>
       <picture class="live-pred-avatar">
         <source type="image/avif" srcset={imagesA.avif} />
         <source type="image/webp" srcset={imagesA.webp} />
@@ -60,10 +82,10 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
       </picture>
       <span class="live-pred-score-text">
         <span class="live-pred-name">{boxerA.name}</span>
-        <span class="live-pred-pct" data-live-pct={boxerA.id}>—</span>
+        <span class="live-pred-pct">{hasVotes ? formatPredictionPercent(percentageA) : '—'}</span>
       </span>
     </div>
-    <div class="live-pred-score b" data-live-side={boxerB.id}>
+    <div class:list={['live-pred-score', 'b', { 'is-leader': leaderId === boxerB.id }]}>
       <picture class="live-pred-avatar">
         <source type="image/avif" srcset={imagesB.avif} />
         <source type="image/webp" srcset={imagesB.webp} />
@@ -79,18 +101,20 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
       </picture>
       <span class="live-pred-score-text">
         <span class="live-pred-name">{boxerB.name}</span>
-        <span class="live-pred-pct" data-live-pct={boxerB.id}>—</span>
+        <span class="live-pred-pct">{hasVotes ? formatPredictionPercent(percentageB) : '—'}</span>
       </span>
     </div>
   </div>
 
   <div class="live-pred-track" aria-hidden="true">
-    <span class="live-pred-fill live-pred-fill-a" data-live-fill={boxerA.id}></span>
-    <span class="live-pred-fill live-pred-fill-b" data-live-fill={boxerB.id}></span>
+    <span class="live-pred-fill live-pred-fill-a" style={`width: ${hasVotes ? percentageA : 0}%`}
+    ></span>
+    <span class="live-pred-fill live-pred-fill-b" style={`width: ${hasVotes ? percentageB : 0}%`}
+    ></span>
   </div>
 
   <a class="live-pred-cta font-cinzel" href={href}>
-    <span>Haz tu pronóstico</span>
+    <span>Ver pronóstico</span>
     <ArrowRightIcon class="live-pred-cta-arrow" aria-hidden="true" />
   </a>
 </div>
@@ -145,7 +169,6 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     align-items: center;
     gap: 0.6rem;
     min-width: 0;
-    transition: opacity 250ms ease;
   }
   .live-pred-score.b {
     flex-direction: row-reverse;
@@ -163,7 +186,6 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     overflow: hidden;
     background: linear-gradient(180deg, #0c1330 0%, #060a1d 100%);
     box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--color-theme-gold) 32%, transparent);
-    transition: box-shadow 250ms ease;
   }
   .live-pred-avatar img {
     width: 100%;
@@ -202,9 +224,6 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     letter-spacing: 0.01em;
     font-variant-numeric: tabular-nums;
     color: var(--color-theme-cream);
-    transition:
-      color 250ms ease,
-      text-shadow 250ms ease;
   }
 
   /* El bando que va ganando se realza en oro. */
@@ -231,7 +250,6 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     top: 0;
     bottom: 0;
     width: 0;
-    transition: width 760ms cubic-bezier(0.16, 1, 0.3, 1);
   }
   .live-pred-fill-a {
     left: 0;
@@ -252,7 +270,7 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
     );
   }
 
-  /* Sin votos todavía: barra apagada y centrada para invitar al primer voto. */
+  /* Sin votos todavía: barra apagada y centrada. */
   .live-pred[data-has-votes='false'] .live-pred-track {
     background: linear-gradient(
       90deg,
@@ -304,132 +322,13 @@ const imagesB = getBoxerSelectImages(BOXERS_BY_ID[boxerB.id])
   }
 
   @media (prefers-reduced-motion: reduce) {
-    .live-pred-fill,
     .live-pred-cta,
-    .live-pred-cta-arrow,
-    .live-pred-pct,
-    .live-pred-score {
+    .live-pred-cta-arrow {
       transition: none;
+    }
+    .live-pred-cta:hover,
+    .live-pred-cta:focus-visible {
+      transform: none;
     }
   }
 </style>
-
-<script>
-  import { $$ } from '@/lib/dom-selector'
-  import { formatPredictionPercent, formatPredictionVotes } from '@/lib/format-votes'
-
-  interface ApiCombat {
-    combat_id: string
-    predictions: Array<{ fighter_id: string; votes: number; percentage: number }>
-    total_votes: number
-  }
-
-  const REFRESH_MS = 15_000
-
-  let timer: number | null = null
-  let abort: AbortController | null = null
-  let observer: IntersectionObserver | null = null
-  let anyVisible = false
-
-  function widgets() {
-    return Array.from($$<HTMLElement>('[data-live-prediction]'))
-  }
-
-  function updateWidget(el: HTMLElement, combat: ApiCombat) {
-    const total = combat.total_votes
-    const totalNode = el.querySelector<HTMLElement>('[data-live-total]')
-    if (totalNode) totalNode.textContent = formatPredictionVotes(total)
-    el.dataset.hasVotes = String(total > 0)
-
-    let leaderId = ''
-    let leaderPct = -1
-    let tie = false
-
-    combat.predictions.forEach((prediction) => {
-      const pctNode = el.querySelector<HTMLElement>(`[data-live-pct="${prediction.fighter_id}"]`)
-      const fillNode = el.querySelector<HTMLElement>(`[data-live-fill="${prediction.fighter_id}"]`)
-      if (pctNode) {
-        pctNode.textContent = total > 0 ? formatPredictionPercent(prediction.percentage) : '—'
-      }
-      if (fillNode) fillNode.style.width = `${total > 0 ? prediction.percentage : 0}%`
-
-      if (prediction.percentage > leaderPct) {
-        leaderPct = prediction.percentage
-        leaderId = prediction.fighter_id
-        tie = false
-      } else if (prediction.percentage === leaderPct) {
-        tie = true
-      }
-    })
-
-    el.querySelectorAll<HTMLElement>('[data-live-side]').forEach((side) => {
-      side.classList.toggle('is-leader', total > 0 && !tie && side.dataset.liveSide === leaderId)
-    })
-  }
-
-  async function refresh() {
-    if (!anyVisible || document.visibilityState !== 'visible') return
-
-    abort?.abort()
-    const controller = new AbortController()
-    abort = controller
-
-    try {
-      const response = await fetch('/api/predictions', { signal: controller.signal })
-      if (!response.ok) return
-
-      const data = (await response.json()) as { predictions?: ApiCombat[] }
-      if (controller.signal.aborted || !data.predictions) return
-
-      const byCombatId = new Map(data.predictions.map((combat) => [combat.combat_id, combat]))
-      widgets().forEach((el) => {
-        const combat = byCombatId.get(el.dataset.battleId ?? '')
-        if (combat) updateWidget(el, combat)
-      })
-    } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') return
-      console.error('No se pudo cargar el pronóstico en vivo:', error)
-    }
-  }
-
-  function handleVisibilityChange() {
-    if (document.visibilityState === 'visible') void refresh()
-  }
-
-  function teardown() {
-    if (timer !== null) {
-      window.clearInterval(timer)
-      timer = null
-    }
-    abort?.abort()
-    abort = null
-    observer?.disconnect()
-    observer = null
-    document.removeEventListener('visibilitychange', handleVisibilityChange)
-  }
-
-  function setup() {
-    teardown()
-
-    const els = widgets()
-    if (els.length === 0) return
-
-    anyVisible = false
-    observer = new IntersectionObserver(
-      (entries) => {
-        entries.forEach((entry) => {
-          ;(entry.target as HTMLElement).dataset.inview = String(entry.isIntersecting)
-        })
-        anyVisible = widgets().some((el) => el.dataset.inview === 'true')
-        if (anyVisible) void refresh()
-      },
-      { rootMargin: '160px' },
-    )
-    els.forEach((el) => observer?.observe(el))
-
-    timer = window.setInterval(() => void refresh(), REFRESH_MS)
-    document.addEventListener('visibilitychange', handleVisibilityChange)
-  }
-
-  document.addEventListener('astro:page-load', setup)
-</script>

--- a/src/components/PredictionFight.astro
+++ b/src/components/PredictionFight.astro
@@ -4,11 +4,10 @@ import type { PredictionBattle } from '@/consts/predictions'
 
 interface Props {
   prediction: PredictionBattle
-  selectedBoxerId?: string
   index?: number
 }
 
-const { prediction, selectedBoxerId, index = 0 } = Astro.props
+const { prediction, index = 0 } = Astro.props
 // Entrada escalonada (mismo patrón que /combates).
 const animationDelay = `${index * 60}ms`
 const { battle, options } = prediction
@@ -34,18 +33,8 @@ const leaderBoxerId = hasLeader ? prediction.leader.boxer.id : undefined
     <div class="tow-stage">
       <span class="tow-tag font-cinzel">Combate {String(battle.number).padStart(2, '0')}</span>
 
-      <PredictionOption
-        battleId={battle.id}
-        option={optionA}
-        selectedBoxerId={selectedBoxerId}
-        leaderBoxerId={leaderBoxerId}
-      />
-      <PredictionOption
-        battleId={battle.id}
-        option={optionB}
-        selectedBoxerId={selectedBoxerId}
-        leaderBoxerId={leaderBoxerId}
-      />
+      <PredictionOption battleId={battle.id} option={optionA} leaderBoxerId={leaderBoxerId} />
+      <PredictionOption battleId={battle.id} option={optionB} leaderBoxerId={leaderBoxerId} />
 
       <span aria-hidden="true" class="tow-seam"></span>
 

--- a/src/components/PredictionOption.astro
+++ b/src/components/PredictionOption.astro
@@ -9,31 +9,25 @@ import {
 interface Props {
   battleId: string
   option: PredictionOption
-  selectedBoxerId?: string
   leaderBoxerId?: string
 }
 
-const { battleId, option, selectedBoxerId, leaderBoxerId } = Astro.props
-const isSelected = selectedBoxerId === option.boxer.id
-const isMuted = Boolean(selectedBoxerId) && !isSelected
+const { battleId, option, leaderBoxerId } = Astro.props
 const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
 ---
 
-<button
-  type="button"
+<div
   class:list={['tow-side', option.side]}
   data-battle-id={battleId}
   data-boxer-id={option.boxer.id}
   data-boxer-name={option.boxer.name}
   data-prediction-option
-  data-selected={String(isSelected)}
-  data-muted={String(isMuted)}
   data-leader={String(isLeader)}
   data-side={option.side}
   data-vote-count={option.votes}
   data-vote-percentage={option.percentage}
-  aria-label={`Pronosticar victoria de ${option.boxer.name}`}
-  aria-pressed={String(isSelected)}
+  role="group"
+  aria-label={`${option.boxer.name}: ${formatPredictionPercent(option.percentage)} (${formatPredictionSupport(option.votes)})`}
   style={`--vote-share: ${option.percentage.toFixed(2)}%; --vote-color: ${option.color};`}
 >
   <picture class="tow-pic">
@@ -55,10 +49,6 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
   <span aria-hidden="true" class="tow-frame"></span>
 
   <span class="tow-caption">
-    <span aria-hidden="true" style="display: none" class="tow-yourvote font-cinzel">
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3.5" stroke-linecap="round" stroke-linejoin="round" class="tow-yourvote-check"><path d="M20 6 9 17l-5-5" /></svg>
-      Tu voto
-    </span>
     <span class="tow-percent font-cinzel" data-prediction-percent>
       {formatPredictionPercent(option.percentage)}
     </span>
@@ -72,13 +62,11 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     </span>
   </span>
 
-  <span aria-hidden="true" style="opacity: 0" class="tow-cue font-cinzel">Votar</span>
-
   <span aria-hidden="true" class="tow-fill"></span>
-</button>
+</div>
 
 <style>
-  /* static: el .tow-fill se ancla al .tow-stage (relative), no al botón,
+  /* static: el .tow-fill se ancla al .tow-stage (relative), no al lado,
      para que la barra cruce de extremo a extremo las dos fotos. */
   .tow-side {
     position: static;
@@ -89,17 +77,9 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     border: 0;
     padding: 0;
     margin: 0;
-    cursor: pointer;
     background: color-mix(in srgb, var(--color-theme-navy) 70%, black);
     color: var(--color-theme-cream);
     text-align: center;
-    transition:
-      opacity 300ms ease,
-      filter 300ms ease;
-  }
-  .tow-side:focus-visible {
-    outline: 2px solid var(--color-theme-gold);
-    outline-offset: -3px;
   }
 
   .tow-pic {
@@ -114,23 +94,13 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     object-fit: cover;
     object-position: top center;
     filter: saturate(0.92) brightness(0.9);
-    transition:
-      scale 600ms ease,
-      filter 500ms ease;
   }
   .tow-side.b .tow-pic-img {
     transform: scaleX(-1);
   }
-  .tow-side:hover .tow-pic-img {
-    scale: 1.05;
-    filter: saturate(1.06) brightness(1.02);
-  }
-  .tow-side[data-selected='true'] .tow-pic-img {
-    filter: saturate(1.12) brightness(1.04);
-  }
 
   /* Halo del líder: glow detrás del boxeador (z-0, se ve alrededor de la
-     figura recortada). Distinto del anillo dorado de "tu voto". */
+     figura recortada). */
   .tow-spot {
     grid-area: stack;
     z-index: 0;
@@ -140,10 +110,9 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
       color-mix(in srgb, var(--color-theme-gold) 22%, transparent) 46%,
       transparent 72%
     );
-    transition: opacity 340ms ease;
   }
   /* Oculto por style inline (opacity:0, evita el flash en dev). El líder lo
-     revela con !important para ganar al inline; mantiene el fundido. */
+     revela con !important para ganar al inline. */
   .tow-side[data-leader='true'] .tow-spot {
     opacity: 0.55 !important;
   }
@@ -162,26 +131,18 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     );
   }
 
-  /* Marco dorado que aparece sobre la foto elegida. */
   .tow-frame {
     grid-area: stack;
     z-index: 4;
     pointer-events: none;
   }
   /* Redondeamos solo las esquinas EXTERIORES del marco para que sigan el
-     border-radius del contenedor (.tow-stage, 10px) y no asome un ángulo recto
-     dorado sobre la esquina curva de la card. El borde central (junto al VS) se
-     mantiene recto. */
+     border-radius del contenedor (.tow-stage, 10px). */
   .tow-side.a .tow-frame {
     border-radius: 10px 0 0 10px;
   }
   .tow-side.b .tow-frame {
     border-radius: 0 10px 10px 0;
-  }
-  .tow-side[data-selected='true'] .tow-frame {
-    box-shadow:
-      inset 0 0 0 3px var(--color-theme-gold),
-      inset 0 0 44px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
   }
 
   .tow-caption {
@@ -195,32 +156,6 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     padding: 0 0.7rem 2.4rem;
   }
 
-  /* Indicador explícito "Tu voto" en el boxeador elegido.
-     Oculto por style inline (display:none, evita el flash en dev mientras
-     cargan los estilos); se revela con !important solo cuando hay voto. */
-  .tow-yourvote {
-    align-self: center;
-    align-items: center;
-    gap: 0.28rem;
-    margin-bottom: 0.5rem;
-    padding: 0.24rem 0.65rem;
-    border-radius: 999px;
-    background: var(--color-theme-gold);
-    color: var(--color-theme-midnight);
-    font-size: 0.5rem;
-    font-weight: 900;
-    letter-spacing: 0.18em;
-    text-transform: uppercase;
-    box-shadow: 0 4px 16px color-mix(in srgb, var(--color-theme-gold) 40%, transparent);
-  }
-  .tow-yourvote-check {
-    width: 0.7rem;
-    height: 0.7rem;
-  }
-  .tow-side[data-selected='true'] .tow-yourvote {
-    display: inline-flex !important;
-  }
-
   .tow-percent {
     font-size: clamp(1.85rem, 1rem + 3vw, 3rem);
     font-weight: 900;
@@ -231,21 +166,12 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     text-shadow:
       0 1px 3px rgba(0, 0, 0, 0.95),
       0 2px 16px rgba(0, 0, 0, 0.85);
-    transition:
-      color 300ms ease,
-      text-shadow 300ms ease;
   }
-  .tow-side[data-selected='true'] .tow-percent {
+  .tow-side[data-leader='true'] .tow-percent {
     color: var(--color-theme-gold);
     text-shadow:
       0 0 20px color-mix(in srgb, var(--color-theme-gold) 42%, transparent),
       0 0 34px color-mix(in srgb, var(--vote-color) 26%, transparent);
-  }
-  .tow-side[data-vote-changing] .tow-percent {
-    animation: tow-pop 680ms cubic-bezier(0.18, 0.86, 0.24, 1);
-  }
-  .tow-side[data-vote-changing='up'] .tow-percent {
-    color: var(--color-theme-gold);
   }
 
   .tow-name {
@@ -261,7 +187,7 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
       0 2px 12px rgba(0, 0, 0, 0.7);
   }
   .tow-country {
-    display: inline-flex;
+    display: none;
     align-items: center;
     justify-content: center;
     gap: 0.35rem;
@@ -287,55 +213,7 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     color: color-mix(in srgb, var(--color-theme-cream) 52%, transparent);
   }
 
-  /* Vista limpia: ocultamos el país en todas las resoluciones. */
-  .tow-country {
-    display: none;
-  }
-
-  /* Pista de interacción: indica que se puede votar tocando la foto.
-     Sutil por defecto (visible en móvil sin hover), se realza al pasar/enfocar
-     y desaparece en cuanto hay voto en el combate. */
-  /* Marca de agua "VOTAR": gigante y tenue (20%), aparece al pasar/enfocar
-     sobre la foto. z-index 2 (encima de la foto, debajo de %/nombre). */
-  .tow-cue {
-    grid-area: stack;
-    z-index: 0;
-    align-self: center;
-    writing-mode: vertical-rl;
-    text-orientation: upright;
-    color: var(--color-theme-cream);
-    font-size: clamp(1.9rem, 0.8rem + 5.5vw, 3.6rem);
-    font-weight: 900;
-    line-height: 0.82;
-    letter-spacing: 0.01em;
-    text-transform: uppercase;
-    pointer-events: none;
-    transition: opacity 260ms ease;
-  }
-  /* Pegada al borde exterior de cada foto (zona transparente, sin cuerpo),
-     con un respiro para que no quede lamida al borde de la card. */
-  .tow-side.a .tow-cue {
-    justify-self: start;
-    padding-left: 0.85rem;
-  }
-  .tow-side.b .tow-cue {
-    justify-self: end;
-    padding-right: 0.85rem;
-  }
-  /* Oculta por style inline (opacity:0, evita el flash). Se revela al
-     pasar/enfocar con !important (gana al inline) y mantiene el fundido. */
-  .tow-side:hover .tow-cue,
-  .tow-side:focus-visible .tow-cue {
-    opacity: 0.4 !important;
-  }
-  /* Una vez votado (elegido o atenuado), ya no se muestra la pista. */
-  .tow-side[data-selected='true'] .tow-cue,
-  .tow-side[data-muted='true'] .tow-cue {
-    opacity: 0 !important;
-  }
-
-  /* Relleno de la barra tug-of-war (A desde izq, B desde der),
-     aclarando hacia el centro para llevar la mirada al pivote. */
+  /* Relleno de la barra tug-of-war (A desde izq, B desde der). */
   .tow-fill {
     position: absolute;
     bottom: 0;
@@ -346,10 +224,6 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
       inset 0 1px 0 rgba(255, 255, 255, 0.28),
       0 0 18px color-mix(in srgb, var(--vote-color) 48%, transparent);
     pointer-events: none;
-    transition:
-      width 820ms cubic-bezier(0.16, 1, 0.3, 1),
-      filter 420ms ease;
-    will-change: width;
   }
   .tow-side.a .tow-fill {
     left: 0;
@@ -389,40 +263,11 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
       0 0 0 2px rgba(0, 0, 0, 0.45),
       0 0 16px color-mix(in srgb, var(--color-theme-gold) 70%, transparent);
   }
-  .tow-side[data-vote-changing] .tow-fill {
-    filter: saturate(1.3) brightness(1.16);
-  }
 
-  /* Atenuamos solo la foto y el texto del lado no elegido; la barra de votos
-     (relleno del bando) se mantiene vívida porque representa a la comunidad. */
-  .tow-side[data-muted='true'] .tow-pic-img {
-    filter: saturate(0.6) brightness(0.6);
-  }
-  .tow-side[data-muted='true'] .tow-caption {
-    opacity: 0.6;
-  }
-
-  @keyframes tow-pop {
-    0%,
-    100% {
-      transform: translateY(0) scale(1);
-    }
-    35% {
-      transform: translateY(-0.08rem) scale(1.08);
-    }
-  }
-
-  /* Móvil: texto más pequeño y alineado al borde EXTERIOR de cada foto, para
-     separarlo del centro (VS) y que no se sienta solapado. Sin tocar rejilla. */
+  /* Móvil: texto más pequeño y alineado al borde EXTERIOR de cada foto. */
   @media (max-width: 639px) {
-    /* Fotos más altas (3/4) en móvil: más presencia y aire para la info. */
     .tow-side {
       aspect-ratio: 3 / 4;
-    }
-    /* El watermark "VOTAR" es un estado de hover (escritorio). En móvil no hay
-       hover fiable y se desborda; la guía la da la microcopy de arriba. */
-    .tow-cue {
-      display: none;
     }
     .tow-percent {
       font-size: 1.7rem;
@@ -442,19 +287,6 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
       text-align: right;
       padding-right: 0.55rem;
       padding-left: 1.7rem;
-    }
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .tow-side,
-    .tow-pic-img,
-    .tow-fill,
-    .tow-percent {
-      transition: none;
-      animation: none;
-    }
-    .tow-side:hover .tow-pic-img {
-      scale: 1;
     }
   }
 </style>

--- a/src/components/PredictionOption.astro
+++ b/src/components/PredictionOption.astro
@@ -22,6 +22,8 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
   data-boxer-id={option.boxer.id}
   data-boxer-name={option.boxer.name}
   data-prediction-option
+  data-selected="false"
+  data-muted="false"
   data-leader={String(isLeader)}
   data-side={option.side}
   data-vote-count={option.votes}
@@ -49,6 +51,19 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
   <span aria-hidden="true" class="tow-frame"></span>
 
   <span class="tow-caption">
+    <span aria-hidden="true" style="display: none" class="tow-yourvote font-cinzel">
+      <svg
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        stroke-width="3.5"
+        stroke-linecap="round"
+        stroke-linejoin="round"
+        class="tow-yourvote-check"
+        ><path d="M20 6 9 17l-5-5"></path></svg
+      >
+      Tu voto
+    </span>
     <span class="tow-percent font-cinzel" data-prediction-percent>
       {formatPredictionPercent(option.percentage)}
     </span>
@@ -144,6 +159,11 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
   .tow-side.b .tow-frame {
     border-radius: 0 10px 10px 0;
   }
+  .tow-side[data-selected='true'] .tow-frame {
+    box-shadow:
+      inset 0 0 0 3px var(--color-theme-gold),
+      inset 0 0 44px color-mix(in srgb, var(--color-theme-gold) 22%, transparent);
+  }
 
   .tow-caption {
     grid-area: stack;
@@ -154,6 +174,31 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
     align-items: center;
     gap: 0.05rem;
     padding: 0 0.7rem 2.4rem;
+  }
+
+  /* Indicador "Tu voto" (solo lectura: lo marca PredictionUserVotes).
+     Oculto por style inline; se revela con !important cuando hay voto. */
+  .tow-yourvote {
+    align-self: center;
+    align-items: center;
+    gap: 0.28rem;
+    margin-bottom: 0.5rem;
+    padding: 0.24rem 0.65rem;
+    border-radius: 999px;
+    background: var(--color-theme-gold);
+    color: var(--color-theme-midnight);
+    font-size: 0.5rem;
+    font-weight: 900;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    box-shadow: 0 4px 16px color-mix(in srgb, var(--color-theme-gold) 40%, transparent);
+  }
+  .tow-yourvote-check {
+    width: 0.7rem;
+    height: 0.7rem;
+  }
+  .tow-side[data-selected='true'] .tow-yourvote {
+    display: inline-flex !important;
   }
 
   .tow-percent {
@@ -167,11 +212,21 @@ const isLeader = Boolean(leaderBoxerId) && leaderBoxerId === option.boxer.id
       0 1px 3px rgba(0, 0, 0, 0.95),
       0 2px 16px rgba(0, 0, 0, 0.85);
   }
-  .tow-side[data-leader='true'] .tow-percent {
+  .tow-side[data-leader='true'] .tow-percent,
+  .tow-side[data-selected='true'] .tow-percent {
     color: var(--color-theme-gold);
     text-shadow:
       0 0 20px color-mix(in srgb, var(--color-theme-gold) 42%, transparent),
       0 0 34px color-mix(in srgb, var(--vote-color) 26%, transparent);
+  }
+  .tow-side[data-selected='true'] .tow-pic-img {
+    filter: saturate(1.12) brightness(1.04);
+  }
+  .tow-side[data-muted='true'] .tow-pic-img {
+    filter: saturate(0.6) brightness(0.6);
+  }
+  .tow-side[data-muted='true'] .tow-caption {
+    opacity: 0.6;
   }
 
   .tow-name {

--- a/src/components/PredictionUserVotes.astro
+++ b/src/components/PredictionUserVotes.astro
@@ -1,0 +1,114 @@
+---
+/**
+ * Hidrata en cliente los votos propios del usuario (GET ?mine=1) y marca
+ * visualmente "Tu voto". La votación está cerrada: no hay POST ni cambios.
+ */
+---
+
+<!-- Anuncia a lectores de pantalla al cargar los votos propios (SC 4.1.3). -->
+<div class="sr-only" role="status" aria-live="polite" data-prediction-user-announcer></div>
+
+<script>
+  import { $, $$ } from '@/lib/dom-selector'
+
+  let hydration: Promise<void> | null = null
+  let authListenerBound = false
+
+  function getPredictionFight(battleId: string) {
+    return $<HTMLElement>(`[data-prediction-fight][data-battle-id="${battleId}"]`)
+  }
+
+  function setBattleVote(battleId: string, boxerId: string | null) {
+    const fight = getPredictionFight(battleId)
+    if (!fight) return
+
+    $$<HTMLElement>('[data-prediction-option]', fight).forEach((option) => {
+      const isSelected = option.dataset.boxerId === boxerId
+
+      option.dataset.selected = String(isSelected)
+      option.dataset.muted = String(Boolean(boxerId) && !isSelected)
+    })
+  }
+
+  function applyUserVotes(votes: Record<string, string>) {
+    Object.entries(votes).forEach(([battleId, boxerId]) => {
+      setBattleVote(battleId, boxerId)
+    })
+
+    const count = Object.keys(votes).length
+    const announcer = $<HTMLElement>('[data-prediction-user-announcer]')
+    if (announcer) {
+      announcer.textContent =
+        count > 0
+          ? `Se han cargado tus ${count} pronósticos. La votación está cerrada.`
+          : 'No tienes pronósticos registrados. La votación está cerrada.'
+    }
+  }
+
+  function clearUserVotes() {
+    $$<HTMLElement>('[data-prediction-fight]').forEach((fight) => {
+      const battleId = fight.dataset.battleId
+      if (battleId) setBattleVote(battleId, null)
+    })
+  }
+
+  function hydrateUserVotes() {
+    if (hydration) return hydration
+
+    hydration = (async () => {
+      try {
+        const response = await fetch('/api/predictions?mine=1', {
+          credentials: 'same-origin',
+          headers: { Accept: 'application/json' },
+        })
+
+        if (response.status === 401) {
+          clearUserVotes()
+          return
+        }
+
+        if (!response.ok) return
+
+        const data = (await response.json()) as {
+          votes?: Array<{ combat_id: string; fighter_id: string }>
+        }
+        const userVotes = Object.fromEntries(
+          (data.votes ?? []).map((vote) => [vote.combat_id, vote.fighter_id]),
+        )
+        applyUserVotes(userVotes)
+      } catch (error) {
+        console.error('No se pudieron cargar los votos del usuario:', error)
+      } finally {
+        hydration = null
+      }
+    })()
+
+    return hydration
+  }
+
+  function handleAuthSession(event: Event) {
+    const detail = (event as CustomEvent<{ user?: unknown }>).detail
+    if (!detail?.user) {
+      clearUserVotes()
+      return
+    }
+
+    void hydrateUserVotes()
+  }
+
+  function setup() {
+    if (!authListenerBound) {
+      document.addEventListener('auth:session', handleAuthSession)
+      authListenerBound = true
+    }
+
+    // Si AuthButton ya hidrató antes de que este script se registrara,
+    // pedimos los votos al montar cuando la sesión ya está marcada.
+    const authRoot = $<HTMLElement>('[data-auth-button]')
+    if (authRoot?.dataset.authState === 'in') {
+      void hydrateUserVotes()
+    }
+  }
+
+  document.addEventListener('astro:page-load', setup)
+</script>

--- a/src/components/combat/CombatPredictionsSection.astro
+++ b/src/components/combat/CombatPredictionsSection.astro
@@ -1,22 +1,13 @@
 ---
-import AuthButton from '@/components/AuthButton.astro'
 import PredictionFight from '@/components/PredictionFight.astro'
 import SectionDivider from '@/components/SectionDivider.astro'
 import type { PredictionBattle } from '@/consts/predictions'
 
-interface AuthUser {
-  name: string
-  image?: string | null
-}
-
 interface Props {
   prediction: PredictionBattle | null
-  selectedBoxerId?: string
-  user: AuthUser | null
-  callbackURL: string
 }
 
-const { prediction, selectedBoxerId, user, callbackURL } = Astro.props
+const { prediction } = Astro.props
 ---
 
 {
@@ -36,12 +27,8 @@ const { prediction, selectedBoxerId, user, callbackURL } = Astro.props
           </h2>
         </div>
 
-        <div id="predictions-auth" class="mb-6 flex justify-center" data-predictions-auth>
-          <AuthButton user={user} callbackURL={callbackURL} />
-        </div>
-
-        <ol class="grid gap-5 md:gap-6" role="list" data-prediction-list>
-          <PredictionFight prediction={prediction} selectedBoxerId={selectedBoxerId} />
+        <ol class="grid gap-5 md:gap-6" role="list">
+          <PredictionFight prediction={prediction} />
         </ol>
       </div>
     </section>

--- a/src/lib/database.ts
+++ b/src/lib/database.ts
@@ -1,6 +1,26 @@
-import { createClient } from '@libsql/client/web'
+import { createClient, type Client } from '@libsql/client/web'
 
-export const turso = createClient({
-  url: import.meta.env.TURSO_DATABASE_URL,
-  authToken: import.meta.env.TURSO_AUTH_TOKEN,
+let client: Client | null = null
+
+function getTursoClient(): Client {
+  if (client) return client
+
+  const url = import.meta.env.TURSO_DATABASE_URL
+  const authToken = import.meta.env.TURSO_AUTH_TOKEN
+
+  if (!url) {
+    throw new Error('TURSO_DATABASE_URL no está configurada')
+  }
+
+  client = createClient({ url, authToken })
+  return client
+}
+
+// Proxy lazy: evita tumbar el import del módulo cuando faltan env vars en
+// builds/dev locales. El fallo ocurre al primer uso y queda capturable.
+export const turso: Client = new Proxy({} as Client, {
+  get(_target, property, _receiver) {
+    const value = Reflect.get(getTursoClient(), property, getTursoClient())
+    return typeof value === 'function' ? value.bind(getTursoClient()) : value
+  },
 })

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -244,6 +244,25 @@ export async function getAllPredictions(): Promise<CombatPrediction[]> {
   }
 }
 
+// Una sola lectura a Turso por proceso de build: las páginas estáticas
+// (home, /pronosticos, fichas) reutilizan la misma promesa y evitan N queries.
+let buildTimePredictionsPromise: Promise<CombatPrediction[]> | null = null
+
+/**
+ * Predicciones fijadas en build para servir HTML estático sin llamar a la API
+ * en el cliente. Si Turso no está disponible, devolvemos lista vacía.
+ */
+export function loadBuildTimePredictions(): Promise<CombatPrediction[]> {
+  if (!buildTimePredictionsPromise) {
+    buildTimePredictionsPromise = getAllPredictions().catch((error) => {
+      console.error('Error al cargar predicciones en build:', error)
+      return [] as CombatPrediction[]
+    })
+  }
+
+  return buildTimePredictionsPromise
+}
+
 /**
  * Registra o actualiza el voto activo de un usuario para un combate.
  */

--- a/src/lib/predictions.ts
+++ b/src/lib/predictions.ts
@@ -254,10 +254,21 @@ let buildTimePredictionsPromise: Promise<CombatPrediction[]> | null = null
  */
 export function loadBuildTimePredictions(): Promise<CombatPrediction[]> {
   if (!buildTimePredictionsPromise) {
-    buildTimePredictionsPromise = getAllPredictions().catch((error) => {
-      console.error('Error al cargar predicciones en build:', error)
-      return [] as CombatPrediction[]
-    })
+    buildTimePredictionsPromise = (async () => {
+      if (!import.meta.env.TURSO_DATABASE_URL) {
+        console.warn(
+          'TURSO_DATABASE_URL no definida: se generan pronósticos sin totales de votos.',
+        )
+        return [] as CombatPrediction[]
+      }
+
+      try {
+        return await getAllPredictions()
+      } catch (error) {
+        console.error('Error al cargar predicciones en build:', error)
+        return [] as CombatPrediction[]
+      }
+    })()
   }
 
   return buildTimePredictionsPromise

--- a/src/pages/api/predictions.ts
+++ b/src/pages/api/predictions.ts
@@ -1,24 +1,13 @@
 import { getSessionFromHeaders } from '@/lib/auth'
-import {
-  getAllPredictions,
-  getPredictionsByCombat,
-  getUserVotes,
-  PredictionDataError,
-  registerVote,
-} from '@/lib/predictions'
+import { getAllPredictions, getPredictionsByCombat, getUserVotes } from '@/lib/predictions'
 import { rateLimit } from '@/lib/rate-limit'
 import type { APIRoute } from 'astro'
 
 export const prerender = false
 
-// Un usuario honesto pronostica 10 combates y rara vez cambia de opinión más de
-// un par de veces; 20 votos por minuto deja margen de sobra y corta los bucles.
-const VOTE_RATE_LIMIT = { limit: 20, windowMs: 60_000 }
-
-// Las predicciones públicas las pollea cada cliente cada 15s: dejamos que el CDN
-// de Vercel sirva la respuesta desde el edge durante 10s y revalide en segundo
-// plano, de modo que millones de polls se traducen en muy pocos hits a Turso.
-// `stale-while-revalidate` evita que ninguna petición espere a la base de datos.
+// Las predicciones públicas pueden usarse desde overlays/herramientas. El CDN
+// de Vercel sirve la respuesta desde el edge durante 10s y revalida en segundo
+// plano para evitar martillar Turso.
 const PUBLIC_CACHE_HEADERS = {
   'Cache-Control': 'public, s-maxage=10, stale-while-revalidate=30',
 }
@@ -31,34 +20,8 @@ const PRIVATE_CACHE_HEADERS = {
 }
 
 // El GET de "mis votos" no pasa por el CDN (es privado), así que lo limitamos
-// para que un cliente logueado no pueda martillear lecturas a Turso. Ventana
-// holgada: el uso normal (una lectura por carga) ni se acerca.
+// para que un cliente logueado no pueda martillear lecturas a Turso.
 const READ_RATE_LIMIT = { limit: 60, windowMs: 60_000 }
-
-// Los IDs reales (`boxer-a-vs-boxer-b`, slug de boxeador) son cortos. Acotar la
-// longitud evita procesar payloads enormes antes de validarlos contra el
-// allowlist de combates/boxeadores.
-const MAX_ID_LENGTH = 80
-
-// Defensa CSRF en profundidad: la cookie de sesión de better-auth ya es
-// SameSite=Lax (no viaja en POST cross-site), pero además rechazamos cualquier
-// POST cuyo `Origin` no sea del propio host. Las peticiones legítimas del
-// navegador siempre traen un `Origin` del mismo origen; las llamadas sin
-// `Origin` (raras) se permiten para no romper clientes válidos.
-function isSameOriginRequest(request: Request): boolean {
-  const origin = request.headers.get('origin')
-  if (!origin) return true
-
-  const host = request.headers.get('host')
-  const forwardedHost = request.headers.get('x-forwarded-host')
-
-  try {
-    const originHost = new URL(origin).host
-    return originHost === host || originHost === forwardedHost
-  } catch {
-    return false
-  }
-}
 
 function json(data: unknown, status = 200, headers: Record<string, string> = {}) {
   return new Response(JSON.stringify(data), {
@@ -115,50 +78,8 @@ export const GET: APIRoute = async ({ request, url }) => {
   }
 }
 
-export const POST: APIRoute = async ({ request }) => {
-  try {
-    if (!isSameOriginRequest(request)) {
-      return json({ error: 'Origen no permitido' }, 403)
-    }
-
-    const userId = await getUserId(request)
-
-    if (!userId) {
-      return json({ error: 'Usuario no autenticado' }, 401)
-    }
-
-    const { allowed, retryAfter } = rateLimit(`predictions:${userId}`, VOTE_RATE_LIMIT)
-
-    if (!allowed) {
-      return json(
-        { error: 'Demasiados votos en poco tiempo. Espera unos segundos e inténtalo de nuevo.' },
-        429,
-        { 'Retry-After': String(retryAfter) },
-      )
-    }
-
-    const body = await request.json().catch(() => null)
-    const combatId = typeof body?.combat_id === 'string' ? body.combat_id : ''
-    const fighterId = typeof body?.fighter_id === 'string' ? body.fighter_id : ''
-
-    if (
-      !combatId ||
-      !fighterId ||
-      combatId.length > MAX_ID_LENGTH ||
-      fighterId.length > MAX_ID_LENGTH
-    ) {
-      return json({ error: 'combat_id y fighter_id son obligatorios' }, 400)
-    }
-
-    const { vote, prediction } = await registerVote(combatId, fighterId, userId)
-
-    return json({ vote, prediction }, 200, PRIVATE_CACHE_HEADERS)
-  } catch (error) {
-    if (error instanceof PredictionDataError) {
-      return json({ error: error.message }, error.status)
-    }
-
-    console.error('Error en POST /api/predictions:', error)
-    return json({ error: 'Error al registrar voto' }, 500)
-  }
+export const POST: APIRoute = async () => {
+  // La votación se cerró al empezar el evento: los totales viven en el HTML
+  // estático generado en build. Mantenemos GET para overlays/herramientas.
+  return json({ error: 'La votación de pronósticos está cerrada' }, 410)
 }

--- a/src/pages/boxeadores/[id].astro
+++ b/src/pages/boxeadores/[id].astro
@@ -24,6 +24,7 @@ import {
 import { getBoxerMainPhotoUrl } from '@/consts/boxer-gallery'
 import { formatFollowers } from '@/lib/socials'
 import Layout from '@/layouts/Layout.astro'
+import { loadBuildTimePredictions } from '@/lib/predictions'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
 import { serializeJsonLd } from '@/utils/serialize-json-ld'
@@ -101,6 +102,9 @@ const battle = battles.find((b) => b.boxerIds.includes(boxer.id))
 const opponentId = battle?.boxerIds.find((id) => id !== boxer.id)
 const opponent = opponentId ? BOXERS_BY_ID[opponentId] : null
 const opponentSelectImages = opponent ? getBoxerSelectImages(opponent) : null
+const combatPrediction = battle
+  ? (await loadBuildTimePredictions()).find((prediction) => prediction.combat_id === battle.id)
+  : undefined
 
 const boxerWorkoutVideos: WorkoutVideo[] = boxer.workout ?? []
 const hasBoxerWorkoutVideos = boxerWorkoutVideos.length > 0
@@ -376,6 +380,8 @@ const breadcrumbJsonLd = {
                   id: battle.boxerIds[1],
                   name: BOXERS_BY_ID[battle.boxerIds[1]].name,
                 }}
+                sides={combatPrediction?.predictions}
+                totalVotes={combatPrediction?.total_votes ?? 0}
               />
               </>
             )

--- a/src/pages/combate/[id].astro
+++ b/src/pages/combate/[id].astro
@@ -13,15 +13,14 @@ import {
 } from '@/consts/boxers'
 import { getBoxerMainPhotoUrl } from '@/consts/boxer-gallery'
 import Layout from '@/layouts/Layout.astro'
+import { loadBuildTimePredictions } from '@/lib/predictions'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
 import { serializeJsonLd } from '@/utils/serialize-json-ld'
 import type { GetStaticPaths } from 'astro'
 
-// La ficha de combate solo usa datos estáticos (battlesById/BOXERS_BY_ID) y los
-// pronósticos se cargan en cliente vía <LivePrediction>. No hay nada por usuario
-// ni consultas a BD en el servidor, así que la prerenderizamos: se sirve desde
-// el CDN en lugar de renderizarse on-demand en cada visita.
+// Página estática: boxeadores + pronósticos fijados en build. Sin SSR ni
+// polling de /api/predictions en el cliente.
 export const prerender = true
 
 export const getStaticPaths = (() => {
@@ -38,6 +37,9 @@ const [boxer1Id, boxer2Id] = battle.boxerIds
 const boxer1 = BOXERS_BY_ID[boxer1Id]
 const boxer2 = BOXERS_BY_ID[boxer2Id]
 const battleVideo = battle.video
+const combatPrediction = (await loadBuildTimePredictions()).find(
+  (prediction) => prediction.combat_id === battle.id,
+)
 const boxer1Hero = getBoxerHeroImages(boxer1)
 const boxer2Hero = getBoxerHeroImages(boxer2)
 const boxer1Select = getBoxerSelectImages(boxer1)
@@ -190,6 +192,8 @@ const breadcrumbJsonLd = {
         battleId={battle.id}
         boxerA={{ id: boxer1.id, name: boxer1.name }}
         boxerB={{ id: boxer2.id, name: boxer2.name }}
+        sides={combatPrediction?.predictions}
+        totalVotes={combatPrediction?.total_votes ?? 0}
       />
     </section>
 

--- a/src/pages/pronosticos.astro
+++ b/src/pages/pronosticos.astro
@@ -1,5 +1,7 @@
 ---
+import AuthButton from '@/components/AuthButton.astro'
 import PredictionFight from '@/components/PredictionFight.astro'
+import PredictionUserVotes from '@/components/PredictionUserVotes.astro'
 import SectionDivider from '@/components/SectionDivider.astro'
 import { createPredictionBattles } from '@/consts/predictions'
 import Layout from '@/layouts/Layout.astro'
@@ -7,8 +9,9 @@ import { loadBuildTimePredictions } from '@/lib/predictions'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
 
-// La votación está cerrada (evento en curso): la página es estática y los
-// totales se fijan en build desde Turso. Sin SSR, sin auth y sin polling.
+// Totales de la comunidad fijados en build. La sesión y los votos propios se
+// hidratan en cliente (AuthButton + GET /api/predictions?mine=1). La votación
+// está cerrada: solo se pueden ver, no cambiar.
 export const prerender = true
 
 const title = 'Pronósticos - La Velada del Año VI'
@@ -47,7 +50,17 @@ const predictionBattles = createPredictionBattles(storedPredictions)
     </p>
 
     <div class="mt-8 w-full max-w-5xl sm:mt-12">
-      <ol class="mt-5 grid gap-5 sm:gap-6" role="list">
+      <div id="predictions-auth" class="flex justify-center" data-predictions-auth>
+        <AuthButton />
+      </div>
+
+      <p
+        class="mt-4 text-center font-cinzel text-[0.58rem] font-medium tracking-[0.14em] text-white/40 uppercase"
+      >
+        La votación está cerrada · solo puedes consultar tus pronósticos
+      </p>
+
+      <ol class="mt-5 grid gap-5 sm:gap-6" role="list" data-prediction-list>
         {
           predictionBattles
             .slice()
@@ -60,6 +73,7 @@ const predictionBattles = createPredictionBattles(storedPredictions)
     </div>
   </section>
 
+  <PredictionUserVotes />
   <Sponsors />
   <Footer />
 </Layout>

--- a/src/pages/pronosticos.astro
+++ b/src/pages/pronosticos.astro
@@ -1,44 +1,23 @@
 ---
-import AuthButton from '@/components/AuthButton.astro'
 import PredictionFight from '@/components/PredictionFight.astro'
-import PredictionShareController from '@/components/PredictionShareController.astro'
-import PredictionVoteController from '@/components/PredictionVoteController.astro'
 import SectionDivider from '@/components/SectionDivider.astro'
 import { createPredictionBattles } from '@/consts/predictions'
 import Layout from '@/layouts/Layout.astro'
-import { getAllPredictions, getUserVotes } from '@/lib/predictions'
+import { loadBuildTimePredictions } from '@/lib/predictions'
 import Footer from '@/sections/Footer.astro'
 import Sponsors from '@/sections/Sponsors.astro'
 
-export const prerender = false
+// La votación está cerrada (evento en curso): la página es estática y los
+// totales se fijan en build desde Turso. Sin SSR, sin auth y sin polling.
+export const prerender = true
 
 const title = 'Pronósticos - La Velada del Año VI'
-const description = 'Pronostica los ganadores de los combates de La Velada del Año VI.'
+const description =
+  'Consulta los pronósticos de la comunidad para los combates de La Velada del Año VI.'
 const canonical = 'https://www.infolavelada.com/pronosticos'
-const user = Astro.locals.user
 
-// Lanzamos las dos lecturas a Turso en paralelo: los votos del usuario no
-// dependen de las predicciones globales, así que encadenarlas con dos `await`
-// sumaba dos round-trips a la BD en el TTFB de cada carga con sesión iniciada
-// (la página es `prerender = false` y el render espera a ambas). Con
-// `Promise.all` el render solo espera a la más lenta de las dos.
-const [storedPredictions, storedUserVotes] = await Promise.all([
-  getAllPredictions().catch((error) => {
-    console.error('Error al cargar predicciones:', error)
-    return [] as Awaited<ReturnType<typeof getAllPredictions>>
-  }),
-  user?.id
-    ? getUserVotes(user.id).catch((error) => {
-        console.error('Error al cargar votos del usuario:', error)
-        return [] as Awaited<ReturnType<typeof getUserVotes>>
-      })
-    : Promise.resolve([] as Awaited<ReturnType<typeof getUserVotes>>),
-])
-
+const storedPredictions = await loadBuildTimePredictions()
 const predictionBattles = createPredictionBattles(storedPredictions)
-const userVotesByCombat = Object.fromEntries(
-  storedUserVotes.map((vote) => [vote.combat_id, vote.fighter_id]),
-)
 ---
 
 <Layout title={title} description={description} canonical={canonical} robots="noindex, nofollow">
@@ -64,47 +43,23 @@ const userVotesByCombat = Object.fromEntries(
     <p
       class="mt-3 text-center font-cinzel text-xs font-medium tracking-[0.16em] text-balance text-white/55 not-motion-reduce:animate-fade-in-up animate-delay-200 sm:text-sm sm:tracking-[0.25em]"
     >
-      Vota a tu ganador en cada combate de La Velada del Año VI
+      Así pronosticó la comunidad cada combate de La Velada del Año VI
     </p>
 
     <div class="mt-8 w-full max-w-5xl sm:mt-12">
-      <div id="predictions-auth" class="flex justify-center" data-predictions-auth>
-        <AuthButton user={user} />
-      </div>
-
-      <div class="mt-4 flex justify-center">
-        <PredictionShareController
-          variant="top"
-          isLoggedIn={Boolean(user)}
-          totalFights={predictionBattles.length}
-        />
-      </div>
-
-      <ol class="mt-5 grid gap-5 sm:gap-6" role="list" data-prediction-list>
+      <ol class="mt-5 grid gap-5 sm:gap-6" role="list">
         {
           predictionBattles
             .slice()
             .reverse()
             .map((prediction, index) => (
-              <PredictionFight
-                prediction={prediction}
-                selectedBoxerId={userVotesByCombat[prediction.battle.id]}
-                index={index}
-              />
+              <PredictionFight prediction={prediction} index={index} />
             ))
         }
       </ol>
-
-      <div class="mt-10 flex justify-center sm:mt-12">
-        <PredictionShareController
-          isLoggedIn={Boolean(user)}
-          totalFights={predictionBattles.length}
-        />
-      </div>
     </div>
   </section>
 
-  <PredictionVoteController isLoggedIn={Boolean(user)} userVotes={userVotesByCombat} user={user} />
   <Sponsors />
   <Footer />
 </Layout>

--- a/src/sections/Predictions.astro
+++ b/src/sections/Predictions.astro
@@ -4,13 +4,18 @@ import LivePrediction from '@/components/LivePrediction.astro'
 import SectionHeader from '@/components/SectionHeader.astro'
 import { battles, type Battle } from '@/consts/battles'
 import { BOXERS_BY_ID } from '@/consts/boxers'
+import { loadBuildTimePredictions } from '@/lib/predictions'
 
-// Combates más interesantes para la home; el resto se vota en /pronosticos.
+// Combates más interesantes para la home; el resto se ve en /pronosticos.
 // Se resuelven por boxeador para no depender del orden de la pareja.
 const FEATURED_BOXER_IDS = ['thegrefg', 'plex', 'roro', 'viruzz']
 const featuredBattles = FEATURED_BOXER_IDS.map((boxerId) =>
   battles.find((battle) => battle.boxerIds.includes(boxerId)),
 ).filter((battle): battle is Battle => Boolean(battle))
+
+const predictionsByBattle = new Map(
+  (await loadBuildTimePredictions()).map((prediction) => [prediction.combat_id, prediction]),
+)
 ---
 
 <section
@@ -26,23 +31,29 @@ const featuredBattles = FEATURED_BOXER_IDS.map((boxerId) =>
   <div class="mx-auto flex max-w-5xl flex-col items-center">
     <SectionHeader
       titleId="home-predictions-title"
-      eyebrow="En directo"
+      eyebrow="Comunidad"
       title="PRONÓSTICOS"
-      subtitle="Vota a tu ganador y sigue en tiempo real lo que pronostica la comunidad"
+      subtitle="Así pronosticó la comunidad los combates de La Velada del Año VI"
       subtitleClass="mb-10 max-w-xl tracking-[0.16em] sm:mb-12 sm:text-sm"
     />
 
     <ul class="grid w-full list-none grid-cols-1 gap-4 p-0 sm:grid-cols-2 sm:gap-5" role="list">
       {
-        featuredBattles.map((battle) => (
-          <li>
-            <LivePrediction
-              battleId={battle.id}
-              boxerA={{ id: battle.boxerIds[0], name: BOXERS_BY_ID[battle.boxerIds[0]].name }}
-              boxerB={{ id: battle.boxerIds[1], name: BOXERS_BY_ID[battle.boxerIds[1]].name }}
-            />
-          </li>
-        ))
+        featuredBattles.map((battle) => {
+          const prediction = predictionsByBattle.get(battle.id)
+
+          return (
+            <li>
+              <LivePrediction
+                battleId={battle.id}
+                boxerA={{ id: battle.boxerIds[0], name: BOXERS_BY_ID[battle.boxerIds[0]].name }}
+                boxerB={{ id: battle.boxerIds[1], name: BOXERS_BY_ID[battle.boxerIds[1]].name }}
+                sides={prediction?.predictions}
+                totalVotes={prediction?.total_votes ?? 0}
+              />
+            </li>
+          )
+        })
       }
     </ul>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> [!important]
> **One change per PR.** Scope to a single component or section — not a whole page. Split unrelated changes into separate PRs.

## Type

- [x] feat
- [ ] fix
- [ ] refactor
- [ ] perf
- [ ] docs
- [ ] chore

## Related Issue

Closes #

## Changes

- `src/pages/pronosticos.astro`: página estática (`prerender = true`); totales de la comunidad fijados en build; login para ver votos propios (sin poder cambiarlos).
- `src/lib/predictions.ts`: `loadBuildTimePredictions()` — una lectura a Turso por build; si no hay env (preview/PR), genera totales a 0 sin romper el build.
- `src/lib/database.ts`: cliente Turso lazy para no fallar el import sin `TURSO_*`.
- `src/components/PredictionOption.astro`: UI de solo lectura; badge «Tu voto» al hidratar la sesión.
- `src/components/PredictionUserVotes.astro`: hidrata `GET /api/predictions?mine=1` y marca los votos propios; no hay POST.
- `src/components/AuthButton.astro`: hidratación de sesión en páginas estáticas; copy «Inicia sesión para ver tus votos».
- `src/components/LivePrediction.astro` + home/combate/boxeador: totales estáticos de build, sin polling.
- `src/pages/api/predictions.ts`: `POST` → `410` (votación cerrada); se mantiene `GET` (overlays + votos propios).

## Dependencies

- Added: None
- Removed: None

## Notes

En previews/PR no hay variables de entorno de Turso: los totales salen a 0 y el build no falla. En producción sí existen y los números se fijan en el build.

## Screenshots

| View | Before | After |
|------|--------|-------|
| Mobile | | |
| Desktop | | |

## Checklist

- [ ] Tested on mobile (<768px)
- [ ] Tested on desktop (≥1024px)
- [ ] No console errors
- [ ] No regressions on affected routes

## Breaking Changes

- La votación de pronósticos ya no está disponible (`POST /api/predictions` → 410).
- Los totales de la comunidad dejan de actualizarse en vivo en cliente; se fijan en build.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9b99-5219-779d-8111-47b9f097ef23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9b99-5219-779d-8111-47b9f097ef23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Nuevas funciones**
  - Los pronósticos se muestran con resultados, porcentajes, líderes y empates precargados.
  - Las personas autenticadas pueden consultar sus propios votos, con selección y estados visuales actualizados.
  - El acceso mantiene la sesión visible durante la carga y muestra avatares con iniciales como respaldo.

- **Cambios**
  - La votación de pronósticos se ha cerrado; ahora solo es posible consultar resultados.
  - Las páginas de combates y boxeadores cargan los datos de pronósticos desde la generación del sitio.
  - Se simplificaron las indicaciones visuales y se mejoró el comportamiento en páginas estáticas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->